### PR TITLE
Support for Optional Args in spaceBeforeTypeColon

### DIFF
--- a/README.md
+++ b/README.md
@@ -585,12 +585,24 @@ The following patterns are considered problems:
 (foo : string) => {}
 // Message: There must be no space before "foo" parameter type annotation colon.
 
+// Options: ["never"]
+(foo ?: string) => {}
+// Message: There must be no space before "foo" parameter type annotation colon.
+
 // Options: ["always"]
 (foo: string) => {}
 // Message: There must be a space before "foo" parameter type annotation colon.
 
 // Options: ["always"]
 (foo  : string) => {}
+// Message: There must be 1 space before "foo" parameter type annotation colon.
+
+// Options: ["always"]
+(foo?: string) => {}
+// Message: There must be a space before "foo" parameter type annotation colon.
+
+// Options: ["always"]
+(foo  ?: string) => {}
 // Message: There must be 1 space before "foo" parameter type annotation colon.
 ```
 
@@ -601,11 +613,16 @@ The following patterns are not considered problems:
 
 (foo: string) => {}
 
+(foo?: string) => {}
+
 // Options: ["never"]
 (foo: string) => {}
 
 // Options: ["always"]
 (foo : string) => {}
+
+// Options: ["always"]
+(foo ?: string) => {}
 ```
 
 

--- a/src/rules/spaceBeforeTypeColon.js
+++ b/src/rules/spaceBeforeTypeColon.js
@@ -13,7 +13,7 @@ export default iterateFunctionNodes((context) => {
             const typeAnnotation = _.get(identifierNode, 'typeAnnotation') || _.get(identifierNode, 'left.typeAnnotation');
 
             if (typeAnnotation) {
-                const spaceBefore = typeAnnotation.start - identifierNode.end;
+                const spaceBefore = typeAnnotation.start - identifierNode.end - (identifierNode.optional ? 1 : 0);
 
                 if (always && spaceBefore > 1) {
                     context.report(identifierNode, 'There must be 1 space before "' + parameterName + '" parameter type annotation colon.');

--- a/tests/rules/assertions/spaceBeforeTypeColon.js
+++ b/tests/rules/assertions/spaceBeforeTypeColon.js
@@ -12,6 +12,17 @@ export default {
             ]
         },
         {
+            code: '(foo ?: string) => {}',
+            errors: [
+                {
+                    message: 'There must be no space before "foo" parameter type annotation colon.'
+                }
+            ],
+            options: [
+                'never'
+            ]
+        },
+        {
             code: '(foo: string) => {}',
             errors: [
                 {
@@ -32,6 +43,28 @@ export default {
             options: [
                 'always'
             ]
+        },
+        {
+            code: '(foo?: string) => {}',
+            errors: [
+                {
+                    message: 'There must be a space before "foo" parameter type annotation colon.'
+                }
+            ],
+            options: [
+                'always'
+            ]
+        },
+        {
+            code: '(foo  ?: string) => {}',
+            errors: [
+                {
+                    message: 'There must be 1 space before "foo" parameter type annotation colon.'
+                }
+            ],
+            options: [
+                'always'
+            ]
         }
     ],
     valid: [
@@ -42,6 +75,9 @@ export default {
             code: '(foo: string) => {}'
         },
         {
+            code: '(foo?: string) => {}'
+        },
+        {
             code: '(foo: string) => {}',
             options: [
                 'never'
@@ -49,6 +85,12 @@ export default {
         },
         {
             code: '(foo : string) => {}',
+            options: [
+                'always'
+            ]
+        },
+        {
+            code: '(foo ?: string) => {}',
             options: [
                 'always'
             ]


### PR DESCRIPTION
Just allowing an additional character (the `?`) when the type is optional.

```js
(foo?: string) => {}
```