### PR TITLE
Object & Class Type Spacing

### DIFF
--- a/README.md
+++ b/README.md
@@ -701,6 +701,20 @@ type X = { foo?:?string }
 
 type X = { foo?:  ?string }
 // Message: There must be 1 space after "foo" type annotation colon.
+
+class X { foo:string }
+// Message: There must be a space after "foo" class property type annotation colon.
+
+// Options: ["never"]
+class X { foo: string }
+// Message: There must be no space after "foo" class property type annotation colon.
+
+class X { foo:?string }
+// Message: There must be a space after "foo" class property type annotation colon.
+
+// Options: ["never"]
+class X { foo: ?string }
+// Message: There must be no space after "foo" class property type annotation colon.
 ```
 
 The following patterns are not considered problems:
@@ -792,6 +806,20 @@ type X = { foo?: ?string }
 
 // Options: ["never"]
 type X = { foo?:?string }
+
+class Foo { bar }
+
+class Foo { bar = 3 }
+
+class Foo { bar: string }
+
+class Foo { bar: ?string }
+
+// Options: ["never"]
+class Foo { bar:string }
+
+// Options: ["never"]
+class Foo { bar:?string }
 ```
 
 
@@ -894,6 +922,20 @@ type X = { foo?  : string }
 // Options: ["always"]
 type X = { foo   ?: string }
 // Message: There must be a space before "foo" type annotation colon.
+
+class X { foo :string }
+// Message: There must be no space before "foo" class property type annotation colon.
+
+// Options: ["always"]
+class X { foo: string }
+// Message: There must be a space before "foo" class property type annotation colon.
+
+class X { foo :?string }
+// Message: There must be no space before "foo" class property type annotation colon.
+
+// Options: ["always"]
+class X { foo: ?string }
+// Message: There must be a space before "foo" class property type annotation colon.
 ```
 
 The following patterns are not considered problems:
@@ -955,6 +997,19 @@ type X = { foo?: string }
 
 // Options: ["always"]
 type X = { foo? : string }
+
+class Foo { bar }
+
+class Foo { bar = 3 }
+
+class Foo { bar: string }
+
+class Foo { bar: ?string }
+
+class Foo { bar:?string }
+
+// Options: ["always"]
+class Foo { bar : string }
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -674,6 +674,33 @@ async function foo({ lorem, ipsum, dolor }:SomeType) {}
 
 ([ a, b ] :string[]) => {}
 // Message: There must be a space after "[ a, b ]" parameter type annotation colon.
+
+type X = { foo:string }
+// Message: There must be a space after "foo" type annotation colon.
+
+// Options: ["always"]
+type X = { foo:string }
+// Message: There must be a space after "foo" type annotation colon.
+
+// Options: ["never"]
+type X = { foo: string }
+// Message: There must be no space after "foo" type annotation colon.
+
+type X = { foo:  string }
+// Message: There must be 1 space after "foo" type annotation colon.
+
+type X = { foo?:string }
+// Message: There must be a space after "foo" type annotation colon.
+
+// Options: ["never"]
+type X = { foo?: string }
+// Message: There must be no space after "foo" type annotation colon.
+
+type X = { foo?:?string }
+// Message: There must be a space after "foo" type annotation colon.
+
+type X = { foo?:  ?string }
+// Message: There must be 1 space after "foo" type annotation colon.
 ```
 
 The following patterns are not considered problems:
@@ -750,9 +777,21 @@ function x({ a, b }: { a: string, b: number }) {}
 (): { a: number, b: string } => {}
 
 // Options: ["never"]
-() :{ a: number, b: string } => {}
+() :{ a:number, b:string } => {}
 
 ([ a, b ]: string[]) => {}
