### PR TITLE
Skip Arrow Return Types & option for expressions only

### DIFF
--- a/.README/rules/require-parameter-type.md
+++ b/.README/rules/require-parameter-type.md
@@ -2,4 +2,34 @@
 
 Requires that all function parameters have type annotations.
 
+#### Options
+
+You can skip all arrow functions by providing the `excludeArrowFunctions` option with `true`.
+
+Alternatively, you can want to exclude only function expressions (e.g. `x => x * 2`). Provide `excludeArrowFunctions` with `expressionsOnly` for this. 
+
+```js
+{
+    "rules": {
+        "flowtype/require-parameter-type": [
+            2,
+            {
+              "excludeArrowFunctions": true
+            }
+        ]
+    }
+}
+
+{
+    "rules": {
+        "flowtype/require-parameter-type": [
+            2,
+            {
+              "excludeArrowFunctions": "expressionsOnly"
+            }
+        ]
+    }
+}
+```
+
 <!-- assertions requireParameterType -->

--- a/.README/rules/require-return-type.md
+++ b/.README/rules/require-return-type.md
@@ -2,4 +2,36 @@
 
 Requires that functions have return type annotation.
 
+#### Options
+
+You can skip all arrow functions by providing the `excludeArrowFunctions` option with `true`.
+
+Alternatively, you can want to exclude only function expressions (e.g. `() => 2`). Provide `excludeArrowFunctions` with `expressionsOnly` for this. 
+
+```js
+{
+    "rules": {
+        "flowtype/require-return-type": [
+            2,
+            "always",
+            {
+              "excludeArrowFunctions": true
+            }
+        ]
+    }
+}
+
+{
+    "rules": {
+        "flowtype/require-return-type": [
+            2,
+            "always",
+            {
+              "excludeArrowFunctions": "expressionsOnly"
+            }
+        ]
+    }
+}
+```
+
 <!-- assertions requireReturnType -->

--- a/README.md
+++ b/README.md
@@ -224,6 +224,36 @@ interface AType<BType> {}
 
 Requires that all function parameters have type annotations.
 
+<h4 id="eslint-plugin-flowtype-rules-require-parameter-type-options">Options</h4>
+
+You can skip all arrow functions by providing the `excludeArrowFunctions` option with `true`.
+
+Alternatively, you can want to exclude only function expressions (e.g. `x => x * 2`). Provide `excludeArrowFunctions` with `expressionsOnly` for this. 
+
+```js
+{
+    "rules": {
+        "flowtype/require-parameter-type": [
+            2,
+            {
+              "excludeArrowFunctions": true
+            }
+        ]
+    }
+}
+
+{
+    "rules": {
+        "flowtype/require-parameter-type": [
+            2,
+            {
+              "excludeArrowFunctions": "expressionsOnly"
+            }
+        ]
+    }
+}
+```
+
 The following patterns are considered problems:
 
 ```js
@@ -255,6 +285,14 @@ function x(foo) {}
 // @flow
 (foo) => {}
 // Message: Missing "foo" parameter type annotation.
+
+// Options: [{"excludeArrowFunctions":"expressionsOnly"}]
+(foo) => {}
+// Message: Missing "foo" parameter type annotation.
+
+// Options: [{"excludeArrowFunctions":"expressionsOnly"}]
+function x(foo) {}
+// Message: Missing "foo" parameter type annotation.
 ```
 
 The following patterns are not considered problems:
@@ -274,6 +312,9 @@ The following patterns are not considered problems:
 
 // Options: [{"excludeArrowFunctions":true}]
 (foo) => {}
+
+// Options: [{"excludeArrowFunctions":"expressionsOnly"}]
+(foo) => 3
 ```
 
 
@@ -281,6 +322,38 @@ The following patterns are not considered problems:
 <h3 id="eslint-plugin-flowtype-rules-require-return-type"><code>require-return-type</code></h3>
 
 Requires that functions have return type annotation.
+
+<h4 id="eslint-plugin-flowtype-rules-require-return-type-options">Options</h4>
+
+You can skip all arrow functions by providing the `excludeArrowFunctions` option with `true`.
+
+Alternatively, you can want to exclude only function expressions (e.g. `() => 2`). Provide `excludeArrowFunctions` with `expressionsOnly` for this. 
+
+```js
+{
+    "rules": {
+        "flowtype/require-return-type": [
+            2,
+            "always",
+            {
+              "excludeArrowFunctions": true
+            }
+        ]
+    }
+}
+
+{
+    "rules": {
+        "flowtype/require-return-type": [
+            2,
+            "always",
+            {
+              "excludeArrowFunctions": "expressionsOnly"
+            }
+        ]
+    }
+}
+```
 
 The following patterns are considered problems:
 
@@ -363,6 +436,14 @@ async () => { return; }
 // Options: ["always"]
 function* x() {}
 // Message: Missing return type annotation.
+
+// Options: ["always",{"excludeArrowFunctions":"expressionsOnly"}]
+() => { return 3; }
+// Message: Missing return type annotation.
+
+// Options: ["always",{"excludeArrowFunctions":"expressionsOnly"}]
+async () => { return 4; }
+// Message: Missing return type annotation.
 ```
 
 The following patterns are not considered problems:
@@ -415,6 +496,27 @@ async function doThing(): Promise<void> {}
 function* doThing(): Generator<number, void, void> { yield 2; }
 
 async (foo): Promise<number> => { return 3; }
+
+// Options: ["always",{"excludeArrowFunctions":true}]
+() => 3
+
+// Options: ["always",{"excludeArrowFunctions":true}]
+() => { return 4; }
+
+// Options: ["always",{"excludeArrowFunctions":true}]
+() => undefined
+
+// Options: ["always",{"excludeArrowFunctions":true,"annotateUndefined":"always"}]
+() => undefined
+
+// Options: ["always",{"excludeArrowFunctions":true,"annotateUndefined":"always"}]
+() => { return undefined; }
+
+// Options: ["always",{"excludeArrowFunctions":"expressionsOnly"}]
+() => 3
+
+// Options: ["always",{"excludeArrowFunctions":"expressionsOnly"}]
+async () => 3
 ```
 
 

--- a/src/rules/requireParameterType.js
+++ b/src/rules/requireParameterType.js
@@ -18,9 +18,15 @@ export default iterateFunctionNodes((context) => {
         _.forEach(functionNode.params, (identifierNode) => {
             const parameterName = getParameterName(identifierNode, context);
             const typeAnnotation = _.get(identifierNode, 'typeAnnotation') || _.get(identifierNode, 'left.typeAnnotation');
-            const shouldSkip = functionNode.type === 'ArrowFunctionExpression' && skipArrows;
 
-            if (!typeAnnotation && !shouldSkip) {
+            const isArrow = functionNode.type === 'ArrowFunctionExpression';
+            const isArrowFunctionExpression = functionNode.expression;
+
+            if (skipArrows === 'expressionsOnly' && isArrowFunctionExpression || skipArrows === true && isArrow) {
+                return;
+            }
+
+            if (!typeAnnotation) {
                 context.report(identifierNode, 'Missing "' + parameterName + '" parameter type annotation.');
             }
         });

--- a/src/rules/requireReturnType.js
+++ b/src/rules/requireReturnType.js
@@ -46,7 +46,7 @@ export default (context) => {
         const isFunctionReturnUndefined = !isArrowFunctionExpression && !hasImplicitReturnType && (!targetNode.returnStatementNode || isUndefinedReturnType(targetNode.returnStatementNode));
         const isReturnTypeAnnotationUndefined = getIsReturnTypeAnnotationUndefined(targetNode);
 
-        if (skipArrows && isArrow) {
+        if (skipArrows === 'expressionsOnly' && isArrowFunctionExpression || skipArrows === true && isArrow) {
             return;
         }
 

--- a/src/rules/requireReturnType.js
+++ b/src/rules/requireReturnType.js
@@ -12,6 +12,7 @@ export default (context) => {
 
     const annotateReturn = (_.get(context, 'options[0]') || 'always') === 'always';
     const annotateUndefined = (_.get(context, 'options[1].annotateUndefined') || 'never') === 'always';
+    const skipArrows = _.get(context, 'options[1].excludeArrowFunctions') || false;
 
     const targetNodes = [];
 
@@ -39,10 +40,15 @@ export default (context) => {
             throw new Error('Mismatch.');
         }
 
+        const isArrow = functionNode.type === 'ArrowFunctionExpression';
         const isArrowFunctionExpression = functionNode.expression;
         const hasImplicitReturnType = functionNode.async || functionNode.generator;
         const isFunctionReturnUndefined = !isArrowFunctionExpression && !hasImplicitReturnType && (!targetNode.returnStatementNode || isUndefinedReturnType(targetNode.returnStatementNode));
         const isReturnTypeAnnotationUndefined = getIsReturnTypeAnnotationUndefined(targetNode);
+
+        if (skipArrows && isArrow) {
+            return;
+        }
 
         if (isFunctionReturnUndefined && isReturnTypeAnnotationUndefined && !annotateUndefined) {
             context.report(functionNode, 'Must not annotate undefined return type.');

--- a/tests/rules/assertions/requireParameterType.js
+++ b/tests/rules/assertions/requireParameterType.js
@@ -81,6 +81,32 @@ export default {
                     onlyFilesWithFlowAnnotation: true
                 }
             }
+        },
+        {
+            code: '(foo) => {}',
+            errors: [
+                {
+                    message: 'Missing "foo" parameter type annotation.'
+                }
+            ],
+            options: [
+                {
+                    excludeArrowFunctions: 'expressionsOnly'
+                }
+            ]
+        },
+        {
+            code: 'function x(foo) {}',
+            errors: [
+                {
+                    message: 'Missing "foo" parameter type annotation.'
+                }
+            ],
+            options: [
+                {
+                    excludeArrowFunctions: 'expressionsOnly'
+                }
+            ]
         }
     ],
     valid: [
@@ -112,6 +138,14 @@ export default {
             options: [
                 {
                     excludeArrowFunctions: true
+                }
+            ]
+        },
+        {
+            code: '(foo) => 3',
+            options: [
+                {
+                    excludeArrowFunctions: 'expressionsOnly'
                 }
             ]
         }

--- a/tests/rules/assertions/requireReturnType.js
+++ b/tests/rules/assertions/requireReturnType.js
@@ -378,6 +378,53 @@ export default {
         },
         {
             code: 'async (foo): Promise<number> => { return 3; }'
+        },
+        {
+            code: '() => 3',
+            options: [
+                'always',
+                {
+                    excludeArrowFunctions: true
+                }
+            ]
+        },
+        {
+            code: '() => { return 4; }',
+            options: [
+                'always',
+                {
+                    excludeArrowFunctions: true
+                }
+            ]
+        },
+        {
+            code: '() => undefined',
+            options: [
+                'always',
+                {
+                    excludeArrowFunctions: true
+                }
+            ]
+        },
+        {
+            code: '() => undefined',
+            options: [
+                'always',
+                {
+                    excludeArrowFunctions: true,
+                    annotateUndefined: 'always'
+                }
+            ]
+        },
+        {
+            code: '() => { return undefined; }',
+            options: [
+                'always',
+                {
+                    excludeArrowFunctions: true,
+                    annotateUndefined: 'always'
+                }
+            ]
         }
     ]
 };

--- a/tests/rules/assertions/requireReturnType.js
+++ b/tests/rules/assertions/requireReturnType.js
@@ -246,6 +246,34 @@ export default {
             options: [
                 'always'
             ]
+        },
+        {
+            code: '() => { return 3; }',
+            errors: [
+                {
+                    message: 'Missing return type annotation.'
+                }
+            ],
+            options: [
+                'always',
+                {
+                    excludeArrowFunctions: 'expressionsOnly'
+                }
+            ]
+        },
+        {
+            code: 'async () => { return 4; }',
+            errors: [
+                {
+                    message: 'Missing return type annotation.'
+                }
+            ],
+            options: [
+                'always',
+                {
+                    excludeArrowFunctions: 'expressionsOnly'
+                }
+            ]
         }
     ],
     valid: [
@@ -423,6 +451,24 @@ export default {
                 {
                     excludeArrowFunctions: true,
                     annotateUndefined: 'always'
+                }
+            ]
+        },
+        {
+            code: '() => 3',
+            options: [
+                'always',
+                {
+                    excludeArrowFunctions: 'expressionsOnly'
+                }
+            ]
+        },
+        {
+            code: 'async () => 3',
+            options: [
+                'always',
+                {
+                    excludeArrowFunctions: 'expressionsOnly'
                 }
             ]
         }


### PR DESCRIPTION
* adds option for arrow functions to skip return types: https://github.com/gajus/eslint-plugin-flowtype/commit/866605b63f6b4092ee95d73288788083fc782d9d
  * replicates the `{ "excludeArrowFunctions": true }` option for param types in #50
* adds option for only arrow function _expressions_ to skip return type: https://github.com/gajus/eslint-plugin-flowtype/commit/b09b85d2f4138c383d480ea9e4db10f599851cbb
  * can use `{ "excludeArrowFunctions": "expressionsOnly" }` on return types
* adds option for only arrow function _expressions_ to skip parameter types: https://github.com/gajus/eslint-plugin-flowtype/commit/265a3483c660e3e99c1bf14a08dfc6e5200fcdb0
  * can use `{ "excludeArrowFunctions": "expressionsOnly" }` on param types
* docs: https://github.com/gajus/eslint-plugin-flowtype/commit/685d73cc7081759f946491731a43b3ff4073f6be