### PR TITLE
Fix "space-before-type-colon" for non-arrow functions

### DIFF
--- a/src/rules/spaceBeforeTypeColon.js
+++ b/src/rules/spaceBeforeTypeColon.js
@@ -7,13 +7,15 @@ import {
 export default iterateFunctionNodes((context) => {
     const always = context.options[0] === 'always';
 
+    const sourceCode = context.getSourceCode();
+
     return (functionNode) => {
         _.forEach(functionNode.params, (identifierNode) => {
             const parameterName = getParameterName(identifierNode, context);
             const typeAnnotation = _.get(identifierNode, 'typeAnnotation') || _.get(identifierNode, 'left.typeAnnotation');
 
             if (typeAnnotation) {
-                const spaceBefore = typeAnnotation.start - identifierNode.end - (identifierNode.optional ? 1 : 0);
+                const spaceBefore = typeAnnotation.start - sourceCode.getFirstToken(identifierNode, 0).end - (identifierNode.optional ? 1 : 0);
 
                 if (always && spaceBefore > 1) {
                     context.report(identifierNode, 'There must be 1 space before "' + parameterName + '" parameter type annotation colon.');

--- a/tests/rules/assertions/spaceAfterTypeColon.js
+++ b/tests/rules/assertions/spaceAfterTypeColon.js
@@ -45,6 +45,14 @@ export default {
             ]
         },
         {
+            code: 'function foo (foo:string) {}',
+            errors: [
+                {
+                    message: 'There must be a space after "foo" parameter type annotation colon.'
+                }
+            ]
+        },
+        {
             code: '(foo:  string) => {}',
             errors: [
                 {
@@ -159,10 +167,28 @@ export default {
             code: '(foo: string) => {}'
         },
         {
+            code: 'function x(foo: string) {}'
+        },
+        {
+            code: 'class Foo { constructor(foo: string) {} }'
+        },
+        {
             code: '(foo: (string|number)) => {}'
         },
         {
             code: '(foo:string) => {}',
+            options: [
+                'never'
+            ]
+        },
+        {
+            code: 'function x(foo:string) {}',
+            options: [
+                'never'
+            ]
+        },
+        {
+            code: 'class Foo { constructor(foo:string) {} }',
             options: [
                 'never'
             ]

--- a/tests/rules/assertions/spaceBeforeTypeColon.js
+++ b/tests/rules/assertions/spaceBeforeTypeColon.js
@@ -65,6 +65,63 @@ export default {
             options: [
                 'always'
             ]
+        },
+        {
+            code: 'function x(foo : string) {}',
+            errors: [
+                {
+                    message: 'There must be no space before "foo" parameter type annotation colon.'
+                }
+            ]
+        },
+        {
+            code: 'function x(foo: string) {}',
+            errors: [
+                {
+                    message: 'There must be a space before "foo" parameter type annotation colon.'
+                }
+            ],
+            options: [
+                'always'
+            ]
+        },
+        {
+            code: 'var x = function (foo : string) {}',
+            errors: [
+                {
+                    message: 'There must be no space before "foo" parameter type annotation colon.'
+                }
+            ]
+        },
+        {
+            code: 'var x = function (foo: string) {}',
+            errors: [
+                {
+                    message: 'There must be a space before "foo" parameter type annotation colon.'
+                }
+            ],
+            options: [
+                'always'
+            ]
+        },
+        {
+            code: 'class Foo { constructor(foo : string ) {} }',
+            errors: [
+                {
+                    message: 'There must be no space before "foo" parameter type annotation colon.'
+                }
+            ]
+        },
+        {
+            code: 'class Foo { constructor(foo: string ) {} }',
+            errors: [
+                {
+                    message: 'There must be a space before "foo" parameter type annotation colon.'
+                }
+            ],
+            options: [
+                'always'
+            ]
         }
     ],
     valid: [
@@ -91,6 +148,33 @@ export default {
         },
         {
             code: '(foo ?: string) => {}',
+            options: [
+                'always'
+            ]
+        },
+        {
+            code: 'function x(foo: string) {}'
+        },
+        {
+            code: 'function x(foo : string) {}',
+            options: [
+                'always'
+            ]
+        },
+        {
+            code: 'var x = function (foo: string) {}'
+        },
+        {
+            code: 'var x = function (foo : string) {}',
+            options: [
+                'always'
+            ]
+        },
+        {
+            code: 'class Foo { constructor(foo: string ) {} }'
+        },
+        {
+            code: 'class Foo { constructor(foo : string ) {} }',
             options: [
                 'always'
             ]


### PR DESCRIPTION
Currently the `space-before-type-colon` rule only works for arrow functions. It seems the current implementation is actually based off a parsing bug: https://github.com/babel/babylon/issues/51 - for normal functions, the parameter locations include the type annotations, but they don't for arrow functions.

It now works for both normal functions and arrow functions (and should continue working if that bug is fixed). I've also added a few more tests to `space-after-type-colon` just to be sure it works.

Fixes #20.