### PR TITLE
Fix tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -665,7 +665,7 @@ function foo (foo:string) {}
 // Message: There must be 1 space after return type colon.
 
 async function foo({ lorem, ipsum, dolor }:SomeType) {}
-// Message: There must be a space after "{ lorem, ipsum, dolor }:SomeType" parameter type annotation colon.
+// Message: There must be a space after "{ lorem, ipsum, dolor }" parameter type annotation colon.
 
 ({ lorem, ipsum, dolor } :   SomeType) => {}
 // Message: There must be 1 space after "{ lorem, ipsum, dolor }" parameter type annotation colon.
@@ -956,7 +956,7 @@ class Foo { constructor(foo: string ) {} }
 // Message: There must be a space before "foo" parameter type annotation colon.
 
 async function foo({ lorem, ipsum, dolor } : SomeType) {}
-// Message: There must be no space before "{ lorem, ipsum, dolor } : SomeType" parameter type annotation colon.
+// Message: There must be no space before "{ lorem, ipsum, dolor }" parameter type annotation colon.
 
 ({ lorem, ipsum, dolor } : SomeType) => {}
 // Message: There must be no space before "{ lorem, ipsum, dolor }" parameter type annotation colon.
@@ -1102,6 +1102,8 @@ var x = function (foo: string) {}
 
 // Options: ["always"]
 var x = function (foo : string) {}
+
+class X { foo({ bar }: Props = this.props) {} }
 
 class Foo { constructor(foo: string ) {} }
 

--- a/src/utilities/getParameterName.js
+++ b/src/utilities/getParameterName.js
@@ -26,7 +26,13 @@ export default (identifierNode, context) => {
     }
 
     if (identifierNode.type === 'ObjectPattern' || identifierNode.type === 'ArrayPattern') {
-        return context.getSourceCode().getText(identifierNode);
+        const text = context.getSourceCode().getText(identifierNode);
+
+        if (identifierNode.typeAnnotation) {
+            return text.replace(context.getSourceCode().getText(identifierNode.typeAnnotation), '').trim();
+        } else {
+            return text;
+        }
     }
     if (_.get(identifierNode, 'left.type') === 'ObjectPattern') {
         return context.getSourceCode().getText(identifierNode.left);

--- a/tests/rules/assertions/spaceAfterTypeColon.js
+++ b/tests/rules/assertions/spaceAfterTypeColon.js
@@ -177,7 +177,7 @@ export default {
             code: 'async function foo({ lorem, ipsum, dolor }:SomeType) {}',
             errors: [
                 {
-                    message: 'There must be a space after "{ lorem, ipsum, dolor }:SomeType" parameter type annotation colon.'
+                    message: 'There must be a space after "{ lorem, ipsum, dolor }" parameter type annotation colon.'
                 }
             ],
             output: 'async function foo({ lorem, ipsum, dolor }: SomeType) {}'
@@ -186,8 +186,6 @@ export default {
             code: '({ lorem, ipsum, dolor } :   SomeType) => {}',
             errors: [
                 {
-                    // NOTE: this message is different because of a Babylon parser bug with arrow functions
-                    // where the param ranges don't include the type annotation like other functions do
                     message: 'There must be 1 space after "{ lorem, ipsum, dolor }" parameter type annotation colon.'
                 }
             ],

--- a/tests/rules/assertions/spaceBeforeTypeColon.js
+++ b/tests/rules/assertions/spaceBeforeTypeColon.js
@@ -151,7 +151,7 @@ export default {
             code: 'async function foo({ lorem, ipsum, dolor } : SomeType) {}',
             errors: [
                 {
-                    message: 'There must be no space before "{ lorem, ipsum, dolor } : SomeType" parameter type annotation colon.'
+                    message: 'There must be no space before "{ lorem, ipsum, dolor }" parameter type annotation colon.'
                 }
             ],
             output: 'async function foo({ lorem, ipsum, dolor }: SomeType) {}'
@@ -160,8 +160,6 @@ export default {
             code: '({ lorem, ipsum, dolor } : SomeType) => {}',
             errors: [
                 {
-                    // NOTE: this message is different because of a Babylon parser bug with arrow functions
-                    // where the param ranges don't include the type annotation like other functions do
                     message: 'There must be no space before "{ lorem, ipsum, dolor }" parameter type annotation colon.'
                 }
             ],


### PR DESCRIPTION
Background:

So today a [bug in Babylon was fixed](https://github.com/babel/babylon/pull/57). Previously, the locations on function params included the type annotation, but arrow functions didn't. (which was the cause of #47)

This meant that the `getParameterName` output for an arrow-function param would be `{ lorem, ipsum, dolor }`, and normal function params would be `{ lorem, ipsum, dolor }: SomeType` (includes the type annotation).

Now, we can either update the tests so arrow functions standardise with normal functions (`{ lorem, ipsum, dolor }: SomeType`) or update the code to have the cleaner output that we previously had for arrows, but for all functions types: `{ lorem, ipsum, dolor }`

---

I'd say it's a little hacky, basically getting the source for the entire param, and stripping out the source of the type annotation.