### PR TITLE
issue 11: space-after-type-colon does not apply to the return type

### DIFF
--- a/src/rules/spaceAfterTypeColon.js
+++ b/src/rules/spaceAfterTypeColon.js
@@ -24,5 +24,17 @@ export default iterateFunctionNodes((context) => {
                 }
             }
         });
+
+        if (functionNode.returnType) {
+            const spaceAfter = functionNode.returnType.typeAnnotation.start - functionNode.returnType.start - 1;
+
+            if (always && spaceAfter > 1) {
+                context.report(functionNode, 'There must be 1 space after return type colon.');
+            } else if (always && spaceAfter === 0) {
+                context.report(functionNode, 'There must be a space after return type colon.');
+            } else if (!always && spaceAfter > 0) {
+                context.report(functionNode, 'There must be no space after return type colon.');
+            }
+        }
     };
 });

--- a/tests/rules/assertions/spaceAfterTypeColon.js
+++ b/tests/rules/assertions/spaceAfterTypeColon.js
@@ -54,6 +54,37 @@ export default {
             options: [
                 'always'
             ]
+        },
+        {
+            code: '():Object => {}',
+            errors: [
+                {
+                    message: 'There must be a space after return type colon.'
+                }
+            ],
+            options: [
+                'always'
+            ]
+        }, {
+            code: '(): Object => {}',
+            errors: [
+                {
+                    message: 'There must be no space after return type colon.'
+                }
+            ],
+            options: [
+                'never'
+            ]
+        }, {
+            code: '():  Object => {}',
+            errors: [
+                {
+                    message: 'There must be 1 space after return type colon.'
+                }
+            ],
+            options: [
+                'always'
+            ]
         }
     ],
     valid: [
@@ -71,6 +102,17 @@ export default {
         },
         {
             code: '(foo: string) => {}',
+            options: [
+                'always'
+            ]
+        },
+        {
+            code: '():Object => {}',
+            options: [
+                'never'
+            ]
+        }, {
+            code: '(): Object => {}',
             options: [
                 'always'
             ]


### PR DESCRIPTION
Given the following configuration:

```json
"flowtype/space-after-type-colon": [
   1,
   "never"
]
```

and a function:

```js
function fn (key: string): Object {
```

Running the linter will produce the following:

> xxx:yy  warning  There must be no space after "key" parameter type annotation colon  flowtype/space-after-type-colon

This patch will address this issue and ensure that the return type is also taken into consideration when checking for spaces after the colon.