+
+type X = { foo: string }
+
+// Options: ["never"]
+type X = { foo:string }
+
+type X = { foo?: string }
+
+type X = { foo?: ?string }
+
+// Options: ["never"]
+type X = { foo?:?string }
 ```
 
 
@@ -825,6 +864,36 @@ async function foo({ lorem, ipsum, dolor } : SomeType) {}
 
 ([ a, b ] : string[]) => {}
 // Message: There must be no space before "[ a, b ]" parameter type annotation colon.
+
+type X = { foo : string }
+// Message: There must be no space before "foo" type annotation colon.
+
+// Options: ["never"]
+type X = { foo : string }
+// Message: There must be no space before "foo" type annotation colon.
+
+// Options: ["always"]
+type X = { foo: string }
+// Message: There must be a space before "foo" type annotation colon.
+
+// Options: ["always"]
+type X = { foo  : string }
+// Message: There must be 1 space before "foo" type annotation colon.
+
+type X = { foo? : string }
+// Message: There must be no space before "foo" type annotation colon.
+
+// Options: ["always"]
+type X = { foo?: string }
+// Message: There must be a space before "foo" type annotation colon.
+
+// Options: ["always"]
+type X = { foo?  : string }
+// Message: There must be 1 space before "foo" type annotation colon.
+
+// Options: ["always"]
+type X = { foo   ?: string }
+// Message: There must be a space before "foo" type annotation colon.
 ```
 
 The following patterns are not considered problems:
@@ -873,9 +942,19 @@ function x({ a, b }: { a: string, b: number }) {}
 (): { a: number, b: string } => {}
 
 // Options: ["always"]
-() : { a: number, b: string } => {}
+() : { a : number, b : string } => {}
 
 ([ a, b ]: string[]) => {}
