### PR TITLE
Proposal: Rename expressionsOnly option to conciseOnly?

### DIFF
--- a/.README/rules/require-parameter-type.md
+++ b/.README/rules/require-parameter-type.md
@@ -6,7 +6,7 @@ Requires that all function parameters have type annotations.
 
 You can skip all arrow functions by providing the `excludeArrowFunctions` option with `true`.
 
-Alternatively, you can want to exclude only function expressions (e.g. `x => x * 2`). Provide `excludeArrowFunctions` with `expressionsOnly` for this. 
+Alternatively, you can want to exclude only concise arrow functions (e.g. `x => x * 2`). Provide `excludeArrowFunctions` with `conciseOnly` for this.
 
 ```js
 {
@@ -25,7 +25,7 @@ Alternatively, you can want to exclude only function expressions (e.g. `x => x *
         "flowtype/require-parameter-type": [
             2,
             {
-              "excludeArrowFunctions": "expressionsOnly"
+              "excludeArrowFunctions": "conciseOnly"
             }
         ]
     }

--- a/.README/rules/require-return-type.md
+++ b/.README/rules/require-return-type.md
@@ -6,7 +6,7 @@ Requires that functions have return type annotation.
 
 You can skip all arrow functions by providing the `excludeArrowFunctions` option with `true`.
 
