### PR TITLE
Fix where async func would not require return type

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,6 +343,26 @@ The following patterns are considered problems:
 // @flow
  (foo) => { return undefined; }
 // Message: Must annotate undefined return type.
+
+// Options: ["always"]
+async () => { return 2; }
+// Message: Missing return type annotation.
+
+// Options: ["always",{"annotateUndefined":"always"}]
+async () => {}
+// Message: Missing return type annotation.
+
+// Options: ["always",{"annotateUndefined":"always"}]
+async function x() {}
+// Message: Missing return type annotation.
+
+// Options: ["always"]
+async () => { return; }
+// Message: Missing return type annotation.
+
+// Options: ["always"]
+function* x() {}
+// Message: Missing return type annotation.
 ```
 
 The following patterns are not considered problems:
@@ -393,6 +413,8 @@ async function doThing(): Promise<void> {}
 
 // Options: ["always",{"annotateUndefined":"always"}]
 function* doThing(): Generator<number, void, void> { yield 2; }
+
+async (foo): Promise<number> => { return 3; }
 ```
 
 

--- a/src/rules/requireReturnType.js
+++ b/src/rules/requireReturnType.js
@@ -40,12 +40,13 @@ export default (context) => {
         }
 
         const isArrowFunctionExpression = functionNode.expression;
-        const isFunctionReturnUndefined = !isArrowFunctionExpression && (!targetNode.returnStatementNode || isUndefinedReturnType(targetNode.returnStatementNode));
+        const hasImplicitReturnType = functionNode.async || functionNode.generator;
+        const isFunctionReturnUndefined = !isArrowFunctionExpression && !hasImplicitReturnType && (!targetNode.returnStatementNode || isUndefinedReturnType(targetNode.returnStatementNode));
         const isReturnTypeAnnotationUndefined = getIsReturnTypeAnnotationUndefined(targetNode);
 
         if (isFunctionReturnUndefined && isReturnTypeAnnotationUndefined && !annotateUndefined) {
             context.report(functionNode, 'Must not annotate undefined return type.');
-        } else if (isFunctionReturnUndefined && !isReturnTypeAnnotationUndefined && annotateUndefined && !(functionNode.async || functionNode.generator)) {
+        } else if (isFunctionReturnUndefined && !isReturnTypeAnnotationUndefined && annotateUndefined) {
             context.report(functionNode, 'Must annotate undefined return type.');
         } else if (!isFunctionReturnUndefined && !isReturnTypeAnnotationUndefined) {
             if (annotateReturn && !functionNode.returnType) {

--- a/tests/rules/assertions/requireReturnType.js
+++ b/tests/rules/assertions/requireReturnType.js
@@ -185,6 +185,67 @@ export default {
                     onlyFilesWithFlowAnnotation: true
                 }
             }
+        },
+        {
+            code: 'async () => { return 2; }',
+            errors: [
+                {
+                    message: 'Missing return type annotation.'
+                }
+            ],
+            options: [
+                'always'
+            ]
+        },
+        {
+            code: 'async () => {}',
+            errors: [
+                {
+                    message: 'Missing return type annotation.'
+                }
+            ],
+            options: [
+                'always',
+                {
+                    annotateUndefined: 'always'
+                }
+            ]
+        },
+        {
+            code: 'async function x() {}',
+            errors: [
+                {
+                    message: 'Missing return type annotation.'
+                }
+            ],
+            options: [
+                'always',
+                {
+                    annotateUndefined: 'always'
+                }
+            ]
+        },
+        {
+            code: 'async () => { return; }',
+            errors: [
+                {
+                    message: 'Missing return type annotation.'
+                }
+            ],
+            options: [
+                'always'
+            ]
+        },
+        {
+            code: 'function* x() {}',
+            errors: [
+                {
+                    message: 'Missing return type annotation.'
+                }
+            ],
+            options: [
+                'always'
+            ]
         }
     ],
     valid: [
@@ -314,6 +375,9 @@ export default {
                     annotateUndefined: 'always'
                 }
             ]
+        },
+        {
+            code: 'async (foo): Promise<number> => { return 3; }'
         }
     ]
 };


### PR DESCRIPTION
Realised I messed up with #49 - sorry!

It would not error on an async/generator function missing a return type.

Cleaned up the implementation a little so `isFunctionReturnUndefined` can't be true if it's a async/generator function (as they'd return at least a Promise or Generator)