### PR TITLE
Fix space-after-type-colon false-positive on return of function types.

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,6 +348,18 @@ function foo (foo: string) {}
 // Message: There must be 1 space after "foo" parameter type annotation colon.
 
 // Options: ["always"]
+(foo:(() => void)) => {}
+// Message: There must be a space after "foo" parameter type annotation colon.
+
+// Options: ["never"]
+(foo: (() => void)) => {}
+// Message: There must be no space after "foo" parameter type annotation colon.
+
+// Options: ["always"]
+(foo:  (() => void)) => {}
+// Message: There must be 1 space after "foo" parameter type annotation colon.
+
+// Options: ["always"]
 ():Object => {}
 // Message: There must be a space after return type colon.
 
@@ -358,6 +370,18 @@ function foo (foo: string) {}
 // Options: ["always"]
 ():  Object => {}
 // Message: There must be 1 space after return type colon.
+
+// Options: ["always"]
+():(() => void) => {}
+// Message: There must be a space after return type colon.
+
+// Options: ["never"]
+(): (() => void) => {}
+// Message: There must be no space after return type colon.
+
+// Options: ["always"]
+():  (() => void) => {}
+// Message: There must be 1 space after return type colon.
 ```
 
 The following patterns are not considered problems:
@@ -367,6 +391,8 @@ The following patterns are not considered problems:
 
 (foo: string) => {}
 
+(foo: (string|number)) => {}
+
 // Options: ["never"]
 (foo:string) => {}
 
@@ -374,10 +400,40 @@ The following patterns are not considered problems:
 (foo: string) => {}
 
 // Options: ["never"]
+(foo:(() => void)) => {}
+
+// Options: ["always"]
+(foo: (() => void)) => {}
+
+// Options: ["never"]
 ():Object => {}
 
 // Options: ["always"]
 (): Object => {}
+
+// Options: ["never"]
+():(number | string) => {}
+
+// Options: ["always"]
+(): (number | string) => {}
+
+// Options: ["never"]
+():number|string => {}
+
+// Options: ["always"]
+(): number|string => {}
+
+// Options: ["never"]
+():(() => void) => {}
+
+// Options: ["always"]
+(): (() => void) => {}
+
+// Options: ["never"]
+():( () => void ) => {}
+
+// Options: ["always"]
+(): ( () => void ) => {}
 ```
 
 

--- a/src/rules/spaceAfterTypeColon.js
+++ b/src/rules/spaceAfterTypeColon.js
@@ -7,13 +7,16 @@ import {
 export default iterateFunctionNodes((context) => {
     const always = (context.options[0] || 'always') === 'always';
 
+    const sourceCode = context.getSourceCode();
+
     return (functionNode) => {
         _.forEach(functionNode.params, (identifierNode) => {
             const parameterName = getParameterName(identifierNode, context);
             const typeAnnotation = _.get(identifierNode, 'typeAnnotation') || _.get(identifierNode, 'left.typeAnnotation');
 
             if (typeAnnotation) {
-                const spaceAfter = typeAnnotation.typeAnnotation.start - typeAnnotation.start - 1;
+                const token = sourceCode.getFirstToken(typeAnnotation, 1);
+                const spaceAfter = token.start - typeAnnotation.start - 1;
 
                 if (always && spaceAfter > 1) {
                     context.report(identifierNode, 'There must be 1 space after "' + parameterName + '" parameter type annotation colon.');
@@ -26,7 +29,8 @@ export default iterateFunctionNodes((context) => {
         });
 
         if (functionNode.returnType) {
-            const spaceAfter = functionNode.returnType.typeAnnotation.start - functionNode.returnType.start - 1;
+            const token = sourceCode.getFirstToken(functionNode.returnType, 1);
+            const spaceAfter = token.start - functionNode.returnType.start - 1;
 
             if (always && spaceAfter > 1) {
                 context.report(functionNode, 'There must be 1 space after return type colon.');

--- a/tests/rules/assertions/spaceAfterTypeColon.js
+++ b/tests/rules/assertions/spaceAfterTypeColon.js
@@ -56,6 +56,39 @@ export default {
             ]
         },
         {
+            code: '(foo:(() => void)) => {}',
+            errors: [
+                {
+                    message: 'There must be a space after "foo" parameter type annotation colon.'
+                }
+            ],
+            options: [
+                'always'
+            ]
+        },
+        {
+            code: '(foo: (() => void)) => {}',
+            errors: [
+                {
+                    message: 'There must be no space after "foo" parameter type annotation colon.'
+                }
+            ],
+            options: [
+                'never'
+            ]
+        },
+        {
+            code: '(foo:  (() => void)) => {}',
+            errors: [
+                {
+                    message: 'There must be 1 space after "foo" parameter type annotation colon.'
+                }
+            ],
+            options: [
+                'always'
+            ]
+        },
+        {
             code: '():Object => {}',
             errors: [
                 {
@@ -85,6 +118,37 @@ export default {
             options: [
                 'always'
             ]
+        },
+        {
+            code: '():(() => void) => {}',
+            errors: [
+                {
+                    message: 'There must be a space after return type colon.'
+                }
+            ],
+            options: [
+                'always'
+            ]
+        }, {
+            code: '(): (() => void) => {}',
+            errors: [
+                {
+                    message: 'There must be no space after return type colon.'
+                }
+            ],
+            options: [
+                'never'
+            ]
+        }, {
+            code: '():  (() => void) => {}',
+            errors: [
+                {
+                    message: 'There must be 1 space after return type colon.'
+                }
+            ],
+            options: [
+                'always'
+            ]
         }
     ],
     valid: [
@@ -93,6 +157,9 @@ export default {
         },
         {
             code: '(foo: string) => {}'
+        },
+        {
+            code: '(foo: (string|number)) => {}'
         },
         {
             code: '(foo:string) => {}',
@@ -107,12 +174,70 @@ export default {
             ]
         },
         {
+            code: '(foo:(() => void)) => {}',
+            options: [
+                'never'
+            ]
+        },
+        {
+            code: '(foo: (() => void)) => {}',
+            options: [
+                'always'
+            ]
+        },
+        {
             code: '():Object => {}',
             options: [
                 'never'
             ]
-        }, {
+        },
+        {
             code: '(): Object => {}',
+            options: [
+                'always'
+            ]
+        },
+        {
+            code: '():(number | string) => {}',
+            options: [
+                'never'
+            ]
+        },
+        {
+            code: '(): (number | string) => {}',
+            options: [
+                'always'
+            ]
+        },
+        {
+            code: '():number|string => {}',
+            options: [
+                'never'
+            ]
+        },
+        {
+            code: '(): number|string => {}',
+            options: [
+                'always'
+            ]
+        },
+        {
+            code: '():(() => void) => {}',
+            options: [
+                'never'
+            ]
+        }, {
+            code: '(): (() => void) => {}',
+            options: [
+                'always'
+            ]
+        }, {
+            code: '():( () => void ) => {}',
+            options: [
+                'never'
+            ]
+        }, {
+            code: '(): ( () => void ) => {}',
             options: [
                 'always'
             ]


### PR DESCRIPTION
Fixes #32 

Matching of compound types `(number|string)` was broken too, now it works.