-Alternatively, you can want to exclude only function expressions (e.g. `() => 2`). Provide `excludeArrowFunctions` with `expressionsOnly` for this. 
+Alternatively, you can want to exclude only concise arrow functions (e.g. `() => 2`). Provide `excludeArrowFunctions` with `conciseOnly` for this.
 
 ```js
 {
@@ -27,7 +27,7 @@ Alternatively, you can want to exclude only function expressions (e.g. `() => 2`
             2,
             "always",
             {
-              "excludeArrowFunctions": "expressionsOnly"
+              "excludeArrowFunctions": "conciseOnly"
             }
         ]
     }

--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ Requires that all function parameters have type annotations.
 
 You can skip all arrow functions by providing the `excludeArrowFunctions` option with `true`.
 
-Alternatively, you can want to exclude only function expressions (e.g. `x => x * 2`). Provide `excludeArrowFunctions` with `expressionsOnly` for this. 
+Alternatively, you can want to exclude only concise arrow functions (e.g. `x => x * 2`). Provide `excludeArrowFunctions` with `conciseOnly` for this.
 
 ```js
 {
@@ -249,7 +249,7 @@ Alternatively, you can want to exclude only function expressions (e.g. `x => x *
         "flowtype/require-parameter-type": [
             2,
             {
-              "excludeArrowFunctions": "expressionsOnly"
+              "excludeArrowFunctions": "conciseOnly"
             }
         ]
     }
@@ -288,11 +288,11 @@ function x(foo) {}
 (foo) => {}
 // Message: Missing "foo" parameter type annotation.
 
-// Options: [{"excludeArrowFunctions":"expressionsOnly"}]
+// Options: [{"excludeArrowFunctions":"conciseOnly"}]
 (foo) => {}
 // Message: Missing "foo" parameter type annotation.
 
-// Options: [{"excludeArrowFunctions":"expressionsOnly"}]
+// Options: [{"excludeArrowFunctions":"conciseOnly"}]
 function x(foo) {}
 // Message: Missing "foo" parameter type annotation.
 ```
@@ -315,7 +315,7 @@ The following patterns are not considered problems:
 // Options: [{"excludeArrowFunctions":true}]
 (foo) => {}
 
-// Options: [{"excludeArrowFunctions":"expressionsOnly"}]
+// Options: [{"excludeArrowFunctions":"conciseOnly"}]
 (foo) => 3
 ```
 
@@ -329,7 +329,7 @@ Requires that functions have return type annotation.
 
 You can skip all arrow functions by providing the `excludeArrowFunctions` option with `true`.
 
-Alternatively, you can want to exclude only function expressions (e.g. `() => 2`). Provide `excludeArrowFunctions` with `expressionsOnly` for this. 
+Alternatively, you can want to exclude only concise arrow functions (e.g. `() => 2`). Provide `excludeArrowFunctions` with `conciseOnly` for this.
 
 ```js
 {
@@ -350,7 +350,7 @@ Alternatively, you can want to exclude only function expressions (e.g. `() => 2`
             2,
             "always",
             {
-              "excludeArrowFunctions": "expressionsOnly"
+              "excludeArrowFunctions": "conciseOnly"
             }
         ]
     }
@@ -439,11 +439,11 @@ async () => { return; }
 function* x() {}
 // Message: Missing return type annotation.
 
-// Options: ["always",{"excludeArrowFunctions":"expressionsOnly"}]
+// Options: ["always",{"excludeArrowFunctions":"conciseOnly"}]
 () => { return 3; }
 // Message: Missing return type annotation.
 
-// Options: ["always",{"excludeArrowFunctions":"expressionsOnly"}]
+// Options: ["always",{"excludeArrowFunctions":"conciseOnly"}]
 async () => { return 4; }
 // Message: Missing return type annotation.
 ```
@@ -508,16 +508,16 @@ async (foo): Promise<number> => { return 3; }
 // Options: ["always",{"excludeArrowFunctions":true}]
 () => undefined
 
-// Options: ["always",{"excludeArrowFunctions":true,"annotateUndefined":"always"}]
+// Options: ["always",{"annotateUndefined":"always","excludeArrowFunctions":true}]
 () => undefined
 
-// Options: ["always",{"excludeArrowFunctions":true,"annotateUndefined":"always"}]
+// Options: ["always",{"annotateUndefined":"always","excludeArrowFunctions":true}]
 () => { return undefined; }
 
-// Options: ["always",{"excludeArrowFunctions":"expressionsOnly"}]
+// Options: ["always",{"excludeArrowFunctions":"conciseOnly"}]
 () => 3
 
-// Options: ["always",{"excludeArrowFunctions":"expressionsOnly"}]
+// Options: ["always",{"excludeArrowFunctions":"conciseOnly"}]
 async () => 3
 ```
 

--- a/bin/readmeAssertions.js
+++ b/bin/readmeAssertions.js
@@ -28,6 +28,10 @@ const formatCodeSnippet = (setup) => {
     return paragraphs.join('\n');
 };
 
+const formatCodeSnippets = (snippets) => {
+    return snippets.filter((snippet) => !snippet.deprecated).map(formatCodeSnippet);
+};
+
 const getAssertions = () => {
     const assertionFiles = glob.sync(path.resolve(__dirname, './../tests/rules/assertions/*.js'));
 
@@ -39,8 +43,8 @@ const getAssertions = () => {
         const codes = require(filePath);
 
         return {
-            valid: _.map(codes.valid, formatCodeSnippet),
-            invalid: _.map(codes.invalid, formatCodeSnippet)
+            valid: formatCodeSnippets(codes.valid),
+            invalid: formatCodeSnippets(codes.invalid)
         };
     });
 

--- a/src/rules/requireParameterType.js
+++ b/src/rules/requireParameterType.js
@@ -5,6 +5,10 @@ import {
     iterateFunctionNodes
 } from './../utilities';
 
+const skipConciseArrows = (skipArrowsOption) => {
+    return ['expressionsOnly', 'conciseOnly'].indexOf(skipArrowsOption) !== -1;
+};
+
 export default iterateFunctionNodes((context) => {
     const checkThisFile = !_.get(context, 'settings.flowtype.onlyFilesWithFlowAnnotation') || isFlowFile(context);
 
@@ -20,9 +24,9 @@ export default iterateFunctionNodes((context) => {
             const typeAnnotation = _.get(identifierNode, 'typeAnnotation') || _.get(identifierNode, 'left.typeAnnotation');
 
             const isArrow = functionNode.type === 'ArrowFunctionExpression';
-            const isArrowFunctionExpression = functionNode.expression;
+            const isArrowFunctionExpression = isArrow && functionNode.expression;
 
-            if (skipArrows === 'expressionsOnly' && isArrowFunctionExpression || skipArrows === true && isArrow) {
+            if (skipConciseArrows(skipArrows) && isArrowFunctionExpression || skipArrows === true && isArrow) {
                 return;
             }
 

--- a/src/rules/requireReturnType.js
+++ b/src/rules/requireReturnType.js
@@ -3,6 +3,10 @@ import {
     isFlowFile
 } from './../utilities';
 
+const skipConciseArrows = (skipArrowsOption) => {
+    return ['expressionsOnly', 'conciseOnly'].indexOf(skipArrowsOption) !== -1;
+};
+
 export default (context) => {
     const checkThisFile = !_.get(context, 'settings.flowtype.onlyFilesWithFlowAnnotation') || isFlowFile(context);
 
@@ -41,12 +45,12 @@ export default (context) => {
         }
 
         const isArrow = functionNode.type === 'ArrowFunctionExpression';
-        const isArrowFunctionExpression = functionNode.expression;
+        const isArrowFunctionExpression = isArrow && functionNode.expression;
         const hasImplicitReturnType = functionNode.async || functionNode.generator;
         const isFunctionReturnUndefined = !isArrowFunctionExpression && !hasImplicitReturnType && (!targetNode.returnStatementNode || isUndefinedReturnType(targetNode.returnStatementNode));
         const isReturnTypeAnnotationUndefined = getIsReturnTypeAnnotationUndefined(targetNode);
 
-        if (skipArrows === 'expressionsOnly' && isArrowFunctionExpression || skipArrows === true && isArrow) {
+        if (skipConciseArrows(skipArrows) && isArrowFunctionExpression || skipArrows === true && isArrow) {
             return;
         }
 

--- a/tests/rules/assertions/requireParameterType.js
+++ b/tests/rules/assertions/requireParameterType.js
@@ -84,6 +84,7 @@ export default {
         },
         {
             code: '(foo) => {}',
+            deprecated: true,
             errors: [
                 {
                     message: 'Missing "foo" parameter type annotation.'
@@ -97,6 +98,7 @@ export default {
         },
         {
             code: 'function x(foo) {}',
+            deprecated: true,
             errors: [
                 {
                     message: 'Missing "foo" parameter type annotation.'
@@ -105,6 +107,32 @@ export default {
             options: [
                 {
                     excludeArrowFunctions: 'expressionsOnly'
+                }
+            ]
+        },
+        {
+            code: '(foo) => {}',
+            errors: [
+                {
+                    message: 'Missing "foo" parameter type annotation.'
+                }
+            ],
+            options: [
+                {
+                    excludeArrowFunctions: 'conciseOnly'
+                }
+            ]
+        },
+        {
+            code: 'function x(foo) {}',
+            errors: [
+                {
+                    message: 'Missing "foo" parameter type annotation.'
+                }
+            ],
+            options: [
+                {
+                    excludeArrowFunctions: 'conciseOnly'
                 }
             ]
         }
@@ -143,9 +171,18 @@ export default {
         },
         {
             code: '(foo) => 3',
+            deprecated: true,
             options: [
                 {
                     excludeArrowFunctions: 'expressionsOnly'
+                }
+            ]
+        },
+        {
+            code: '(foo) => 3',
+            options: [
+                {
+                    excludeArrowFunctions: 'conciseOnly'
                 }
             ]
         }

--- a/tests/rules/assertions/requireReturnType.js
+++ b/tests/rules/assertions/requireReturnType.js
@@ -249,6 +249,7 @@ export default {
         },
         {
             code: '() => { return 3; }',
+            deprecated: true,
             errors: [
                 {
                     message: 'Missing return type annotation.'
@@ -263,6 +264,7 @@ export default {
         },
         {
             code: 'async () => { return 4; }',
+            deprecated: true,
             errors: [
                 {
                     message: 'Missing return type annotation.'
@@ -272,6 +274,34 @@ export default {
                 'always',
                 {
                     excludeArrowFunctions: 'expressionsOnly'
+                }
+            ]
+        },
+        {
+            code: '() => { return 3; }',
+            errors: [
+                {
+                    message: 'Missing return type annotation.'
+                }
+            ],
+            options: [
+                'always',
+                {
+                    excludeArrowFunctions: 'conciseOnly'
+                }
+            ]
+        },
+        {
+            code: 'async () => { return 4; }',
+            errors: [
+                {
+                    message: 'Missing return type annotation.'
+                }
+            ],
+            options: [
+                'always',
+                {
+                    excludeArrowFunctions: 'conciseOnly'
                 }
             ]
         }
@@ -456,6 +486,7 @@ export default {
         },
         {
             code: '() => 3',
+            deprecated: true,
             options: [
                 'always',
                 {
@@ -465,10 +496,29 @@ export default {
         },
         {
             code: 'async () => 3',
+            deprecated: true,
             options: [
                 'always',
                 {
                     excludeArrowFunctions: 'expressionsOnly'
+                }
+            ]
+        },
+        {
+            code: '() => 3',
+            options: [
+                'always',
+                {
+                    excludeArrowFunctions: 'conciseOnly'
+                }
+            ]
+        },
+        {
+            code: 'async () => 3',
+            options: [
+                'always',
+                {
+                    excludeArrowFunctions: 'conciseOnly'
                 }
             ]
         }


### PR DESCRIPTION
See: https://github.com/gajus/eslint-plugin-flowtype/issues/3#issuecomment-239321316

The option's a little confusing as I meant it to mean "an arrow function with an expression as the body", but it's easily misunderstood as "a function expression" (although it is under the `excludeArrowFunctions` option).

I chose "concise" as that's what MDN refers to them as:

> [Arrow functions can have either a "concise body" or the usual "block body".](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Functions/Arrow_functions#Function_body)
https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Functions/Arrow_functions#Function_body

