### PR TITLE
Fix #43: Check for a basic flow syntax error; prevents crashing

### DIFF
--- a/.README/README.md
+++ b/.README/README.md
@@ -58,7 +58,8 @@ npm install eslint-plugin-flowtype
             1,
             "^([A-Z][a-z0-9]+)+Type$"
         ],
-        "flowtype/use-flow-type": 1
+        "flowtype/use-flow-type": 1,
+        "flowtype/valid-syntax": 1
     },
     "settings": {
         "flowtype": {
@@ -94,3 +95,4 @@ When `true`, only checks files with a [`@flow` annotation](http://flowtype.org/d
 {"gitdown": "include", "file": "./rules/space-before-type-colon.md"}
 {"gitdown": "include", "file": "./rules/type-id-match.md"}
 {"gitdown": "include", "file": "./rules/use-flow-type.md"}
+{"gitdown": "include", "file": "./rules/valid-syntax.md"}

--- a/.README/rules/valid-syntax.md
+++ b/.README/rules/valid-syntax.md
@@ -1,0 +1,5 @@
+### `valid-syntax`
+
+Checks for simple Flow syntax errors.
+
+<!-- assertions validSyntax -->

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@
         * [`space-before-type-colon`](#eslint-plugin-flowtype-rules-space-before-type-colon)
         * [`type-id-match`](#eslint-plugin-flowtype-rules-type-id-match)
         * [`use-flow-type`](#eslint-plugin-flowtype-rules-use-flow-type)
+        * [`valid-syntax`](#eslint-plugin-flowtype-rules-valid-syntax)
 
 
 <h2 id="eslint-plugin-flowtype-installation">Installation</h2>
@@ -72,7 +73,8 @@ npm install eslint-plugin-flowtype
             1,
             "^([A-Z][a-z0-9]+)+Type$"
         ],
-        "flowtype/use-flow-type": 1
+        "flowtype/use-flow-type": 1,
+        "flowtype/valid-syntax": 1
     },
     "settings": {
         "flowtype": {
@@ -973,6 +975,31 @@ type A = {}; function x<Y: A.B.C>(i: Y) { i }; x()
 
 function x<Y: A.B.C>(i: Y) { i }; type A = {}; x()
 // Additional rules: {"no-unused-vars":1}
+```
+
+
+
+<h3 id="eslint-plugin-flowtype-rules-valid-syntax"><code>valid-syntax</code></h3>
+
+Checks for simple Flow syntax errors.
+
+The following patterns are considered problems:
+
+```js
+function x(foo = "1": string) {}
+// Message: "foo" parameter type annotation must be placed on left-hand side of assignment.
+
+function x(foo = bar(): Type, baz = []: []) {}
+// Message: "foo" parameter type annotation must be placed on left-hand side of assignment.
+// Message: "baz" parameter type annotation must be placed on left-hand side of assignment.
+```
+
+The following patterns are not considered problems:
+
+```js
+function x(foo: string = "1") {}
+
+function x(foo: Type = bar()) {}
 ```
 
 

--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,7 @@ import spaceAfterTypeColon from './rules/spaceAfterTypeColon';
 import spaceBeforeTypeColon from './rules/spaceBeforeTypeColon';
 import typeIdMatch from './rules/typeIdMatch';
 import useFlowType from './rules/useFlowType';
+import validSyntax from './rules/validSyntax';
 
 export default {
     rules: {
@@ -16,7 +17,8 @@ export default {
         'space-after-type-colon': spaceAfterTypeColon,
         'space-before-type-colon': spaceBeforeTypeColon,
         'type-id-match': typeIdMatch,
-        'use-flow-type': useFlowType
+        'use-flow-type': useFlowType,
+        'valid-syntax': validSyntax
     },
     rulesConfig: {
         'define-flow-type': 0,
@@ -25,6 +27,7 @@ export default {
         'space-after-type-colon': 0,
         'space-before-type-colon': 0,
         'type-id-match': 0,
-        'use-flow-type': 0
+        'use-flow-type': 0,
+        'valid-syntax': 0
     }
 };

--- a/src/rules/validSyntax.js
+++ b/src/rules/validSyntax.js
@@ -1,0 +1,21 @@
+import _ from 'lodash';
+import {
+    getParameterName,
+    iterateFunctionNodes
+} from './../utilities';
+
+export default iterateFunctionNodes((context) => {
+    return (functionNode) => {
+        _.forEach(functionNode.params, (identifierNode) => {
+            const parameterName = getParameterName(identifierNode, context);
+            const nodeType = _.get(identifierNode, 'type');
+            const isAssignmentPattern = nodeType === 'AssignmentPattern';
+            const hasTypeAnnotation = Boolean(_.get(identifierNode, 'typeAnnotation'));
+            const leftAnnotated = Boolean(_.get(identifierNode, 'left.typeAnnotation'));
+
+            if (isAssignmentPattern && hasTypeAnnotation && !leftAnnotated) {
+                context.report(identifierNode, '"' + parameterName + '" parameter type annotation must be placed on left-hand side of assignment.');
+            }
+        });
+    };
+});

--- a/tests/rules/assertions/validSyntax.js
+++ b/tests/rules/assertions/validSyntax.js
@@ -1,0 +1,31 @@
+export default {
+    invalid: [
+        {
+            code: 'function x(foo = "1": string) {}',
+            errors: [
+                {
+                    message: '"foo" parameter type annotation must be placed on left-hand side of assignment.'
+                }
+            ]
+        },
+        {
+            code: 'function x(foo = bar(): Type, baz = []: []) {}',
+            errors: [
+                {
+                    message: '"foo" parameter type annotation must be placed on left-hand side of assignment.'
+                },
+                {
+                    message: '"baz" parameter type annotation must be placed on left-hand side of assignment.'
+                }
+            ]
+        }
+    ],
+    valid: [
+        {
+            code: 'function x(foo: string = "1") {}'
+        },
+        {
+            code: 'function x(foo: Type = bar()) {}'
+        }
+    ]
+};

--- a/tests/rules/index.js
+++ b/tests/rules/index.js
@@ -14,7 +14,8 @@ const reportingRules = [
     'space-after-type-colon',
     'space-before-type-colon',
     'type-id-match',
-    'use-flow-type'
+    'use-flow-type',
+    'valid-syntax'
 ];
 
 const parser = require.resolve('babel-eslint');


### PR DESCRIPTION
See #43.

It definitely works, but I'd understand if creating this rule doesn't fit your vision of the project.

I named it that way so we could add other syntax checks to it should we need to.