### PR TITLE
Class properties fail in getParameterName

### DIFF
--- a/src/utilities/getParameterName.js
+++ b/src/utilities/getParameterName.js
@@ -17,7 +17,7 @@ export default (identifierNode, context) => {
         return identifierNode.argument.name;
     }
 
-    if (identifierNode.type === 'ObjectTypeProperty' || identifierNode.type === 'FunctionTypeParam') {
+    if (identifierNode.type === 'ObjectTypeProperty' || identifierNode.type === 'FunctionTypeParam' || identifierNode.type === 'ClassProperty') {
         return context.getSourceCode().getFirstToken(identifierNode).value;
     }
 


### PR DESCRIPTION
For some reason when I updated to the latest version, I started seeing the exception getting thrown in this file.  I have a class like this:

```
type State = {bar: string};
class Foo {
  state: State;
}
```
That was failing