### PR TITLE
fix #6: destructuring with a default parameter

### DIFF
--- a/src/utilities/getParameterName.js
+++ b/src/utilities/getParameterName.js
@@ -16,9 +16,7 @@ export default (identifierNode, context) => {
     if (identifierNode.type === 'ObjectPattern' || identifierNode.type === 'ArrayPattern') {
         return context.getSourceCode().getText(identifierNode);
     }
-
-    if (_.has(identifierNode, 'left.type') && _.has(identifierNode, 'right.type') &&
-        identifierNode.left.type === 'ObjectPattern' && identifierNode.right.type === 'ObjectExpression') {
+    if (_.get(identifierNode, 'left.type') === 'ObjectPattern' && _.get(identifierNode, 'right.type') === 'ObjectExpression') {
         return context.getSourceCode().getText(identifierNode.left);
     }
 

--- a/src/utilities/getParameterName.js
+++ b/src/utilities/getParameterName.js
@@ -17,5 +17,10 @@ export default (identifierNode, context) => {
         return context.getSourceCode().getText(identifierNode);
     }
 
+    if (_.has(identifierNode, 'left.type') && _.has(identifierNode, 'right.type') &&
+        identifierNode.left.type === 'ObjectPattern' && identifierNode.right.type === 'ObjectExpression') {
+        return context.getSourceCode().getText(identifierNode.left);
+    }
+
     throw new Error('Unsupported function signature.');
 };

--- a/tests/rules/assertions/requireParameterType.js
+++ b/tests/rules/assertions/requireParameterType.js
@@ -39,6 +39,14 @@ export default {
                     message: 'Missing "[foo]" parameter type annotation.'
                 }
             ]
+        },
+        {
+            code: '({foo = 1} = {}) => {}',
+            errors: [
+                {
+                    message: 'Missing "{foo = 1}" parameter type annotation.'
+                }
+            ]
         }
     ],
     valid: [


### PR DESCRIPTION
Here's a quick fix for #6 .

### Tests
I added an "invalid" fixture but wasn't able to create a "valid" fixture.

My valid fixture was: `({foo = 1}: {foo: number} = {}) => {}'` which raises the following error:

```
    AssertionError: Should have no errors but had 1: [ { ruleId: null,
    fatal: true,
    severity: 2,
    source: '({foo = 1}: {foo: number} = {}) => {}',
    message: 'Parsing error: Binding rvalue',
    line: 1,
    column: 2 } ]
```

### Linting
There were a couple of errors and warnings when linting the plugin itself (`npm run lint`), but none of these were introduced by this patch so I decided to ignore them.