### PR TITLE
Add support for @noflow to require-valid-file-annotation.

### DIFF
--- a/src/rules/requireValidFileAnnotation.js
+++ b/src/rules/requireValidFileAnnotation.js
@@ -5,7 +5,7 @@ import {
 } from './../utilities';
 
 const looksLikeFlowFileAnnotation = (comment) => {
-    return /@flow/i.test(comment);
+    return /@(?:no)?flow/i.test(comment);
 };
 
 export const schema = [

--- a/src/utilities/isFlowFileAnnotation.js
+++ b/src/utilities/isFlowFileAnnotation.js
@@ -1,8 +1,12 @@
 import _ from 'lodash';
 
+const FLOW_MATCHER = /^@(?:no)?flow$/;
+
 export default (comment) => {
     // The flow parser splits comments with the following regex to look for the @flow flag.
     // See https://github.com/facebook/flow/blob/a96249b93541f2f7bfebd8d62085bf7a75de02f2/src/parsing/docblock.ml#L39
-    return _.includes(comment.split(/[ \t\r\n\\*/]+/), '@flow');
+    return _.some(comment.split(/[ \t\r\n\\*/]+/), (commentPart) => {
+        return FLOW_MATCHER.test(commentPart);
+    });
 };
 

--- a/tests/rules/assertions/requireValidFileAnnotation.js
+++ b/tests/rules/assertions/requireValidFileAnnotation.js
@@ -33,6 +33,22 @@ export default {
             ]
         },
         {
+            code: '// @NoFlow',
+            errors: [
+                {
+                    message: 'Malformed flow file annotation.'
+                }
+            ]
+        },
+        {
+            code: '// @nofloweeeeeee',
+            errors: [
+                {
+                    message: 'Malformed flow file annotation.'
+                }
+            ]
+        },
+        {
             code: 'a;',
             errors: [
                 {
@@ -65,6 +81,9 @@ export default {
         },
         {
             code: '// @flow\n// @FLow'
+        },
+        {
+            code: '// @noflow\na;'
         },
         {
             code: 'a;',


### PR DESCRIPTION
See https://flowtype.org/blog/2015/12/01/Version-0.19.0.html#noflow

It's nice to not error on this so you explicitly exclude a file, but still require that every file is opted in or out.