### PR TITLE
Handle unknown syntax

### DIFF
--- a/src/utilities/getParameterName.js
+++ b/src/utilities/getParameterName.js
@@ -24,7 +24,7 @@ export default (identifierNode, context) => {
     if (identifierNode.type === 'ObjectPattern' || identifierNode.type === 'ArrayPattern') {
         return context.getSourceCode().getText(identifierNode);
     }
-    if (_.get(identifierNode, 'left.type') === 'ObjectPattern' && _.get(identifierNode, 'right.type') === 'ObjectExpression') {
+    if (_.get(identifierNode, 'left.type') === 'ObjectPattern') {
         return context.getSourceCode().getText(identifierNode.left);
     }
 

--- a/tests/rules/assertions/spaceBeforeTypeColon.js
+++ b/tests/rules/assertions/spaceBeforeTypeColon.js
@@ -459,6 +459,9 @@ export default {
             ]
         },
         {
+            code: 'class X { foo({ bar }: Props = this.props) {} }'
+        },
+        {
             code: 'class Foo { constructor(foo: string ) {} }'
         },
         {


### PR DESCRIPTION
We just encountered an error where the rule was throwing on non-Flow file because it didn't understand how to display a name for it (as it works that out before it evaluates the code)

two changes:

1. added support for destructuring where the right-side is a "MemberExpression": `class X { foo({ bar }: Props = this.props) {} }`
2. don't throw when we can't evaluate a name for the parameter, just provide "Unknown signature" as the name