### PR TITLE
require-valid-file-annotation rule implementation

### DIFF
--- a/.README/README.md
+++ b/.README/README.md
@@ -86,6 +86,7 @@ When `true`, only checks files with a [`@flow` annotation](http://flowtype.org/d
 
 {"gitdown": "include", "file": "./rules/require-parameter-type.md"}
 {"gitdown": "include", "file": "./rules/require-return-type.md"}
+{"gitdown": "include", "file": "./rules/require-valid-file-annotation.md"}
 {"gitdown": "include", "file": "./rules/space-after-type-colon.md"}
 {"gitdown": "include", "file": "./rules/space-before-type-colon.md"}
 {"gitdown": "include", "file": "./rules/type-id-match.md"}

--- a/.README/rules/require-valid-file-annotation.md
+++ b/.README/rules/require-valid-file-annotation.md
@@ -1,0 +1,20 @@
+### `require-valid-file-annotation`
+
+Makes sure that files have a valid `@flow` annotation. It will report annotations with typos (such as `// @floww`) or not placed at the top of the file, and optionaly missing annotations.
+
+#### Options
+
+By default, this rule won't complain if there is no `@flow` annotation at all in the file. Passing a `"always"` option reports files missing those annotations as well.
+
+```js
+{
+    "rules": {
+        "flowtype/require-valid-file-annotation": [
+            2,
+            "always"
+        ]
+    }
+}
+```
+
+<!-- assertions requireValidFileAnnotation -->

--- a/README.md
+++ b/README.md
@@ -239,6 +239,76 @@ The following patterns are not considered problems:
 ```
 
 
+### `require-valid-file-annotation`
+
+Makes sure that files have a valid `@flow` annotation. It will report annotations with typos (such as `// @floww`) or not placed at the top of the file, and optionaly missing annotations.
+
+#### Options
+
+By default, this rule won't complain if there is no `@flow` annotation at all in the file. Passing a `"always"` option reports files missing those annotations as well.
+
+```js
+{
+    "rules": {
+        "flowtype/require-valid-file-annotation": [
+            2,
+            "always"
+        ]
+    }
+}
+```
+
+The following patterns are considered problems:
+
+```js
+;// @flow
+// Message: Flow file annotation not at the top of the file.
+
+;
+// @flow
+// Message: Flow file annotation not at the top of the file.
+
+// @Flow
+// Message: Malformed flow file annotation.
+
+// @floweeeeeee
+// Message: Malformed flow file annotation.
+
+// Options: ["always"]
+a;
+// Message: Flow file annotation is missing.
+```
+
+The following patterns are not considered problems:
+
+```js
+a;
+
+// @flow
+a;
+
+//@flow
+a;
+
+//**@flow
+a;
+
+/* foo @flow bar */
+a;
+
+
+
+// @flow
+a;
+
+// @flow
+// @FLow
+
+// Options: ["always"]
+a;
+```
+
+
 ### `space-after-type-colon`
 
 Enforces consistent spacing after the type annotation colon.

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 import requireParameterType from './rules/requireParameterType';
 import requireReturnType from './rules/requireReturnType';
+import requireValidFileAnnotation from './rules/requireValidFileAnnotation';
 import spaceAfterTypeColon from './rules/spaceAfterTypeColon';
 import spaceBeforeTypeColon from './rules/spaceBeforeTypeColon';
 import typeIdMatch from './rules/typeIdMatch';
@@ -8,6 +9,7 @@ export default {
     rules: {
         'require-parameter-type': requireParameterType,
         'require-return-type': requireReturnType,
+        'require-valid-file-annotation': requireValidFileAnnotation,
         'space-after-type-colon': spaceAfterTypeColon,
         'space-before-type-colon': spaceBeforeTypeColon,
         'type-id-match': typeIdMatch

--- a/src/rules/requireValidFileAnnotation.js
+++ b/src/rules/requireValidFileAnnotation.js
@@ -1,0 +1,48 @@
+import _ from 'lodash';
+import {
+    isFlowFile,
+    isFlowFileAnnotation,
+} from './../utilities';
+
+function looksLikeFlowFileAnnotation(comment) {
+    return /@flow/i.test(comment);
+}
+
+
+export const schema = [
+    {
+        enum: ['always']
+    }
+];
+
+export default (context) => {
+    const checkThisFile = !_.get(context, 'settings.flowtype.onlyFilesWithFlowAnnotation') || isFlowFile(context);
+
+    if (!checkThisFile) {
+        return {};
+    }
+
+    const always = context.options[0] === 'always';
+
+    return {
+        Program(node) {
+            const firstToken = node.tokens[0];
+
+            const potentialFlowFileAnnotation = _.find(context.getAllComments(), (comment) => {
+                return looksLikeFlowFileAnnotation(comment.value);
+            });
+
+            if (potentialFlowFileAnnotation) {
+                if (firstToken && firstToken.start < potentialFlowFileAnnotation.start) {
+                    context.report(potentialFlowFileAnnotation, 'Flow file annotation not at the top of the file.');
+                }
+
+                if (!isFlowFileAnnotation(potentialFlowFileAnnotation.value)) {
+                    context.report(potentialFlowFileAnnotation, 'Malformed flow file annotation.');
+                }
+            } else if (always) {
+                context.report(node, 'Flow file annotation is missing.');
+            }
+        }
+    };
+};

--- a/src/utilities/index.js
+++ b/src/utilities/index.js
@@ -2,4 +2,5 @@
 
 export getParameterName from './getParameterName.js';
 export isFlowFile from './isFlowFile.js';
+export isFlowFileAnnotation from './isFlowFileAnnotation.js';
 export iterateFunctionNodes from './iterateFunctionNodes.js';

--- a/src/utilities/isFlowFile.js
+++ b/src/utilities/isFlowFile.js
@@ -1,4 +1,4 @@
-import _ from 'lodash';
+import isFlowFileAnnotation from './isFlowFileAnnotation.js';
 
 export default (context) => {
     const comments = context.getAllComments();
@@ -9,5 +9,5 @@ export default (context) => {
 
     const firstComment = comments[0];
 
-    return _.includes(firstComment.value, '@flow');
+    return isFlowFileAnnotation(firstComment.value);
 };

--- a/src/utilities/isFlowFileAnnotation.js
+++ b/src/utilities/isFlowFileAnnotation.js
@@ -1,0 +1,8 @@
+import _ from 'lodash';
+
+export default (comment) => {
+    // The flow parser splits comments with the following regex to look for the @flow flag.
+    // See https://github.com/facebook/flow/blob/a96249b93541f2f7bfebd8d62085bf7a75de02f2/src/parsing/docblock.ml#L39
+    return _.includes(comment.split(/[ \t\r\n\\*/]+/), '@flow');
+};
+

--- a/tests/rules/assertions/requireValidFileAnnotation.js
+++ b/tests/rules/assertions/requireValidFileAnnotation.js
@@ -1,0 +1,79 @@
+export default {
+    invalid: [
+        {
+            code: ';// @flow',
+            errors: [
+                {
+                    message: 'Flow file annotation not at the top of the file.'
+                }
+            ],
+        },
+        {
+            code: ';\n// @flow',
+            errors: [
+                {
+                    message: 'Flow file annotation not at the top of the file.'
+                }
+            ],
+        },
+        {
+            code: '// @Flow',
+            errors: [
+                {
+                    message: 'Malformed flow file annotation.'
+                }
+            ]
+        },
+        {
+            code: '// @floweeeeeee',
+            errors: [
+                {
+                    message: 'Malformed flow file annotation.'
+                }
+            ]
+        },
+        {
+            code: 'a;',
+            options: ['always'],
+            errors: [
+                {
+                    message: 'Flow file annotation is missing.'
+                }
+            ]
+        }
+    ],
+    valid: [
+        {
+            code: 'a;'
+        },
+        {
+            code: '// @flow\na;'
+        },
+        {
+            code: '//@flow\na;'
+        },
+        {
+            code: '//**@flow\na;'
+        },
+        {
+            code: '/* foo @flow bar */\na;'
+        },
+        {
+            code: '\n\n// @flow\na;'
+        },
+        {
+            code: '// @flow\n// @FLow'
+        },
+        {
+            code: 'a;',
+            options: ['always'],
+            settings: {
+                flowtype: {
+                    onlyFilesWithFlowAnnotation: true
+                }
+            }
+        }
+    ]
+};
+
+

--- a/tests/rules/index.js
+++ b/tests/rules/index.js
@@ -13,6 +13,7 @@ const ruleTester = new RuleTester();
 _.forEach([
     'require-parameter-type',
     'require-return-type',
+    'require-valid-file-annotation',
     'space-after-type-colon',
     'space-before-type-colon',
     'type-id-match'


### PR DESCRIPTION
A new rule to check for typos or placement error of the `// @flow` comment.

Even if I know the rule, I keep inadvertently inserting the `/*eslint ...*/` comment or `"use strict"` at the beginning of the file, disabling the flow check, and nothing is warning me about this. I think it would be a great addition to this plugin.

I'm open to discussion: you can consider this as a proposal and a prototype implementation.

PS: I love the `readmeAssertions.js` script! great idea.
PPS: You should commit the .eslintrc you are using for this project.