### PR TITLE
Allow require-parameter-type to take ignoreParameterNames option

### DIFF
--- a/src/rules/requireParameterType.js
+++ b/src/rules/requireParameterType.js
@@ -8,6 +8,8 @@ import {
 export default iterateFunctionNodes((context) => {
     const checkThisFile = !_.get(context, 'settings.flowtype.onlyFilesWithFlowAnnotation') || isFlowFile(context);
 
+    const ignoreParameterNames = _.get(context, 'options[1].ignoreParameterNames', []);
+
     if (!checkThisFile) {
         return () => {};
     }
@@ -15,9 +17,10 @@ export default iterateFunctionNodes((context) => {
     return (functionNode) => {
         _.forEach(functionNode.params, (identifierNode) => {
             const parameterName = getParameterName(identifierNode, context);
+            const ignoreThisParameter = _.includes(ignoreParameterNames, parameterName);
             const typeAnnotation = _.get(identifierNode, 'typeAnnotation') || _.get(identifierNode, 'left.typeAnnotation');
 
-            if (!typeAnnotation) {
+            if (!typeAnnotation && !ignoreThisParameter) {
                 context.report(identifierNode, 'Missing "' + parameterName + '" parameter type annotation.');
             }
         });

--- a/tests/rules/assertions/requireParameterType.js
+++ b/tests/rules/assertions/requireParameterType.js
@@ -9,6 +9,20 @@ export default {
             ]
         },
         {
+            code: '(_, foo) => {}',
+            errors: [
+                {
+                    message: 'Missing "foo" parameter type annotation.'
+                }
+            ],
+            options: [
+                'always',
+                {
+                    ignoreParameterNames: ['_']
+                }
+            ]
+        },
+        {
             code: '(foo = \'FOO\') => {}',
             errors: [
                 {
@@ -65,6 +79,24 @@ export default {
     valid: [
         {
             code: '(foo: string) => {}'
+        },
+        {
+            code: '(_) => {}',
+            options: [
+                'always',
+                {
+                    ignoreParameterNames: ['_']
+                }
+            ]
+        },
+        {
+            code: '(_, foo: string) => {}',
+            options: [
+                'always',
+                {
+                    ignoreParameterNames: ['_']
+                }
+            ]
         },
         {
             code: '(foo: string = \'FOO\') => {}'


### PR DESCRIPTION
Add an optional configuration parameter be added for `require-parameter-type` to allow a whitelist of parameter names that will be ignored for typechecks.

```json
{
    "parser": "babel-eslint",
    "plugins": [
        "flowtype"
    ],
    "rules": {
        "flowtype/require-parameter-type": [
            1,
            "always",
            {
                "ignoreParameterNames": [
                    "_"
                ]
            }
        ],
        "flowtype/require-return-type": [
            1,
            "always",
            {
                "annotateUndefined": "never"
            }
        ],
        "flowtype/space-after-type-colon": [
            1,
            "always"
        ],
        "flowtype/space-before-type-colon": [
            1,
            "never"
        ],
        "flowtype/type-id-match": [
            1,
            "^([A-Z][a-z0-9]+)+Type$"
        ]
    },
    "settings": {
        "flowtype": {
            "onlyFilesWithFlowAnnotation": false
        }
    }
}
```

#17 