### PR TITLE
Allow require-valid-file-annotation to blacklist some file

### DIFF
--- a/.README/rules/require-valid-file-annotation.md
+++ b/.README/rules/require-valid-file-annotation.md
@@ -4,7 +4,7 @@ Makes sure that files have a valid `@flow` annotation. It will report annotation
 
 #### Options
 
-By default, this rule won't complain if there is no `@flow` annotation at all in the file. Passing a `"always"` option reports files missing those annotations as well.
+By default, this rule won't complain if there is no `@flow` annotation at all in the file. Passing a `"always"` option reports files missing those annotations as well, and additionally with `@no-flow` we can blacklist some files for this option.
 
 ```js
 {

--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ Makes sure that files have a valid `@flow` annotation. It will report annotation
 
 #### Options
 
-By default, this rule won't complain if there is no `@flow` annotation at all in the file. Passing a `"always"` option reports files missing those annotations as well.
+By default, this rule won't complain if there is no `@flow` annotation at all in the file. Passing a `"always"` option reports files missing those annotations as well, and additionally with `@no-flow` we can blacklist some files for this option.
 
 ```js
 {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "eslint-plugin-flowtype",
   "description": "Flowtype linting rules for ESLint.",
-  "version": "2.3.1",
+  "version": "2.3.0",
   "main": "./dist/index.js",
   "repository": {
     "type": "git",

--- a/src/utilities/isFlowFileAnnotation.js
+++ b/src/utilities/isFlowFileAnnotation.js
@@ -4,5 +4,5 @@ export default (comment) => {
     // The flow parser splits comments with the following regex to look for the @flow flag.
     // See https://github.com/facebook/flow/blob/a96249b93541f2f7bfebd8d62085bf7a75de02f2/src/parsing/docblock.ml#L39
     return _.includes(comment.split(/[ \t\r\n\\*/]+/), '@flow') ||
-      _.includes(comment.split(/[ \t\r\n\\*/]+/), '@no-flow')
+      _.includes(comment.split(/[ \t\r\n\\*/]+/), '@no-flow');
 };

--- a/src/utilities/isFlowFileAnnotation.js
+++ b/src/utilities/isFlowFileAnnotation.js
@@ -3,6 +3,6 @@ import _ from 'lodash';
 export default (comment) => {
     // The flow parser splits comments with the following regex to look for the @flow flag.
     // See https://github.com/facebook/flow/blob/a96249b93541f2f7bfebd8d62085bf7a75de02f2/src/parsing/docblock.ml#L39
-    return _.includes(comment.split(/[ \t\r\n\\*/]+/), '@flow');
+    return _.includes(comment.split(/[ \t\r\n\\*/]+/), '@flow') ||
+      _.includes(comment.split(/[ \t\r\n\\*/]+/), '@no-flow')
 };
-

--- a/tests/rules/assertions/requireValidFileAnnotation.js
+++ b/tests/rules/assertions/requireValidFileAnnotation.js
@@ -52,16 +52,28 @@ export default {
             code: '// @flow\na;'
         },
         {
+            code: '// @no-flow\na;'
+        },
+        {
             code: '//@flow\na;'
         },
         {
+            code: '//@no-flow\na;'
+        },
+        {
             code: '//**@flow\na;'
+        },
+        {
+            code: '//**@no-flow\na;'
         },
         {
             code: '/* foo @flow bar */\na;'
         },
         {
             code: '\n\n// @flow\na;'
+        },
+        {
+            code: '\n\n// @no-flow\na;'
         },
         {
             code: '// @flow\n// @FLow'
@@ -77,5 +89,3 @@ export default {
         }
     ]
 };
-
-


### PR DESCRIPTION
This is will be helpful in situation when we want to check all file without flow annotation, but in some case we should be able to blacklist some file.