### PR TITLE
Properly handle arrow function expressions and generic return type annotations

### DIFF
--- a/src/rules/requireReturnType.js
+++ b/src/rules/requireReturnType.js
@@ -32,7 +32,8 @@ export default (context) => {
             throw new Error('Mismatch.');
         }
 
-        const isFunctionReturnUndefined = !targetNode.returnStatementNode || isUndefinedReturnType(targetNode.returnStatementNode);
+        const isArrowFunctionExpression = functionNode.expression;
+        const isFunctionReturnUndefined = !isArrowFunctionExpression && (!targetNode.returnStatementNode || isUndefinedReturnType(targetNode.returnStatementNode));
         const returnTypeTypeAnnotationType = _.get(targetNode, 'functionNode.returnType.typeAnnotation.type');
         const isReturnTypeAnnotationUndefined = returnTypeTypeAnnotationType === 'GenericTypeAnnotation' || returnTypeTypeAnnotationType === 'VoidTypeAnnotation';
 

--- a/src/rules/requireReturnType.js
+++ b/src/rules/requireReturnType.js
@@ -25,6 +25,13 @@ export default (context) => {
         return returnNode.argument === null || returnNode.argument.name === 'undefined' || returnNode.argument.operator === 'void';
     };
 
+    const getIsReturnTypeAnnotationUndefined = (targetNode) => {
+        const isReturnTypeAnnotationLiteralUndefined = _.get(targetNode, 'functionNode.returnType.typeAnnotation.id.name') === 'undefined' && _.get(targetNode, 'functionNode.returnType.typeAnnotation.type') === 'GenericTypeAnnotation';
+        const isReturnTypeAnnotationVoid = _.get(targetNode, 'functionNode.returnType.typeAnnotation.type') === 'VoidTypeAnnotation';
+
+        return isReturnTypeAnnotationLiteralUndefined || isReturnTypeAnnotationVoid;
+    };
+
     const evaluateFunction = (functionNode) => {
         const targetNode = targetNodes.pop();
 
@@ -34,8 +41,7 @@ export default (context) => {
 
         const isArrowFunctionExpression = functionNode.expression;
         const isFunctionReturnUndefined = !isArrowFunctionExpression && (!targetNode.returnStatementNode || isUndefinedReturnType(targetNode.returnStatementNode));
-        const returnTypeTypeAnnotationType = _.get(targetNode, 'functionNode.returnType.typeAnnotation.type');
-        const isReturnTypeAnnotationUndefined = returnTypeTypeAnnotationType === 'GenericTypeAnnotation' || returnTypeTypeAnnotationType === 'VoidTypeAnnotation';
+        const isReturnTypeAnnotationUndefined = getIsReturnTypeAnnotationUndefined(targetNode);
 
         if (isFunctionReturnUndefined && isReturnTypeAnnotationUndefined && !annotateUndefined) {
             context.report(functionNode, 'Must not annotate undefined return type.');

--- a/tests/rules/assertions/requireReturnType.js
+++ b/tests/rules/assertions/requireReturnType.js
@@ -20,6 +20,17 @@ export default {
             ]
         },
         {
+            code: '(foo) => "foo"',
+            errors: [
+                {
+                    message: 'Missing return type annotation.'
+                }
+            ],
+            options: [
+                'always'
+            ]
+        },
+        {
             code: '(foo): undefined => { return; }',
             errors: [
                 {

--- a/tests/rules/assertions/requireReturnType.js
+++ b/tests/rules/assertions/requireReturnType.js
@@ -31,6 +31,14 @@ export default {
             ]
         },
         {
+            code: '(foo) => ({})',
+            errors: [
+                {
+                    message: 'Missing return type annotation.'
+                }
+            ]
+        },
+        {
             code: '(foo): undefined => { return; }',
             errors: [
                 {
@@ -191,6 +199,9 @@ export default {
         },
         {
             code: '(foo) => { return; }'
+        },
+        {
+            code: '(foo): Object => ( {} )'
         },
         {
             code: '(foo) => { return undefined; }'


### PR DESCRIPTION
An arrow function can be written shorthand like so:

```
(foo) => "foo"
```

This was improperly being recognized as not returning a value. This will check to see if the arrow function is an expression and if it is, will be assumed to be returning something.

---

Before the node's return type was deemed undefined if it had one of the following:

- `typeAnnotation` of `VoidTypeAnnotation`
- `typeAnnotation` of `GenericTypeAnnotation`

That will produce false positives because a `typeAnnotation` of `GenericTypeAnnotation` can be things other than `undefined`. This will check for a `GenericTypeAnnotation` that is actually `undefined`.

Closes #15