+
+type X = { foo: string }
+
+// Options: ["always"]
+type X = { foo : string }
+
+type X = { foo?: string }
+
+// Options: ["always"]
+type X = { foo? : string }
 ```
 
 

--- a/src/rules/spaceAfterTypeColon.js
+++ b/src/rules/spaceAfterTypeColon.js
@@ -4,30 +4,42 @@ import {
     iterateFunctionNodes
 } from './../utilities';
 
-const functionEvaluators = iterateFunctionNodes((context) => {
-    const always = (context.options[0] || 'always') === 'always';
+const parseOptions = (context) => {
+    return {
+        always: (context.options[0] || 'always') === 'always'
+    };
+};
+
+const propertyEvaluator = (context, typeForMessage) => {
+    const {always} = parseOptions(context);
+
+    const sourceCode = context.getSourceCode();
+
+    return (node) => {
+        const parameterName = getParameterName(node, context);
+        const typeAnnotation = _.get(node, 'typeAnnotation') || _.get(node, 'left.typeAnnotation');
+
+        if (typeAnnotation) {
+            const token = sourceCode.getFirstToken(typeAnnotation, 1);
+            const spaceAfter = token.start - typeAnnotation.start - 1;
+
+            if (always && spaceAfter > 1) {
+                context.report(node, 'There must be 1 space after "' + parameterName + '" ' + typeForMessage + ' type annotation colon.');
+            } else if (always && spaceAfter === 0) {
+                context.report(node, 'There must be a space after "' + parameterName + '" ' + typeForMessage + ' type annotation colon.');
+            } else if (!always && spaceAfter > 0) {
+                context.report(node, 'There must be no space after "' + parameterName + '" ' + typeForMessage + ' type annotation colon.');
+            }
+        }
+    };
+};
+
+const returnTypeEvaluator = (context) => {
+    const {always} = parseOptions(context);
 
     const sourceCode = context.getSourceCode();
 
     return (functionNode) => {
-        _.forEach(functionNode.params, (identifierNode) => {
-            const parameterName = getParameterName(identifierNode, context);
-            const typeAnnotation = _.get(identifierNode, 'typeAnnotation') || _.get(identifierNode, 'left.typeAnnotation');
-
-            if (typeAnnotation) {
-                const token = sourceCode.getFirstToken(typeAnnotation, 1);
-                const spaceAfter = token.start - typeAnnotation.start - 1;
-
-                if (always && spaceAfter > 1) {
-                    context.report(identifierNode, 'There must be 1 space after "' + parameterName + '" parameter type annotation colon.');
-                } else if (always && spaceAfter === 0) {
-                    context.report(identifierNode, 'There must be a space after "' + parameterName + '" parameter type annotation colon.');
-                } else if (!always && spaceAfter > 0) {
-                    context.report(identifierNode, 'There must be no space after "' + parameterName + '" parameter type annotation colon.');
-                }
-            }
-        });
-
         if (functionNode.returnType) {
             const token = sourceCode.getFirstToken(functionNode.returnType, 1);
             const spaceAfter = token.start - functionNode.returnType.start - 1;
@@ -41,19 +53,27 @@ const functionEvaluators = iterateFunctionNodes((context) => {
             }
         }
     };
+};
+
+const functionEvaluators = iterateFunctionNodes((context) => {
+    const checkParam = propertyEvaluator(context, 'parameter');
+    const checkReturnType = returnTypeEvaluator(context);
+
+    return (functionNode) => {
+        _.forEach(functionNode.params, checkParam);
+        checkReturnType(functionNode);
+    };
 });
 
 const objectTypePropertyEvaluator = (context) => {
-    const always = (context.options[0] || 'always') === 'always';
+    const {always} = parseOptions(context);
 
     const sourceCode = context.getSourceCode();
 
     return (objectTypeProperty) => {
-        const identifier = sourceCode.getFirstToken(objectTypeProperty, 0);
         const colon = sourceCode.getFirstToken(objectTypeProperty, objectTypeProperty.optional ? 2 : 1);
         const typeAnnotation = objectTypeProperty.value;
-
-        const name = identifier.value;
+        const name = getParameterName(objectTypeProperty, context);
 
         const spaceAfter = typeAnnotation.start - colon.end;
 
@@ -67,34 +87,10 @@ const objectTypePropertyEvaluator = (context) => {
     };
 };
 
-const classPropertyEvaluator = (context) => {
-    const always = (context.options[0] || 'always') === 'always';
-
-    const sourceCode = context.getSourceCode();
-
-    return (classProperty) => {
-        const parameterName = getParameterName(classProperty, context);
-        const typeAnnotation = classProperty.typeAnnotation;
-
-        if (typeAnnotation) {
-            const token = sourceCode.getFirstToken(typeAnnotation, 1);
-            const spaceAfter = token.start - typeAnnotation.start - 1;
-
-            if (always && spaceAfter > 1) {
-                context.report(classProperty, 'There must be 1 space after "' + parameterName + '" class property type annotation colon.');
-            } else if (always && spaceAfter === 0) {
-                context.report(classProperty, 'There must be a space after "' + parameterName + '" class property type annotation colon.');
-            } else if (!always && spaceAfter > 0) {
-                context.report(classProperty, 'There must be no space after "' + parameterName + '" class property type annotation colon.');
-            }
-        }
-    };
-};
-
 export default (context) => {
     return {
         ...functionEvaluators(context),
-        ObjectTypeProperty: objectTypePropertyEvaluator(context),
-        ClassProperty: classPropertyEvaluator(context)
+        ClassProperty: propertyEvaluator(context, 'class property'),
+        ObjectTypeProperty: objectTypePropertyEvaluator(context)
     };
 };

--- a/src/rules/spaceAfterTypeColon.js
+++ b/src/rules/spaceAfterTypeColon.js
@@ -67,9 +67,34 @@ const objectTypePropertyEvaluator = (context) => {
     };
 };
 
+const classPropertyEvaluator = (context) => {
+    const always = (context.options[0] || 'always') === 'always';
+
+    const sourceCode = context.getSourceCode();
+
+    return (classProperty) => {
+        const parameterName = getParameterName(classProperty, context);
+        const typeAnnotation = classProperty.typeAnnotation;
+
+        if (typeAnnotation) {
+            const token = sourceCode.getFirstToken(typeAnnotation, 1);
+            const spaceAfter = token.start - typeAnnotation.start - 1;
+
+            if (always && spaceAfter > 1) {
+                context.report(classProperty, 'There must be 1 space after "' + parameterName + '" class property type annotation colon.');
+            } else if (always && spaceAfter === 0) {
+                context.report(classProperty, 'There must be a space after "' + parameterName + '" class property type annotation colon.');
+            } else if (!always && spaceAfter > 0) {
+                context.report(classProperty, 'There must be no space after "' + parameterName + '" class property type annotation colon.');
+            }
+        }
+    };
+};
+
 export default (context) => {
     return {
         ...functionEvaluators(context),
-        ObjectTypeProperty: objectTypePropertyEvaluator(context)
+        ObjectTypeProperty: objectTypePropertyEvaluator(context),
+        ClassProperty: classPropertyEvaluator(context)
     };
 };

--- a/src/rules/spaceBeforeTypeColon.js
+++ b/src/rules/spaceBeforeTypeColon.js
@@ -69,9 +69,34 @@ const objectTypePropertyEvaluator = (context) => {
     };
 };
 
+const classPropertyEvaluator = (context) => {
+    const always = context.options[0] === 'always';
+
+    const sourceCode = context.getSourceCode();
+
+    return (classProperty) => {
+        const parameterName = getParameterName(classProperty, context);
+        const typeAnnotation = _.get(classProperty, 'typeAnnotation') || _.get(classProperty, 'left.typeAnnotation');
+
+        if (typeAnnotation) {
+            const tokenBeforeType = sourceCode.getTokenBefore(typeAnnotation, classProperty.optional ? 1 : 0);
+            const spaceBefore = typeAnnotation.start - tokenBeforeType.end - (classProperty.optional ? 1 : 0);
+
+            if (always && spaceBefore > 1) {
+                context.report(classProperty, 'There must be 1 space before "' + parameterName + '" class property type annotation colon.');
+            } else if (always && spaceBefore === 0) {
+                context.report(classProperty, 'There must be a space before "' + parameterName + '" class property type annotation colon.');
+            } else if (!always && spaceBefore > 0) {
+                context.report(classProperty, 'There must be no space before "' + parameterName + '" class property type annotation colon.');
+            }
+        }
+    };
+};
+
 export default (context) => {
     return {
         ...functionEvaluators(context),
-        ObjectTypeProperty: objectTypePropertyEvaluator(context)
+        ObjectTypeProperty: objectTypePropertyEvaluator(context),
+        ClassProperty: classPropertyEvaluator(context)
     };
 };

--- a/src/rules/spaceBeforeTypeColon.js
+++ b/src/rules/spaceBeforeTypeColon.js
@@ -4,58 +4,55 @@ import {
     iterateFunctionNodes
 } from './../utilities';
 
-const functionEvaluators = iterateFunctionNodes((context) => {
-    const always = context.options[0] === 'always';
+const parseOptions = (context) => {
+    return {
+        always: context.options[0] === 'always'
+    };
+};
+
+const propertyEvaluator = (context, typeForMessage) => {
+    const {always} = parseOptions(context);
 
     const sourceCode = context.getSourceCode();
 
-    return (functionNode) => {
-        _.forEach(functionNode.params, (identifierNode) => {
-            const parameterName = getParameterName(identifierNode, context);
-            const typeAnnotation = _.get(identifierNode, 'typeAnnotation') || _.get(identifierNode, 'left.typeAnnotation');
+    return (node) => {
+        const parameterName = getParameterName(node, context);
+        const typeAnnotation = _.get(node, 'typeAnnotation') || _.get(node, 'left.typeAnnotation');
 
-            if (typeAnnotation) {
-                // usually the identifierNode, but can be the closing } of a destructuring
-                // so foo: string
-                //    ^^^ tokenBeforeType
-                //       ^^^^^^^^ typeAnnotation
-                // so { bar }: Object
-                //    ^^^^^^^ tokenBeforeType
-                //           ^^^^^^^^ typeAnnotation
-                const tokenBeforeType = sourceCode.getTokenBefore(typeAnnotation, identifierNode.optional ? 1 : 0);
-                const spaceBefore = typeAnnotation.start - tokenBeforeType.end - (identifierNode.optional ? 1 : 0);
+        if (typeAnnotation) {
+            // tokenBeforeType can be the identifier or the closing } token of a destructuring
+            const tokenBeforeType = sourceCode.getTokenBefore(typeAnnotation, node.optional ? 1 : 0);
+            const spaceBefore = typeAnnotation.start - tokenBeforeType.end - (node.optional ? 1 : 0);
 
-                if (always && spaceBefore > 1) {
-                    context.report(identifierNode, 'There must be 1 space before "' + parameterName + '" parameter type annotation colon.');
-                } else if (always && spaceBefore === 0) {
-                    context.report(identifierNode, 'There must be a space before "' + parameterName + '" parameter type annotation colon.');
-                } else if (!always && spaceBefore > 0) {
-                    context.report(identifierNode, 'There must be no space before "' + parameterName + '" parameter type annotation colon.');
-                }
+            if (always && spaceBefore > 1) {
+                context.report(node, 'There must be 1 space before "' + parameterName + '" ' + typeForMessage + ' type annotation colon.');
+            } else if (always && spaceBefore === 0) {
+                context.report(node, 'There must be a space before "' + parameterName + '" ' + typeForMessage + ' type annotation colon.');
+            } else if (!always && spaceBefore > 0) {
+                context.report(node, 'There must be no space before "' + parameterName + '" ' + typeForMessage + ' type annotation colon.');
             }
-        });
+        }
+    };
+};
+
+const functionEvaluators = iterateFunctionNodes((context) => {
+    const checkParam = propertyEvaluator(context, 'parameter');
+
+    return (functionNode) => {
+        _.forEach(functionNode.params, checkParam);
     };
 });
 
 const objectTypePropertyEvaluator = (context) => {
-    const always = context.options[0] === 'always';
+    const {always} = parseOptions(context);
 
     const sourceCode = context.getSourceCode();
 
     return (objectTypeProperty) => {
-        // so foo: string
-        //    ^^^ identifier
-        //    ^^^ tokenBeforeColon
-        //       ^ colon
-        // so foo?: string
-        //    ^^^ identifier
-        //       ^ tokenBeforeColon
-        //        ^ colon
-        const identifier = sourceCode.getFirstToken(objectTypeProperty);
+        // tokenBeforeColon can be identifier, or a ? token if is optional
         const tokenBeforeColon = sourceCode.getFirstToken(objectTypeProperty, objectTypeProperty.optional ? 1 : 0);
         const colon = sourceCode.getFirstToken(objectTypeProperty, objectTypeProperty.optional ? 2 : 1);
-
-        const name = identifier.value;
+        const name = getParameterName(objectTypeProperty, context);
 
         const spaceBefore = colon.start - tokenBeforeColon.end;
 
@@ -69,34 +66,10 @@ const objectTypePropertyEvaluator = (context) => {
     };
 };
 
-const classPropertyEvaluator = (context) => {
-    const always = context.options[0] === 'always';
-
-    const sourceCode = context.getSourceCode();
-
-    return (classProperty) => {
-        const parameterName = getParameterName(classProperty, context);
-        const typeAnnotation = _.get(classProperty, 'typeAnnotation') || _.get(classProperty, 'left.typeAnnotation');
-
-        if (typeAnnotation) {
-            const tokenBeforeType = sourceCode.getTokenBefore(typeAnnotation, classProperty.optional ? 1 : 0);
-            const spaceBefore = typeAnnotation.start - tokenBeforeType.end - (classProperty.optional ? 1 : 0);
-
-            if (always && spaceBefore > 1) {
-                context.report(classProperty, 'There must be 1 space before "' + parameterName + '" class property type annotation colon.');
-            } else if (always && spaceBefore === 0) {
-                context.report(classProperty, 'There must be a space before "' + parameterName + '" class property type annotation colon.');
-            } else if (!always && spaceBefore > 0) {
-                context.report(classProperty, 'There must be no space before "' + parameterName + '" class property type annotation colon.');
-            }
-        }
-    };
-};
-
 export default (context) => {
     return {
         ...functionEvaluators(context),
-        ObjectTypeProperty: objectTypePropertyEvaluator(context),
-        ClassProperty: classPropertyEvaluator(context)
+        ClassProperty: propertyEvaluator(context, 'class property'),
+        ObjectTypeProperty: objectTypePropertyEvaluator(context)
     };
 };

--- a/src/rules/spaceBeforeTypeColon.js
+++ b/src/rules/spaceBeforeTypeColon.js
@@ -4,7 +4,7 @@ import {
     iterateFunctionNodes
 } from './../utilities';
 
-export default iterateFunctionNodes((context) => {
+const functionEvaluators = iterateFunctionNodes((context) => {
     const always = context.options[0] === 'always';
 
     const sourceCode = context.getSourceCode();
@@ -15,6 +15,13 @@ export default iterateFunctionNodes((context) => {
             const typeAnnotation = _.get(identifierNode, 'typeAnnotation') || _.get(identifierNode, 'left.typeAnnotation');
 
             if (typeAnnotation) {
+                // usually the identifierNode, but can be the closing } of a destructuring
+                // so foo: string
+                //    ^^^ tokenBeforeType
+                //       ^^^^^^^^ typeAnnotation
+                // so { bar }: Object
+                //    ^^^^^^^ tokenBeforeType
+                //           ^^^^^^^^ typeAnnotation
                 const tokenBeforeType = sourceCode.getTokenBefore(typeAnnotation, identifierNode.optional ? 1 : 0);
                 const spaceBefore = typeAnnotation.start - tokenBeforeType.end - (identifierNode.optional ? 1 : 0);
 
@@ -29,3 +36,42 @@ export default iterateFunctionNodes((context) => {
         });
     };
 });
+
+const objectTypePropertyEvaluator = (context) => {
+    const always = context.options[0] === 'always';
+
+    const sourceCode = context.getSourceCode();
+
+    return (objectTypeProperty) => {
+        // so foo: string
+        //    ^^^ identifier
+        //    ^^^ tokenBeforeColon
+        //       ^ colon
+        // so foo?: string
+        //    ^^^ identifier
+        //       ^ tokenBeforeColon
+        //        ^ colon
+        const identifier = sourceCode.getFirstToken(objectTypeProperty);
+        const tokenBeforeColon = sourceCode.getFirstToken(objectTypeProperty, objectTypeProperty.optional ? 1 : 0);
+        const colon = sourceCode.getFirstToken(objectTypeProperty, objectTypeProperty.optional ? 2 : 1);
+
+        const name = identifier.value;
+
+        const spaceBefore = colon.start - tokenBeforeColon.end;
+
+        if (always && spaceBefore > 1) {
+            context.report(objectTypeProperty, 'There must be 1 space before "' + name + '" type annotation colon.');
+        } else if (always && spaceBefore === 0) {
+            context.report(objectTypeProperty, 'There must be a space before "' + name + '" type annotation colon.');
+        } else if (!always && spaceBefore > 0) {
+            context.report(objectTypeProperty, 'There must be no space before "' + name + '" type annotation colon.');
+        }
+    };
+};
+
+export default (context) => {
+    return {
+        ...functionEvaluators(context),
+        ObjectTypeProperty: objectTypePropertyEvaluator(context)
+    };
+};

--- a/src/utilities/getParameterName.js
+++ b/src/utilities/getParameterName.js
@@ -17,6 +17,10 @@ export default (identifierNode, context) => {
         return identifierNode.argument.name;
     }
 
+    if (identifierNode.type === 'ObjectTypeProperty') {
+        return context.getSourceCode().getFirstToken(identifierNode).value;
+    }
+
     if (identifierNode.type === 'ObjectPattern' || identifierNode.type === 'ArrayPattern') {
         return context.getSourceCode().getText(identifierNode);
     }

--- a/src/utilities/getParameterName.js
+++ b/src/utilities/getParameterName.js
@@ -9,6 +9,10 @@ export default (identifierNode, context) => {
         return identifierNode.left.name;
     }
 
+    if (_.has(identifierNode, 'key.name')) {
+        return identifierNode.key.name;
+    }
+
     if (identifierNode.type === 'RestElement') {
         return identifierNode.argument.name;
     }

--- a/tests/rules/assertions/requireReturnType.js
+++ b/tests/rules/assertions/requireReturnType.js
@@ -439,8 +439,8 @@ export default {
             options: [
                 'always',
                 {
-                    excludeArrowFunctions: true,
-                    annotateUndefined: 'always'
+                    annotateUndefined: 'always',
+                    excludeArrowFunctions: true
                 }
             ]
         },
@@ -449,8 +449,8 @@ export default {
             options: [
                 'always',
                 {
-                    excludeArrowFunctions: true,
-                    annotateUndefined: 'always'
+                    annotateUndefined: 'always',
+                    excludeArrowFunctions: true
                 }
             ]
         },

--- a/tests/rules/assertions/spaceAfterTypeColon.js
+++ b/tests/rules/assertions/spaceAfterTypeColon.js
@@ -272,6 +272,44 @@ export default {
                     message: 'There must be 1 space after "foo" type annotation colon.'
                 }
             ]
+        },
+        {
+            code: 'class X { foo:string }',
+            errors: [
+                {
+                    message: 'There must be a space after "foo" class property type annotation colon.'
+                }
+            ]
+        },
+        {
+            code: 'class X { foo: string }',
+            errors: [
+                {
+                    message: 'There must be no space after "foo" class property type annotation colon.'
+                }
+            ],
+            options: [
+                'never'
+            ]
+        },
+        {
+            code: 'class X { foo:?string }',
+            errors: [
+                {
+                    message: 'There must be a space after "foo" class property type annotation colon.'
+                }
+            ]
+        },
+        {
+            code: 'class X { foo: ?string }',
+            errors: [
+                {
+                    message: 'There must be no space after "foo" class property type annotation colon.'
+                }
+            ],
+            options: [
+                'never'
+            ]
         }
     ],
     valid: [
@@ -427,6 +465,30 @@ export default {
         },
         {
             code: 'type X = { foo?:?string }',
+            options: [
+                'never'
+            ]
+        },
+        {
+            code: 'class Foo { bar }'
+        },
+        {
+            code: 'class Foo { bar = 3 }'
+        },
+        {
+            code: 'class Foo { bar: string }'
+        },
+        {
+            code: 'class Foo { bar: ?string }'
+        },
+        {
+            code: 'class Foo { bar:string }',
+            options: [
+                'never'
+            ]
+        },
+        {
+            code: 'class Foo { bar:?string }',
             options: [
                 'never'
             ]

--- a/tests/rules/assertions/spaceAfterTypeColon.js
+++ b/tests/rules/assertions/spaceAfterTypeColon.js
@@ -199,6 +199,79 @@ export default {
                     message: 'There must be a space after "[ a, b ]" parameter type annotation colon.'
                 }
             ]
+        },
+        {
+            code: 'type X = { foo:string }',
+            errors: [
+                {
+                    message: 'There must be a space after "foo" type annotation colon.'
+                }
+            ]
+        },
+        {
+            code: 'type X = { foo:string }',
+            errors: [
+                {
+                    message: 'There must be a space after "foo" type annotation colon.'
+                }
+            ],
+            options: [
+                'always'
+            ]
+        },
+        {
+            code: 'type X = { foo: string }',
+            errors: [
+                {
+                    message: 'There must be no space after "foo" type annotation colon.'
+                }
+            ],
+            options: [
+                'never'
+            ]
+        },
+        {
+            code: 'type X = { foo:  string }',
+            errors: [
+                {
+                    message: 'There must be 1 space after "foo" type annotation colon.'
+                }
+            ]
+        },
+        {
+            code: 'type X = { foo?:string }',
+            errors: [
+                {
+                    message: 'There must be a space after "foo" type annotation colon.'
+                }
+            ]
+        },
+        {
+            code: 'type X = { foo?: string }',
+            errors: [
+                {
+                    message: 'There must be no space after "foo" type annotation colon.'
+                }
+            ],
+            options: [
+                'never'
+            ]
+        },
+        {
+            code: 'type X = { foo?:?string }',
+            errors: [
+                {
+                    message: 'There must be a space after "foo" type annotation colon.'
+                }
+            ]
+        },
+        {
+            code: 'type X = { foo?:  ?string }',
+            errors: [
+                {
+                    message: 'There must be 1 space after "foo" type annotation colon.'
+                }
+            ]
         }
     ],
     valid: [
@@ -329,13 +402,34 @@ export default {
             code: '(): { a: number, b: string } => {}'
         },
         {
-            code: '() :{ a: number, b: string } => {}',
+            code: '() :{ a:number, b:string } => {}',
             options: [
                 'never'
             ]
         },
         {
             code: '([ a, b ]: string[]) => {}'
+        },
+        {
+            code: 'type X = { foo: string }'
+        },
+        {
+            code: 'type X = { foo:string }',
+            options: [
+                'never'
+            ]
+        },
+        {
+            code: 'type X = { foo?: string }'
+        },
+        {
+            code: 'type X = { foo?: ?string }'
+        },
+        {
+            code: 'type X = { foo?:?string }',
+            options: [
+                'never'
+            ]
         }
     ]
 };

--- a/tests/rules/assertions/spaceBeforeTypeColon.js
+++ b/tests/rules/assertions/spaceBeforeTypeColon.js
@@ -164,6 +164,88 @@ export default {
                     message: 'There must be no space before "[ a, b ]" parameter type annotation colon.'
                 }
             ]
+        },
+        {
+            code: 'type X = { foo : string }',
+            errors: [
+                {
+                    message: 'There must be no space before "foo" type annotation colon.'
+                }
+            ]
+        },
+        {
+            code: 'type X = { foo : string }',
+            errors: [
+                {
+                    message: 'There must be no space before "foo" type annotation colon.'
+                }
+            ],
+            options: [
+                'never'
+            ]
+        },
+        {
+            code: 'type X = { foo: string }',
+            errors: [
+                {
+                    message: 'There must be a space before "foo" type annotation colon.'
+                }
+            ],
+            options: [
+                'always'
+            ]
+        },
+        {
+            code: 'type X = { foo  : string }',
+            errors: [
+                {
+                    message: 'There must be 1 space before "foo" type annotation colon.'
+                }
+            ],
+            options: [
+                'always'
+            ]
+        },
+        {
+            code: 'type X = { foo? : string }',
+            errors: [
+                {
+                    message: 'There must be no space before "foo" type annotation colon.'
+                }
+            ]
+        },
+        {
+            code: 'type X = { foo?: string }',
+            errors: [
+                {
+                    message: 'There must be a space before "foo" type annotation colon.'
+                }
+            ],
+            options: [
+                'always'
+            ]
+        },
+        {
+            code: 'type X = { foo?  : string }',
+            errors: [
+                {
+                    message: 'There must be 1 space before "foo" type annotation colon.'
+                }
+            ],
+            options: [
+                'always'
+            ]
+        },
+        {
+            code: 'type X = { foo   ?: string }',
+            errors: [
+                {
+                    message: 'There must be a space before "foo" type annotation colon.'
+                }
+            ],
+            options: [
+                'always'
+            ]
         }
     ],
     valid: [
@@ -240,13 +322,31 @@ export default {
             code: '(): { a: number, b: string } => {}'
         },
         {
-            code: '() : { a: number, b: string } => {}',
+            code: '() : { a : number, b : string } => {}',
             options: [
                 'always'
             ]
         },
         {
             code: '([ a, b ]: string[]) => {}'
+        },
+        {
+            code: 'type X = { foo: string }'
+        },
+        {
+            code: 'type X = { foo : string }',
+            options: [
+                'always'
+            ]
+        },
+        {
+            code: 'type X = { foo?: string }'
+        },
+        {
+            code: 'type X = { foo? : string }',
+            options: [
+                'always'
+            ]
         }
     ]
 };

--- a/tests/rules/assertions/spaceBeforeTypeColon.js
+++ b/tests/rules/assertions/spaceBeforeTypeColon.js
@@ -246,6 +246,44 @@ export default {
             options: [
                 'always'
             ]
+        },
+        {
+            code: 'class X { foo :string }',
+            errors: [
+                {
+                    message: 'There must be no space before "foo" class property type annotation colon.'
+                }
+            ]
+        },
+        {
+            code: 'class X { foo: string }',
+            errors: [
+                {
+                    message: 'There must be a space before "foo" class property type annotation colon.'
+                }
+            ],
+            options: [
+                'always'
+            ]
+        },
+        {
+            code: 'class X { foo :?string }',
+            errors: [
+                {
+                    message: 'There must be no space before "foo" class property type annotation colon.'
+                }
+            ]
+        },
+        {
+            code: 'class X { foo: ?string }',
+            errors: [
+                {
+                    message: 'There must be a space before "foo" class property type annotation colon.'
+                }
+            ],
+            options: [
+                'always'
+            ]
         }
     ],
     valid: [
@@ -344,6 +382,27 @@ export default {
         },
         {
             code: 'type X = { foo? : string }',
+            options: [
+                'always'
+            ]
+        },
+        {
+            code: 'class Foo { bar }'
+        },
+        {
+            code: 'class Foo { bar = 3 }'
+        },
+        {
+            code: 'class Foo { bar: string }'
+        },
+        {
+            code: 'class Foo { bar: ?string }'
+        },
+        {
+            code: 'class Foo { bar:?string }'
+        },
+        {
+            code: 'class Foo { bar : string }',
             options: [
                 'always'
             ]


### PR DESCRIPTION
Extends the existing `spaceAfterTypeColon` and `spaceBeforeTypeColon` rules to apply to type objects, and also to class properties like:

```js
type Foo = { name: string }

const x: { name: string } = { name: 'Dan' }

class Foo { name: ?string }
```

Probably best to view the [first three commits](https://github.com/gajus/eslint-plugin-flowtype/compare/8a96d6a...abf05b43f896106ade14dcadc9a7b71f7f1e8c21) and then the [final commit](https://github.com/gajus/eslint-plugin-flowtype/commit/23f19989bb0946dc332e12a134b96c0998db5ad8) separately. The final commit refactors the result of the previous commits to share code between the function param evaluator and class property evaluator. [Final source](https://github.com/gajus/eslint-plugin-flowtype/blob/23f19989bb0946dc332e12a134b96c0998db5ad8/src/rules/spaceAfterTypeColon.js).