### PR TITLE
"Unknown function signature" in messages

### DIFF
--- a/src/rules/requireParameterType.js
+++ b/src/rules/requireParameterType.js
@@ -2,7 +2,8 @@ import _ from 'lodash';
 import {
     getParameterName,
     isFlowFile,
-    iterateFunctionNodes
+    iterateFunctionNodes,
+    quoteName
 } from './../utilities';
 
 export default iterateFunctionNodes((context) => {
@@ -28,9 +29,9 @@ export default iterateFunctionNodes((context) => {
             if (!typeAnnotation) {
                 context.report({
                     data: {
-                        name: getParameterName(identifierNode, context)
+                        name: quoteName(getParameterName(identifierNode, context))
                     },
-                    message: 'Missing "{{name}}" parameter type annotation.',
+                    message: 'Missing {{name}}parameter type annotation.',
                     node: identifierNode
                 });
             }

--- a/src/rules/requireParameterType.js
+++ b/src/rules/requireParameterType.js
@@ -16,7 +16,6 @@ export default iterateFunctionNodes((context) => {
 
     return (functionNode) => {
         _.forEach(functionNode.params, (identifierNode) => {
-            const parameterName = getParameterName(identifierNode, context);
             const typeAnnotation = _.get(identifierNode, 'typeAnnotation') || _.get(identifierNode, 'left.typeAnnotation');
 
             const isArrow = functionNode.type === 'ArrowFunctionExpression';
@@ -27,7 +26,13 @@ export default iterateFunctionNodes((context) => {
             }
 
             if (!typeAnnotation) {
-                context.report(identifierNode, 'Missing "' + parameterName + '" parameter type annotation.');
+                context.report({
+                    data: {
+                        name: getParameterName(identifierNode, context)
+                    },
+                    message: 'Missing "{{name}}" parameter type annotation.',
+                    node: identifierNode
+                });
             }
         });
     };

--- a/src/rules/spaceAfterTypeColon.js
+++ b/src/rules/spaceAfterTypeColon.js
@@ -2,7 +2,8 @@ import _ from 'lodash';
 import {
     getParameterName,
     iterateFunctionNodes,
-    spacingFixers
+    spacingFixers,
+    quoteName
 } from './../utilities';
 
 const parseOptions = (context) => {
@@ -41,7 +42,7 @@ const propertyEvaluator = (context, typeForMessage) => {
             const {colon, spaceAfter} = getSpacesAfterColon(node, typeAnnotation);
 
             const data = {
-                name: getParameterName(node, context),
+                name: quoteName(getParameterName(node, context)),
                 type: typeForMessage
             };
 
@@ -49,21 +50,21 @@ const propertyEvaluator = (context, typeForMessage) => {
                 context.report({
                     data,
                     fix: spacingFixers.stripSpacesAfter(colon, spaceAfter - 1),
-                    message: 'There must be 1 space after "{{name}}" {{type}} type annotation colon.',
+                    message: 'There must be 1 space after {{name}}{{type}} type annotation colon.',
                     node
                 });
             } else if (always && spaceAfter === 0) {
                 context.report({
                     data,
                     fix: spacingFixers.addSpaceAfter(colon),
-                    message: 'There must be a space after "{{name}}" {{type}} type annotation colon.',
+                    message: 'There must be a space after {{name}}{{type}} type annotation colon.',
                     node
                 });
             } else if (!always && spaceAfter > 0) {
                 context.report({
                     data,
                     fix: spacingFixers.stripSpacesAfter(colon, spaceAfter),
-                    message: 'There must be no space after "{{name}}" {{type}} type annotation colon.',
+                    message: 'There must be no space after {{name}}{{type}} type annotation colon.',
                     node
                 });
             }
@@ -137,28 +138,28 @@ const objectTypePropertyEvaluator = (context) => {
         const spaces = typeAnnotation.start - colon.end;
 
         const data = {
-            name: getParameterName(objectTypeProperty, context)
+            name: quoteName(getParameterName(objectTypeProperty, context))
         };
 
         if (always && spaces > 1) {
             context.report({
                 data,
                 fix: spacingFixers.stripSpacesAfter(colon, spaces - 1),
-                message: 'There must be 1 space after "{{name}}" type annotation colon.',
+                message: 'There must be 1 space after {{name}}type annotation colon.',
                 node: objectTypeProperty
             });
         } else if (always && spaces === 0) {
             context.report({
                 data,
                 fix: spacingFixers.addSpaceAfter(colon),
-                message: 'There must be a space after "{{name}}" type annotation colon.',
+                message: 'There must be a space after {{name}}type annotation colon.',
                 node: objectTypeProperty
             });
         } else if (!always && spaces > 0) {
             context.report({
                 data,
                 fix: spacingFixers.stripSpacesAfter(colon, spaces),
-                message: 'There must be no space after "{{name}}" type annotation colon.',
+                message: 'There must be no space after {{name}}type annotation colon.',
                 node: objectTypeProperty
             });
         }

--- a/src/rules/spaceAfterTypeColon.js
+++ b/src/rules/spaceAfterTypeColon.js
@@ -35,28 +35,35 @@ const propertyEvaluator = (context, typeForMessage) => {
     };
 
     return (node) => {
-        const parameterName = getParameterName(node, context);
         const typeAnnotation = _.get(node, 'typeAnnotation') || _.get(node, 'left.typeAnnotation');
 
         if (typeAnnotation) {
             const {colon, spaceAfter} = getSpacesAfterColon(node, typeAnnotation);
 
+            const data = {
+                name: getParameterName(node, context),
+                type: typeForMessage
+            };
+
             if (always && spaceAfter > 1) {
                 context.report({
+                    data,
                     fix: spacingFixers.stripSpacesAfter(colon, spaceAfter - 1),
-                    message: 'There must be 1 space after "' + parameterName + '" ' + typeForMessage + ' type annotation colon.',
+                    message: 'There must be 1 space after "{{name}}" {{type}} type annotation colon.',
                     node
                 });
             } else if (always && spaceAfter === 0) {
                 context.report({
+                    data,
                     fix: spacingFixers.addSpaceAfter(colon),
-                    message: 'There must be a space after "' + parameterName + '" ' + typeForMessage + ' type annotation colon.',
+                    message: 'There must be a space after "{{name}}" {{type}} type annotation colon.',
                     node
                 });
             } else if (!always && spaceAfter > 0) {
                 context.report({
+                    data,
                     fix: spacingFixers.stripSpacesAfter(colon, spaceAfter),
-                    message: 'There must be no space after "' + parameterName + '" ' + typeForMessage + ' type annotation colon.',
+                    message: 'There must be no space after "{{name}}" {{type}} type annotation colon.',
                     node
                 });
             }
@@ -126,26 +133,32 @@ const objectTypePropertyEvaluator = (context) => {
     return (objectTypeProperty) => {
         const colon = getColon(objectTypeProperty);
         const typeAnnotation = objectTypeProperty.value;
-        const name = getParameterName(objectTypeProperty, context);
 
         const spaces = typeAnnotation.start - colon.end;
 
+        const data = {
+            name: getParameterName(objectTypeProperty, context)
+        };
+
         if (always && spaces > 1) {
             context.report({
+                data,
                 fix: spacingFixers.stripSpacesAfter(colon, spaces - 1),
-                message: 'There must be 1 space after "' + name + '" type annotation colon.',
+                message: 'There must be 1 space after "{{name}}" type annotation colon.',
                 node: objectTypeProperty
             });
         } else if (always && spaces === 0) {
             context.report({
+                data,
                 fix: spacingFixers.addSpaceAfter(colon),
-                message: 'There must be a space after "' + name + '" type annotation colon.',
+                message: 'There must be a space after "{{name}}" type annotation colon.',
                 node: objectTypeProperty
             });
         } else if (!always && spaces > 0) {
             context.report({
+                data,
                 fix: spacingFixers.stripSpacesAfter(colon, spaces),
-                message: 'There must be no space after "' + name + '" type annotation colon.',
+                message: 'There must be no space after "{{name}}" type annotation colon.',
                 node: objectTypeProperty
             });
         }

--- a/src/rules/spaceBeforeTypeColon.js
+++ b/src/rules/spaceBeforeTypeColon.js
@@ -2,7 +2,8 @@ import _ from 'lodash';
 import {
     getParameterName,
     iterateFunctionNodes,
-    spacingFixers
+    spacingFixers,
+    quoteName
 } from './../utilities';
 
 const parseOptions = (context) => {
@@ -45,7 +46,7 @@ const propertyEvaluator = (context, typeForMessage) => {
             const {spaces, tokenBeforeType} = getSpacesBeforeColon(node, typeAnnotation);
 
             const data = {
-                name: getParameterName(node, context),
+                name: quoteName(getParameterName(node, context)),
                 type: typeForMessage
             };
 
@@ -53,21 +54,21 @@ const propertyEvaluator = (context, typeForMessage) => {
                 context.report({
                     data,
                     fix: spacingFixers.stripSpacesAfter(tokenBeforeType, spaces - 1),
-                    message: 'There must be 1 space before "{{name}}" {{type}} type annotation colon.',
+                    message: 'There must be 1 space before {{name}}{{type}} type annotation colon.',
                     node
                 });
             } else if (always && spaces === 0) {
                 context.report({
                     data,
                     fix: spacingFixers.addSpaceAfter(tokenBeforeType),
-                    message: 'There must be a space before "{{name}}" {{type}} type annotation colon.',
+                    message: 'There must be a space before {{name}}{{type}} type annotation colon.',
                     node
                 });
             } else if (!always && spaces > 0) {
                 context.report({
                     data,
                     fix: spacingFixers.stripSpacesAfter(tokenBeforeType, spaces),
-                    message: 'There must be no space before "{{name}}" {{type}} type annotation colon.',
+                    message: 'There must be no space before {{name}}{{type}} type annotation colon.',
                     node
                 });
             }
@@ -104,28 +105,28 @@ const objectTypePropertyEvaluator = (context) => {
         const spaces = colon.start - tokenBeforeColon.end;
 
         const data = {
-            name: getParameterName(objectTypeProperty, context)
+            name: quoteName(getParameterName(objectTypeProperty, context))
         };
 
         if (always && spaces > 1) {
             context.report({
                 data,
                 fix: spacingFixers.stripSpacesAfter(tokenBeforeColon, spaces - 1),
-                message: 'There must be 1 space before "{{name}}" type annotation colon.',
+                message: 'There must be 1 space before {{name}}type annotation colon.',
                 node: objectTypeProperty
             });
         } else if (always && spaces === 0) {
             context.report({
                 data,
                 fix: spacingFixers.addSpaceAfter(tokenBeforeColon),
-                message: 'There must be a space before "{{name}}" type annotation colon.',
+                message: 'There must be a space before {{name}}type annotation colon.',
                 node: objectTypeProperty
             });
         } else if (!always && spaces > 0) {
             context.report({
                 data,
                 fix: spacingFixers.stripSpacesAfter(tokenBeforeColon, spaces),
-                message: 'There must be no space before "{{name}}" type annotation colon.',
+                message: 'There must be no space before {{name}}type annotation colon.',
                 node: objectTypeProperty
             });
         }

--- a/src/rules/spaceBeforeTypeColon.js
+++ b/src/rules/spaceBeforeTypeColon.js
@@ -38,29 +38,36 @@ const propertyEvaluator = (context, typeForMessage) => {
     };
 
     return (node) => {
-        const parameterName = getParameterName(node, context);
         const typeAnnotation = _.get(node, 'typeAnnotation') || _.get(node, 'left.typeAnnotation');
 
         if (typeAnnotation) {
             // tokenBeforeType can be the identifier or the closing } token of a destructuring
             const {spaces, tokenBeforeType} = getSpacesBeforeColon(node, typeAnnotation);
 
+            const data = {
+                name: getParameterName(node, context),
+                type: typeForMessage
+            };
+
             if (always && spaces > 1) {
                 context.report({
+                    data,
                     fix: spacingFixers.stripSpacesAfter(tokenBeforeType, spaces - 1),
-                    message: 'There must be 1 space before "' + parameterName + '" ' + typeForMessage + ' type annotation colon.',
+                    message: 'There must be 1 space before "{{name}}" {{type}} type annotation colon.',
                     node
                 });
             } else if (always && spaces === 0) {
                 context.report({
+                    data,
                     fix: spacingFixers.addSpaceAfter(tokenBeforeType),
-                    message: 'There must be a space before "' + parameterName + '" ' + typeForMessage + ' type annotation colon.',
+                    message: 'There must be a space before "{{name}}" {{type}} type annotation colon.',
                     node
                 });
             } else if (!always && spaces > 0) {
                 context.report({
+                    data,
                     fix: spacingFixers.stripSpacesAfter(tokenBeforeType, spaces),
-                    message: 'There must be no space before "' + parameterName + '" ' + typeForMessage + ' type annotation colon.',
+                    message: 'There must be no space before "{{name}}" {{type}} type annotation colon.',
                     node
                 });
             }
@@ -94,26 +101,31 @@ const objectTypePropertyEvaluator = (context) => {
     return (objectTypeProperty) => {
         // tokenBeforeColon can be identifier, or a ? token if is optional
         const [tokenBeforeColon, colon] = getFirstTokens(objectTypeProperty);
-        const name = getParameterName(objectTypeProperty, context);
-
         const spaces = colon.start - tokenBeforeColon.end;
+
+        const data = {
+            name: getParameterName(objectTypeProperty, context)
+        };
 
         if (always && spaces > 1) {
             context.report({
+                data,
                 fix: spacingFixers.stripSpacesAfter(tokenBeforeColon, spaces - 1),
-                message: 'There must be 1 space before "' + name + '" type annotation colon.',
+                message: 'There must be 1 space before "{{name}}" type annotation colon.',
                 node: objectTypeProperty
             });
         } else if (always && spaces === 0) {
             context.report({
+                data,
                 fix: spacingFixers.addSpaceAfter(tokenBeforeColon),
-                message: 'There must be a space before "' + name + '" type annotation colon.',
+                message: 'There must be a space before "{{name}}" type annotation colon.',
                 node: objectTypeProperty
             });
         } else if (!always && spaces > 0) {
             context.report({
+                data,
                 fix: spacingFixers.stripSpacesAfter(tokenBeforeColon, spaces),
-                message: 'There must be no space before "' + name + '" type annotation colon.',
+                message: 'There must be no space before "{{name}}" type annotation colon.',
                 node: objectTypeProperty
             });
         }

--- a/src/rules/validSyntax.js
+++ b/src/rules/validSyntax.js
@@ -1,7 +1,8 @@
 import _ from 'lodash';
 import {
     getParameterName,
-    iterateFunctionNodes
+    iterateFunctionNodes,
+    quoteName
 } from './../utilities';
 
 export default iterateFunctionNodes((context) => {
@@ -15,9 +16,9 @@ export default iterateFunctionNodes((context) => {
             if (isAssignmentPattern && hasTypeAnnotation && !leftAnnotated) {
                 context.report({
                     data: {
-                        name: getParameterName(identifierNode, context)
+                        name: quoteName(getParameterName(identifierNode, context))
                     },
-                    message: '"{{name}}" parameter type annotation must be placed on left-hand side of assignment.',
+                    message: '{{name}}parameter type annotation must be placed on left-hand side of assignment.',
                     node: identifierNode
                 });
             }

--- a/src/rules/validSyntax.js
+++ b/src/rules/validSyntax.js
@@ -7,14 +7,19 @@ import {
 export default iterateFunctionNodes((context) => {
     return (functionNode) => {
         _.forEach(functionNode.params, (identifierNode) => {
-            const parameterName = getParameterName(identifierNode, context);
             const nodeType = _.get(identifierNode, 'type');
             const isAssignmentPattern = nodeType === 'AssignmentPattern';
             const hasTypeAnnotation = Boolean(_.get(identifierNode, 'typeAnnotation'));
             const leftAnnotated = Boolean(_.get(identifierNode, 'left.typeAnnotation'));
 
             if (isAssignmentPattern && hasTypeAnnotation && !leftAnnotated) {
-                context.report(identifierNode, '"' + parameterName + '" parameter type annotation must be placed on left-hand side of assignment.');
+                context.report({
+                    data: {
+                        name: getParameterName(identifierNode, context)
+                    },
+                    message: '"{{name}}" parameter type annotation must be placed on left-hand side of assignment.',
+                    node: identifierNode
+                });
             }
         });
     };

--- a/src/utilities/getParameterName.js
+++ b/src/utilities/getParameterName.js
@@ -32,5 +32,5 @@ export default (identifierNode, context) => {
         return context.getSourceCode().getText(identifierNode.left);
     }
 
-    throw new Error('Unsupported function signature.');
+    return null;
 };

--- a/src/utilities/index.js
+++ b/src/utilities/index.js
@@ -5,3 +5,4 @@ export isFlowFile from './isFlowFile.js';
 export isFlowFileAnnotation from './isFlowFileAnnotation.js';
 export iterateFunctionNodes from './iterateFunctionNodes.js';
 export * as spacingFixers from './spacingFixers';
+export quoteName from './quoteName';

--- a/src/utilities/quoteName.js
+++ b/src/utilities/quoteName.js
@@ -1,0 +1,3 @@
+export default (name) => {
+    return name ? '"' + name + '" ' : '';
+};


### PR DESCRIPTION
Continuing from #65.

When a parameter name can't be determined (because the specific syntax hasn't yet been accounted for), currently it'll throw an error which bubbles up to this message to the user:

![](https://cloud.githubusercontent.com/assets/510740/17707073/99094e6a-63d6-11e6-9e0f-0222420ff516.png)

Instead, I propose it should just skip the name in the message.

(In the previous PR I was just returning a fallback string which wasn't too nice. Instead it's now returning `null`, and I've handled that case in each error message)