### PR TITLE
Fix parens in type aliases in space-after-colon

### DIFF
--- a/src/rules/spaceAfterTypeColon.js
+++ b/src/rules/spaceAfterTypeColon.js
@@ -133,7 +133,7 @@ const objectTypePropertyEvaluator = (context) => {
 
     return (objectTypeProperty) => {
         const colon = getColon(objectTypeProperty);
-        const typeAnnotation = objectTypeProperty.value;
+        const typeAnnotation = sourceCode.getTokenAfter(colon);
 
         const spaces = typeAnnotation.start - colon.end;
 

--- a/src/rules/spaceAfterTypeColon.js
+++ b/src/rules/spaceAfterTypeColon.js
@@ -19,11 +19,11 @@ const propertyEvaluator = (context, typeForMessage) => {
 
     const getSpacesAfterColon = (node, typeAnnotation) => {
         if (node.type === 'FunctionTypeParam') {
-            const colon = sourceCode.getTokenBefore(typeAnnotation);
+            const colon = sourceCode.getFirstToken(node, 1);
 
             return {
                 colon,
-                spaceAfter: typeAnnotation.start - colon.end
+                spaceAfter: sourceCode.getTokenAfter(colon).start - colon.end
             };
         } else {
             const [colon, token] = sourceCode.getFirstTokens(typeAnnotation, 2);

--- a/tests/rules/assertions/spaceAfterTypeColon.js
+++ b/tests/rules/assertions/spaceAfterTypeColon.js
@@ -448,6 +448,32 @@ const OBJECT_TYPE_PROPERTIES = {
             code: 'type X = { foo?:  ?string }',
             errors: [{message: 'There must be 1 space after "foo" type annotation colon.'}],
             output: 'type X = { foo?: ?string }'
+        },
+        {
+            code: 'type Foo = { barType:(string | () => void) }',
+            errors: [{message: 'There must be a space after "barType" type annotation colon.'}],
+            output: 'type Foo = { barType: (string | () => void) }'
+        },
+        {
+            code: 'type Foo = { barType:(((string | () => void))) }',
+            errors: [{message: 'There must be a space after "barType" type annotation colon.'}],
+            output: 'type Foo = { barType: (((string | () => void))) }'
+        },
+        {
+            code: 'type Foo = { barType: (string | () => void) }',
+            errors: [{message: 'There must be no space after "barType" type annotation colon.'}],
+            options: ['never'],
+            output: 'type Foo = { barType:(string | () => void) }'
+        },
+        {
+            code: 'type Foo = { barType:  (string | () => void) }',
+            errors: [{message: 'There must be 1 space after "barType" type annotation colon.'}],
+            output: 'type Foo = { barType: (string | () => void) }'
+        },
+        {
+            code: 'type Foo = { barType:  ((string | () => void)) }',
+            errors: [{message: 'There must be 1 space after "barType" type annotation colon.'}],
+            output: 'type Foo = { barType: ((string | () => void)) }'
         }
     ],
     valid: [
@@ -466,6 +492,20 @@ const OBJECT_TYPE_PROPERTIES = {
         },
         {
             code: 'type X = { foo?:?string }',
+            options: ['never']
+        },
+        {
+            code: 'type Foo = { barType: (string | () => void) }'
+        },
+        {
+            code: 'type Foo = { barType: ((string | () => void)) }'
+        },
+        {
+            code: 'type Foo = { barType:(string | () => void) }',
+            options: ['never']
+        },
+        {
+            code: 'type Foo = { barType:((string | () => void)) }',
             options: ['never']
         }
     ]

--- a/tests/rules/assertions/spaceAfterTypeColon.js
+++ b/tests/rules/assertions/spaceAfterTypeColon.js
@@ -2,382 +2,201 @@ export default {
     invalid: [
         {
             code: '(foo: string) => {}',
-            errors: [
-                {
-                    message: 'There must be no space after "foo" parameter type annotation colon.'
-                }
-            ],
-            options: [
-                'never'
-            ],
+            errors: [{message: 'There must be no space after "foo" parameter type annotation colon.'}],
+            options: ['never'],
             output: '(foo:string) => {}'
         },
         {
             code: 'export default function (foo: string) {}',
-            errors: [
-                {
-                    message: 'There must be no space after "foo" parameter type annotation colon.'
-                }
-            ],
-            options: [
-                'never'
-            ],
+            errors: [{message: 'There must be no space after "foo" parameter type annotation colon.'}],
+            options: ['never'],
             output: 'export default function (foo:string) {}'
         },
         {
             code: 'function foo (foo: string) {}',
-            errors: [
-                {
-                    message: 'There must be no space after "foo" parameter type annotation colon.'
-                }
-            ],
-            options: [
-                'never'
-            ],
+            errors: [{message: 'There must be no space after "foo" parameter type annotation colon.'}],
+            options: ['never'],
             output: 'function foo (foo:string) {}'
         },
         {
             code: '(foo:string) => {}',
-            errors: [
-                {
-                    message: 'There must be a space after "foo" parameter type annotation colon.'
-                }
-            ],
-            options: [
-                'always'
-            ],
+            errors: [{message: 'There must be a space after "foo" parameter type annotation colon.'}],
+            options: ['always'],
             output: '(foo: string) => {}'
         },
         {
             code: 'function foo (foo:string) {}',
-            errors: [
-                {
-                    message: 'There must be a space after "foo" parameter type annotation colon.'
-                }
-            ],
+            errors: [{message: 'There must be a space after "foo" parameter type annotation colon.'}],
             output: 'function foo (foo: string) {}'
         },
         {
             code: '(foo:  string) => {}',
-            errors: [
-                {
-                    message: 'There must be 1 space after "foo" parameter type annotation colon.'
-                }
-            ],
-            options: [
-                'always'
-            ],
+            errors: [{message: 'There must be 1 space after "foo" parameter type annotation colon.'}],
+            options: ['always'],
             output: '(foo: string) => {}'
         },
         {
             code: '(foo:(() => void)) => {}',
-            errors: [
-                {
-                    message: 'There must be a space after "foo" parameter type annotation colon.'
-                }
-            ],
-            options: [
-                'always'
-            ],
+            errors: [{message: 'There must be a space after "foo" parameter type annotation colon.'}],
+            options: ['always'],
             output: '(foo: (() => void)) => {}'
         },
         {
             code: '(foo: (() => void)) => {}',
-            errors: [
-                {
-                    message: 'There must be no space after "foo" parameter type annotation colon.'
-                }
-            ],
-            options: [
-                'never'
-            ],
+            errors: [{message: 'There must be no space after "foo" parameter type annotation colon.'}],
+            options: ['never'],
             output: '(foo:(() => void)) => {}'
         },
         {
             code: '(foo:  (() => void)) => {}',
-            errors: [
-                {
-                    message: 'There must be 1 space after "foo" parameter type annotation colon.'
-                }
-            ],
-            options: [
-                'always'
-            ],
+            errors: [{message: 'There must be 1 space after "foo" parameter type annotation colon.'}],
+            options: ['always'],
             output: '(foo: (() => void)) => {}'
         },
         {
             code: '():Object => {}',
-            errors: [
-                {
-                    message: 'There must be a space after return type colon.'
-                }
-            ],
-            options: [
-                'always'
-            ],
+            errors: [{message: 'There must be a space after return type colon.'}],
+            options: ['always'],
             output: '(): Object => {}'
-        }, {
+        },
+        {
             code: '(): Object => {}',
-            errors: [
-                {
-                    message: 'There must be no space after return type colon.'
-                }
-            ],
-            options: [
-                'never'
-            ],
+            errors: [{message: 'There must be no space after return type colon.'}],
+            options: ['never'],
             output: '():Object => {}'
-        }, {
+        },{
             code: '():  Object => {}',
-            errors: [
-                {
-                    message: 'There must be 1 space after return type colon.'
-                }
-            ],
-            options: [
-                'always'
-            ],
+            errors: [{message: 'There must be 1 space after return type colon.'}],
+            options: ['always'],
             output: '(): Object => {}'
         },
         {
             code: '():(() => void) => {}',
-            errors: [
-                {
-                    message: 'There must be a space after return type colon.'
-                }
-            ],
-            options: [
-                'always'
-            ],
+            errors: [{message: 'There must be a space after return type colon.'}],
+            options: ['always'],
             output: '(): (() => void) => {}'
-        }, {
+        },
+        {
             code: '(): (() => void) => {}',
-            errors: [
-                {
-                    message: 'There must be no space after return type colon.'
-                }
-            ],
-            options: [
-                'never'
-            ],
+            errors: [{message: 'There must be no space after return type colon.'}],
+            options: ['never'],
             output: '():(() => void) => {}'
-        }, {
+        },
+        {
             code: '():  (() => void) => {}',
-            errors: [
-                {
-                    message: 'There must be 1 space after return type colon.'
-                }
-            ],
-            options: [
-                'always'
-            ],
+            errors: [{message: 'There must be 1 space after return type colon.'}],
+            options: ['always'],
             output: '(): (() => void) => {}'
         },
         {
             code: 'async function foo({ lorem, ipsum, dolor }:SomeType) {}',
-            errors: [
-                {
-                    message: 'There must be a space after "{ lorem, ipsum, dolor }" parameter type annotation colon.'
-                }
-            ],
+            errors: [{message: 'There must be a space after "{ lorem, ipsum, dolor }" parameter type annotation colon.'}],
             output: 'async function foo({ lorem, ipsum, dolor }: SomeType) {}'
         },
         {
             code: '({ lorem, ipsum, dolor } :   SomeType) => {}',
-            errors: [
-                {
-                    message: 'There must be 1 space after "{ lorem, ipsum, dolor }" parameter type annotation colon.'
-                }
-            ],
+            errors: [{message: 'There must be 1 space after "{ lorem, ipsum, dolor }" parameter type annotation colon.'}],
             output: '({ lorem, ipsum, dolor } : SomeType) => {}'
         },
         {
             code: '(foo:{ a: string, b: number }) => {}',
-            errors: [
-                {
-                    message: 'There must be a space after "foo" parameter type annotation colon.'
-                }
-            ],
+            errors: [{message: 'There must be a space after "foo" parameter type annotation colon.'}],
             output: '(foo: { a: string, b: number }) => {}'
         },
         {
             code: '({ a, b } :{ a: string, b: number }) => {}',
-            errors: [
-                {
-                    message: 'There must be a space after "{ a, b }" parameter type annotation colon.'
-                }
-            ],
+            errors: [{message: 'There must be a space after "{ a, b }" parameter type annotation colon.'}],
             output: '({ a, b } : { a: string, b: number }) => {}'
         },
         {
             code: '([ a, b ] :string[]) => {}',
-            errors: [
-                {
-                    message: 'There must be a space after "[ a, b ]" parameter type annotation colon.'
-                }
-            ],
+            errors: [{message: 'There must be a space after "[ a, b ]" parameter type annotation colon.'}],
             output: '([ a, b ] : string[]) => {}'
         },
         {
             code: 'type X = { foo:string }',
-            errors: [
-                {
-                    message: 'There must be a space after "foo" type annotation colon.'
-                }
-            ],
+            errors: [{message: 'There must be a space after "foo" type annotation colon.'}],
             output: 'type X = { foo: string }'
         },
         {
             code: 'type X = { foo:string }',
-            errors: [
-                {
-                    message: 'There must be a space after "foo" type annotation colon.'
-                }
-            ],
-            options: [
-                'always'
-            ],
+            errors: [{message: 'There must be a space after "foo" type annotation colon.'}],
+            options: ['always'],
             output: 'type X = { foo: string }'
         },
         {
             code: 'type X = { foo: string }',
-            errors: [
-                {
-                    message: 'There must be no space after "foo" type annotation colon.'
-                }
-            ],
-            options: [
-                'never'
-            ],
+            errors: [{message: 'There must be no space after "foo" type annotation colon.'}],
+            options: ['never'],
             output: 'type X = { foo:string }'
         },
         {
             code: 'type X = { foo:  string }',
-            errors: [
-                {
-                    message: 'There must be 1 space after "foo" type annotation colon.'
-                }
-            ],
+            errors: [{message: 'There must be 1 space after "foo" type annotation colon.'}],
             output: 'type X = { foo: string }'
         },
         {
             code: 'type X = { foo?:string }',
-            errors: [
-                {
-                    message: 'There must be a space after "foo" type annotation colon.'
-                }
-            ],
+            errors: [{message: 'There must be a space after "foo" type annotation colon.'}],
             output: 'type X = { foo?: string }'
         },
         {
             code: 'type X = { foo?: string }',
-            errors: [
-                {
-                    message: 'There must be no space after "foo" type annotation colon.'
-                }
-            ],
-            options: [
-                'never'
-            ],
+            errors: [{message: 'There must be no space after "foo" type annotation colon.'}],
+            options: ['never'],
             output: 'type X = { foo?:string }'
         },
         {
             code: 'type X = { foo?:?string }',
-            errors: [
-                {
-                    message: 'There must be a space after "foo" type annotation colon.'
-                }
-            ],
+            errors: [{message: 'There must be a space after "foo" type annotation colon.'}],
             output: 'type X = { foo?: ?string }'
         },
         {
             code: 'type X = { foo?:  ?string }',
-            errors: [
-                {
-                    message: 'There must be 1 space after "foo" type annotation colon.'
-                }
-            ],
+            errors: [{message: 'There must be 1 space after "foo" type annotation colon.'}],
             output: 'type X = { foo?: ?string }'
         },
         {
             code: 'class X { foo:string }',
-            errors: [
-                {
-                    message: 'There must be a space after "foo" class property type annotation colon.'
-                }
-            ],
+            errors: [{message: 'There must be a space after "foo" class property type annotation colon.'}],
             output: 'class X { foo: string }'
         },
         {
             code: 'class X { foo: string }',
-            errors: [
-                {
-                    message: 'There must be no space after "foo" class property type annotation colon.'
-                }
-            ],
-            options: [
-                'never'
-            ],
+            errors: [{message: 'There must be no space after "foo" class property type annotation colon.'}],
+            options: ['never'],
             output: 'class X { foo:string }'
         },
         {
             code: 'class X { foo:?string }',
-            errors: [
-                {
-                    message: 'There must be a space after "foo" class property type annotation colon.'
-                }
-            ],
+            errors: [{message: 'There must be a space after "foo" class property type annotation colon.'}],
             output: 'class X { foo: ?string }'
         },
         {
             code: 'class X { foo: ?string }',
-            errors: [
-                {
-                    message: 'There must be no space after "foo" class property type annotation colon.'
-                }
-            ],
-            options: [
-                'never'
-            ],
+            errors: [{message: 'There must be no space after "foo" class property type annotation colon.'}],
+            options: ['never'],
             output: 'class X { foo:?string }'
         },
         {
             code: 'type X = (foo:number) => string',
-            errors: [
-                {
-                    message: 'There must be a space after "foo" parameter type annotation colon.'
-                }
-            ],
+            errors: [{message: 'There must be a space after "foo" parameter type annotation colon.'}],
             output: 'type X = (foo: number) => string'
         },
         {
             code: 'type X = (foo: number) => string',
-            errors: [
-                {
-                    message: 'There must be no space after "foo" parameter type annotation colon.'
-                }
-            ],
-            options: [
-                'never'
-            ],
+            errors: [{message: 'There must be no space after "foo" parameter type annotation colon.'}],
+            options: ['never'],
             output: 'type X = (foo:number) => string'
         },
         {
             code: 'type X = (foo:  number) => string',
-            errors: [
-                {
-                    message: 'There must be 1 space after "foo" parameter type annotation colon.'
-                }
-            ],
+            errors: [{message: 'There must be 1 space after "foo" parameter type annotation colon.'}],
             output: 'type X = (foo: number) => string'
         },
         {
             code: 'type X = (foo:?number) => string',
-            errors: [
-                {
-                    message: 'There must be a space after "foo" parameter type annotation colon.'
-                }
-            ],
+            errors: [{message: 'There must be a space after "foo" parameter type annotation colon.'}],
             output: 'type X = (foo: ?number) => string'
         },
         {
@@ -443,96 +262,67 @@ export default {
         },
         {
             code: '(foo:string) => {}',
-            options: [
-                'never'
-            ]
+            options: ['never']
         },
         {
             code: 'function x(foo:string) {}',
-            options: [
-                'never'
-            ]
+            options: ['never']
         },
         {
             code: 'class Foo { constructor(foo:string) {} }',
-            options: [
-                'never'
-            ]
+            options: ['never']
         },
         {
             code: '(foo: string) => {}',
-            options: [
-                'always'
-            ]
+            options: ['always']
         },
         {
             code: '(foo:(() => void)) => {}',
-            options: [
-                'never'
-            ]
+            options: ['never']
         },
         {
             code: '(foo: (() => void)) => {}',
-            options: [
-                'always'
-            ]
+            options: ['always']
         },
         {
             code: '():Object => {}',
-            options: [
-                'never'
-            ]
+            options: ['never']
         },
         {
             code: '(): Object => {}',
-            options: [
-                'always'
-            ]
+            options: ['always']
         },
         {
             code: '():(number | string) => {}',
-            options: [
-                'never'
-            ]
+            options: ['never']
         },
         {
             code: '(): (number | string) => {}',
-            options: [
-                'always'
-            ]
+            options: ['always']
         },
         {
             code: '():number|string => {}',
-            options: [
-                'never'
-            ]
+            options: ['never']
         },
         {
             code: '(): number|string => {}',
-            options: [
-                'always'
-            ]
+            options: ['always']
         },
         {
             code: '():(() => void) => {}',
-            options: [
-                'never'
-            ]
-        }, {
+            options: ['never']
+        },
+        {
             code: '(): (() => void) => {}',
-            options: [
-                'always'
-            ]
-        }, {
+            options: ['always']
+        },
+        {
             code: '():( () => void ) => {}',
-            options: [
-                'never'
-            ]
-        }, {
+            options: ['never']
+        },
+        {
             code: '(): ( () => void ) => {}',
-            options: [
-                'always'
-            ]
+            options: ['always']
         },
         {
             code: 'async function foo({ lorem, ipsum, dolor }: SomeType) {}'
@@ -554,9 +344,7 @@ export default {
         },
         {
             code: '() :{ a:number, b:string } => {}',
-            options: [
-                'never'
-            ]
+            options: ['never']
         },
         {
             code: '([ a, b ]: string[]) => {}'
@@ -566,9 +354,7 @@ export default {
         },
         {
             code: 'type X = { foo:string }',
-            options: [
-                'never'
-            ]
+            options: ['never']
         },
         {
             code: 'type X = { foo?: string }'
@@ -578,9 +364,7 @@ export default {
         },
         {
             code: 'type X = { foo?:?string }',
-            options: [
-                'never'
-            ]
+            options: ['never']
         },
         {
             code: 'class Foo { bar }'
@@ -596,15 +380,11 @@ export default {
         },
         {
             code: 'class Foo { bar:string }',
-            options: [
-                'never'
-            ]
+            options: ['never']
         },
         {
             code: 'class Foo { bar:?string }',
-            options: [
-                'never'
-            ]
+            options: ['never']
         },
         {
             code: 'type X = (foo: number) => string;'
@@ -623,15 +403,11 @@ export default {
         },
         {
             code: 'type X = (foo:number) => string;',
-            options: [
-                'never'
-            ]
+            options: ['never']
         },
         {
             code: 'type X = (foo:?{ x:number }) => string;',
-            options: [
-                'never'
-            ]
+            options: ['never']
         },
         {
             code: 'class X { static foo : number }'

--- a/tests/rules/assertions/spaceAfterTypeColon.js
+++ b/tests/rules/assertions/spaceAfterTypeColon.js
@@ -1,33 +1,12 @@
-export default {
+import _ from 'lodash';
+
+const ARROW_FUNCTION_PARAMS = {
     invalid: [
         {
             code: '(foo: string) => {}',
             errors: [{message: 'There must be no space after "foo" parameter type annotation colon.'}],
             options: ['never'],
             output: '(foo:string) => {}'
-        },
-        {
-            code: 'export default function (foo: string) {}',
-            errors: [{message: 'There must be no space after "foo" parameter type annotation colon.'}],
-            options: ['never'],
-            output: 'export default function (foo:string) {}'
-        },
-        {
-            code: 'function foo (foo: string) {}',
-            errors: [{message: 'There must be no space after "foo" parameter type annotation colon.'}],
-            options: ['never'],
-            output: 'function foo (foo:string) {}'
-        },
-        {
-            code: '(foo:string) => {}',
-            errors: [{message: 'There must be a space after "foo" parameter type annotation colon.'}],
-            options: ['always'],
-            output: '(foo: string) => {}'
-        },
-        {
-            code: 'function foo (foo:string) {}',
-            errors: [{message: 'There must be a space after "foo" parameter type annotation colon.'}],
-            output: 'function foo (foo: string) {}'
         },
         {
             code: '(foo:  string) => {}',
@@ -54,6 +33,70 @@ export default {
             output: '(foo: (() => void)) => {}'
         },
         {
+            code: '({ lorem, ipsum, dolor } :   SomeType) => {}',
+            errors: [{message: 'There must be 1 space after "{ lorem, ipsum, dolor }" parameter type annotation colon.'}],
+            output: '({ lorem, ipsum, dolor } : SomeType) => {}'
+        },
+        {
+            code: '(foo:{ a: string, b: number }) => {}',
+            errors: [{message: 'There must be a space after "foo" parameter type annotation colon.'}],
+            output: '(foo: { a: string, b: number }) => {}'
+        },
+        {
+            code: '({ a, b } :{ a: string, b: number }) => {}',
+            errors: [{message: 'There must be a space after "{ a, b }" parameter type annotation colon.'}],
+            output: '({ a, b } : { a: string, b: number }) => {}'
+        },
+        {
+            code: '([ a, b ] :string[]) => {}',
+            errors: [{message: 'There must be a space after "[ a, b ]" parameter type annotation colon.'}],
+            output: '([ a, b ] : string[]) => {}'
+        }
+    ],
+    valid: [
+        {
+            code: '(foo) => {}'
+        },
+        {
+            code: '(foo: string) => {}'
+        },
+        {
+            code: '(foo: (string|number)) => {}'
+        },
+        {
+            code: '(foo:string) => {}',
+            options: ['never']
+        },
+        {
+            code: '(foo: string) => {}',
+            options: ['always']
+        },
+        {
+            code: '(foo:(() => void)) => {}',
+            options: ['never']
+        },
+        {
+            code: '(foo: (() => void)) => {}',
+            options: ['always']
+        },
+        {
+            code: '({ lorem, ipsum, dolor }: SomeType) => {}'
+        },
+        {
+            code: '(foo: { a: string, b: number }) => {}'
+        },
+        {
+            code: '({ a, b }: ?{ a: string, b: number }) => {}'
+        },
+        {
+            code: '([ a, b ]: string[]) => {}'
+        }
+    ]
+};
+
+const ARROW_FUNCTION_RETURN = {
+    invalid: [
+        {
             code: '():Object => {}',
             errors: [{message: 'There must be a space after return type colon.'}],
             options: ['always'],
@@ -64,7 +107,8 @@ export default {
             errors: [{message: 'There must be no space after return type colon.'}],
             options: ['never'],
             output: '():Object => {}'
-        },{
+        },
+        {
             code: '():  Object => {}',
             errors: [{message: 'There must be 1 space after return type colon.'}],
             options: ['always'],
@@ -87,75 +131,174 @@ export default {
             errors: [{message: 'There must be 1 space after return type colon.'}],
             options: ['always'],
             output: '(): (() => void) => {}'
+        }
+    ],
+    valid: [
+        {
+            code: '():Object => {}',
+            options: ['never']
+        },
+        {
+            code: '(): Object => {}',
+            options: ['always']
+        },
+        {
+            code: '():(number | string) => {}',
+            options: ['never']
+        },
+        {
+            code: '(): (number | string) => {}',
+            options: ['always']
+        },
+        {
+            code: '():number|string => {}',
+            options: ['never']
+        },
+        {
+            code: '(): number|string => {}',
+            options: ['always']
+        },
+        {
+            code: '():(() => void) => {}',
+            options: ['never']
+        },
+        {
+            code: '(): (() => void) => {}',
+            options: ['always']
+        },
+        {
+            code: '():( () => void ) => {}',
+            options: ['never']
+        },
+        {
+            code: '(): ( () => void ) => {}',
+            options: ['always']
+        },
+        {
+            code: '(): { a: number, b: string } => {}'
+        },
+        {
+            code: '() :{ a:number, b:string } => {}',
+            options: ['never']
+        }
+    ]
+};
+
+const FUNCTION_PARAMS = {
+    invalid: [
+        {
+            code: 'export default function (foo: string) {}',
+            errors: [{message: 'There must be no space after "foo" parameter type annotation colon.'}],
+            options: ['never'],
+            output: 'export default function (foo:string) {}'
+        },
+        {
+            code: 'function foo (foo: string) {}',
+            errors: [{message: 'There must be no space after "foo" parameter type annotation colon.'}],
+            options: ['never'],
+            output: 'function foo (foo:string) {}'
+        },
+        {
+            code: '(foo:string) => {}',
+            errors: [{message: 'There must be a space after "foo" parameter type annotation colon.'}],
+            options: ['always'],
+            output: '(foo: string) => {}'
+        },
+        {
+            code: 'function foo (foo:string) {}',
+            errors: [{message: 'There must be a space after "foo" parameter type annotation colon.'}],
+            output: 'function foo (foo: string) {}'
         },
         {
             code: 'async function foo({ lorem, ipsum, dolor }:SomeType) {}',
             errors: [{message: 'There must be a space after "{ lorem, ipsum, dolor }" parameter type annotation colon.'}],
             output: 'async function foo({ lorem, ipsum, dolor }: SomeType) {}'
+        }
+    ],
+    valid: [
+        {
+            code: 'function x(foo: string) {}'
         },
         {
-            code: '({ lorem, ipsum, dolor } :   SomeType) => {}',
-            errors: [{message: 'There must be 1 space after "{ lorem, ipsum, dolor }" parameter type annotation colon.'}],
-            output: '({ lorem, ipsum, dolor } : SomeType) => {}'
+            code: 'class Foo { constructor(foo: string) {} }'
         },
         {
-            code: '(foo:{ a: string, b: number }) => {}',
+            code: 'function x(foo:string) {}',
+            options: ['never']
+        },
+        {
+            code: 'class Foo { constructor(foo:string) {} }',
+            options: ['never']
+        },
+        {
+            code: 'async function foo({ lorem, ipsum, dolor }: SomeType) {}'
+        },
+        {
+            code: 'function x({ a, b }: { a: string, b: number }) {}'
+        }
+    ]
+};
+
+const FUNCTION_RETURN = {
+    invalid: [
+    ],
+    valid: [
+    ]
+};
+
+const FUNCTION_TYPE_PARAMS = {
+    invalid: [
+        {
+            code: 'type X = (foo:number) => string',
             errors: [{message: 'There must be a space after "foo" parameter type annotation colon.'}],
-            output: '(foo: { a: string, b: number }) => {}'
+            output: 'type X = (foo: number) => string'
         },
         {
-            code: '({ a, b } :{ a: string, b: number }) => {}',
-            errors: [{message: 'There must be a space after "{ a, b }" parameter type annotation colon.'}],
-            output: '({ a, b } : { a: string, b: number }) => {}'
-        },
-        {
-            code: '([ a, b ] :string[]) => {}',
-            errors: [{message: 'There must be a space after "[ a, b ]" parameter type annotation colon.'}],
-            output: '([ a, b ] : string[]) => {}'
-        },
-        {
-            code: 'type X = { foo:string }',
-            errors: [{message: 'There must be a space after "foo" type annotation colon.'}],
-            output: 'type X = { foo: string }'
-        },
-        {
-            code: 'type X = { foo:string }',
-            errors: [{message: 'There must be a space after "foo" type annotation colon.'}],
-            options: ['always'],
-            output: 'type X = { foo: string }'
-        },
-        {
-            code: 'type X = { foo: string }',
-            errors: [{message: 'There must be no space after "foo" type annotation colon.'}],
+            code: 'type X = (foo: number) => string',
+            errors: [{message: 'There must be no space after "foo" parameter type annotation colon.'}],
             options: ['never'],
-            output: 'type X = { foo:string }'
+            output: 'type X = (foo:number) => string'
         },
         {
-            code: 'type X = { foo:  string }',
-            errors: [{message: 'There must be 1 space after "foo" type annotation colon.'}],
-            output: 'type X = { foo: string }'
+            code: 'type X = (foo:  number) => string',
+            errors: [{message: 'There must be 1 space after "foo" parameter type annotation colon.'}],
+            output: 'type X = (foo: number) => string'
         },
         {
-            code: 'type X = { foo?:string }',
-            errors: [{message: 'There must be a space after "foo" type annotation colon.'}],
-            output: 'type X = { foo?: string }'
+            code: 'type X = (foo:?number) => string',
+            errors: [{message: 'There must be a space after "foo" parameter type annotation colon.'}],
+            output: 'type X = (foo: ?number) => string'
+        }
+    ],
+    valid: [
+        {
+            code: 'type X = (foo: number) => string;'
         },
         {
-            code: 'type X = { foo?: string }',
-            errors: [{message: 'There must be no space after "foo" type annotation colon.'}],
-            options: ['never'],
-            output: 'type X = { foo?:string }'
+            code: 'type X = (foo : number) => string;'
         },
         {
-            code: 'type X = { foo?:?string }',
-            errors: [{message: 'There must be a space after "foo" type annotation colon.'}],
-            output: 'type X = { foo?: ?string }'
+            code: 'type X = (foo: ?number) => string;'
         },
         {
-            code: 'type X = { foo?:  ?string }',
-            errors: [{message: 'There must be 1 space after "foo" type annotation colon.'}],
-            output: 'type X = { foo?: ?string }'
+            code: 'type X = (foo? : ?number) => string;'
         },
+        {
+            code: 'type X = (foo: ?{ x: number }) => string;'
+        },
+        {
+            code: 'type X = (foo:number) => string;',
+            options: ['never']
+        },
+        {
+            code: 'type X = (foo:?{ x:number }) => string;',
+            options: ['never']
+        }
+    ]
+};
+
+const CLASS_PROPERTIES = {
+    invalid: [
         {
             code: 'class X { foo:string }',
             errors: [{message: 'There must be a space after "foo" class property type annotation colon.'}],
@@ -177,27 +320,6 @@ export default {
             errors: [{message: 'There must be no space after "foo" class property type annotation colon.'}],
             options: ['never'],
             output: 'class X { foo:?string }'
-        },
-        {
-            code: 'type X = (foo:number) => string',
-            errors: [{message: 'There must be a space after "foo" parameter type annotation colon.'}],
-            output: 'type X = (foo: number) => string'
-        },
-        {
-            code: 'type X = (foo: number) => string',
-            errors: [{message: 'There must be no space after "foo" parameter type annotation colon.'}],
-            options: ['never'],
-            output: 'type X = (foo:number) => string'
-        },
-        {
-            code: 'type X = (foo:  number) => string',
-            errors: [{message: 'There must be 1 space after "foo" parameter type annotation colon.'}],
-            output: 'type X = (foo: number) => string'
-        },
-        {
-            code: 'type X = (foo:?number) => string',
-            errors: [{message: 'There must be a space after "foo" parameter type annotation colon.'}],
-            output: 'type X = (foo: ?number) => string'
         },
         {
             code: 'class X { static foo:number }',
@@ -246,127 +368,6 @@ export default {
     ],
     valid: [
         {
-            code: '(foo) => {}'
-        },
-        {
-            code: '(foo: string) => {}'
-        },
-        {
-            code: 'function x(foo: string) {}'
-        },
-        {
-            code: 'class Foo { constructor(foo: string) {} }'
-        },
-        {
-            code: '(foo: (string|number)) => {}'
-        },
-        {
-            code: '(foo:string) => {}',
-            options: ['never']
-        },
-        {
-            code: 'function x(foo:string) {}',
-            options: ['never']
-        },
-        {
-            code: 'class Foo { constructor(foo:string) {} }',
-            options: ['never']
-        },
-        {
-            code: '(foo: string) => {}',
-            options: ['always']
-        },
-        {
-            code: '(foo:(() => void)) => {}',
-            options: ['never']
-        },
-        {
-            code: '(foo: (() => void)) => {}',
-            options: ['always']
-        },
-        {
-            code: '():Object => {}',
-            options: ['never']
-        },
-        {
-            code: '(): Object => {}',
-            options: ['always']
-        },
-        {
-            code: '():(number | string) => {}',
-            options: ['never']
-        },
-        {
-            code: '(): (number | string) => {}',
-            options: ['always']
-        },
-        {
-            code: '():number|string => {}',
-            options: ['never']
-        },
-        {
-            code: '(): number|string => {}',
-            options: ['always']
-        },
-        {
-            code: '():(() => void) => {}',
-            options: ['never']
-        },
-        {
-            code: '(): (() => void) => {}',
-            options: ['always']
-        },
-        {
-            code: '():( () => void ) => {}',
-            options: ['never']
-        },
-        {
-            code: '(): ( () => void ) => {}',
-            options: ['always']
-        },
-        {
-            code: 'async function foo({ lorem, ipsum, dolor }: SomeType) {}'
-        },
-        {
-            code: '({ lorem, ipsum, dolor }: SomeType) => {}'
-        },
-        {
-            code: '(foo: { a: string, b: number }) => {}'
-        },
-        {
-            code: '({ a, b }: ?{ a: string, b: number }) => {}'
-        },
-        {
-            code: 'function x({ a, b }: { a: string, b: number }) {}'
-        },
-        {
-            code: '(): { a: number, b: string } => {}'
-        },
-        {
-            code: '() :{ a:number, b:string } => {}',
-            options: ['never']
-        },
-        {
-            code: '([ a, b ]: string[]) => {}'
-        },
-        {
-            code: 'type X = { foo: string }'
-        },
-        {
-            code: 'type X = { foo:string }',
-            options: ['never']
-        },
-        {
-            code: 'type X = { foo?: string }'
-        },
-        {
-            code: 'type X = { foo?: ?string }'
-        },
-        {
-            code: 'type X = { foo?:?string }',
-            options: ['never']
-        },
-        {
             code: 'class Foo { bar }'
         },
         {
@@ -387,29 +388,6 @@ export default {
             options: ['never']
         },
         {
-            code: 'type X = (foo: number) => string;'
-        },
-        {
-            code: 'type X = (foo : number) => string;'
-        },
-        {
-            code: 'type X = (foo: ?number) => string;'
-        },
-        {
-            code: 'type X = (foo? : ?number) => string;'
-        },
-        {
-            code: 'type X = (foo: ?{ x: number }) => string;'
-        },
-        {
-            code: 'type X = (foo:number) => string;',
-            options: ['never']
-        },
-        {
-            code: 'type X = (foo:?{ x:number }) => string;',
-            options: ['never']
-        },
-        {
             code: 'class X { static foo : number }'
         },
         {
@@ -424,4 +402,86 @@ export default {
             options: ['never']
         }
     ]
+};
+
+const OBJECT_TYPE_PROPERTIES = {
+    invalid: [
+        {
+            code: 'type X = { foo:string }',
+            errors: [{message: 'There must be a space after "foo" type annotation colon.'}],
+            output: 'type X = { foo: string }'
+        },
+        {
+            code: 'type X = { foo:string }',
+            errors: [{message: 'There must be a space after "foo" type annotation colon.'}],
+            options: ['always'],
+            output: 'type X = { foo: string }'
+        },
+        {
+            code: 'type X = { foo: string }',
+            errors: [{message: 'There must be no space after "foo" type annotation colon.'}],
+            options: ['never'],
+            output: 'type X = { foo:string }'
+        },
+        {
+            code: 'type X = { foo:  string }',
+            errors: [{message: 'There must be 1 space after "foo" type annotation colon.'}],
+            output: 'type X = { foo: string }'
+        },
+        {
+            code: 'type X = { foo?:string }',
+            errors: [{message: 'There must be a space after "foo" type annotation colon.'}],
+            output: 'type X = { foo?: string }'
+        },
+        {
+            code: 'type X = { foo?: string }',
+            errors: [{message: 'There must be no space after "foo" type annotation colon.'}],
+            options: ['never'],
+            output: 'type X = { foo?:string }'
+        },
+        {
+            code: 'type X = { foo?:?string }',
+            errors: [{message: 'There must be a space after "foo" type annotation colon.'}],
+            output: 'type X = { foo?: ?string }'
+        },
+        {
+            code: 'type X = { foo?:  ?string }',
+            errors: [{message: 'There must be 1 space after "foo" type annotation colon.'}],
+            output: 'type X = { foo?: ?string }'
+        }
+    ],
+    valid: [
+        {
+            code: 'type X = { foo: string }'
+        },
+        {
+            code: 'type X = { foo:string }',
+            options: ['never']
+        },
+        {
+            code: 'type X = { foo?: string }'
+        },
+        {
+            code: 'type X = { foo?: ?string }'
+        },
+        {
+            code: 'type X = { foo?:?string }',
+            options: ['never']
+        }
+    ]
+};
+
+const ALL = [
+    ARROW_FUNCTION_PARAMS,
+    ARROW_FUNCTION_RETURN,
+    FUNCTION_PARAMS,
+    FUNCTION_RETURN,
+    FUNCTION_TYPE_PARAMS,
+    CLASS_PROPERTIES,
+    OBJECT_TYPE_PROPERTIES
+];
+
+export default {
+    invalid: _.flatMap(ALL, (rules) => { return rules.invalid; }),
+    valid: _.flatMap(ALL, (rules) => { return rules.valid; })
 };

--- a/tests/rules/assertions/spaceAfterTypeColon.js
+++ b/tests/rules/assertions/spaceAfterTypeColon.js
@@ -268,6 +268,32 @@ const FUNCTION_TYPE_PARAMS = {
             code: 'type X = (foo:?number) => string',
             errors: [{message: 'There must be a space after "foo" parameter type annotation colon.'}],
             output: 'type X = (foo: ?number) => string'
+        },
+        {
+            code: 'type X = (foo:(number)) => string',
+            errors: [{message: 'There must be a space after "foo" parameter type annotation colon.'}],
+            output: 'type X = (foo: (number)) => string'
+        },
+        {
+            code: 'type X = (foo:((number))) => string',
+            errors: [{message: 'There must be a space after "foo" parameter type annotation colon.'}],
+            output: 'type X = (foo: ((number))) => string'
+        },
+        {
+            code: 'type X = (foo:  ((number))) => string',
+            errors: [{message: 'There must be 1 space after "foo" parameter type annotation colon.'}],
+            output: 'type X = (foo: ((number))) => string'
+        },
+        {
+            code: 'type X = (foo: ((number))) => string',
+            errors: [{message: 'There must be no space after "foo" parameter type annotation colon.'}],
+            options: ['never'],
+            output: 'type X = (foo:((number))) => string'
+        },
+        {
+            code: 'type X = (foo:?(number)) => string',
+            errors: [{message: 'There must be a space after "foo" parameter type annotation colon.'}],
+            output: 'type X = (foo: ?(number)) => string'
         }
     ],
     valid: [
@@ -292,6 +318,23 @@ const FUNCTION_TYPE_PARAMS = {
         },
         {
             code: 'type X = (foo:?{ x:number }) => string;',
+            options: ['never']
+        },
+        {
+            code: 'type X = (foo: (number)) => string'
+        },
+        {
+            code: 'type X = (foo: ((number))) => string'
+        },
+        {
+            code: 'type X = (foo:((number))) => string',
+            options: ['never']
+        },
+        {
+            code: 'type X = ?(foo: ((number))) => string'
+        },
+        {
+            code: 'type X = ?(foo:((number))) => string',
             options: ['never']
         }
     ]

--- a/tests/rules/assertions/spaceBeforeTypeColon.js
+++ b/tests/rules/assertions/spaceBeforeTypeColon.js
@@ -2,398 +2,208 @@ export default {
     invalid: [
         {
             code: '(foo : string) => {}',
-            errors: [
-                {
-                    message: 'There must be no space before "foo" parameter type annotation colon.'
-                }
-            ],
-            options: [
-                'never'
-            ],
+            errors: [{message: 'There must be no space before "foo" parameter type annotation colon.'}],
+            options: ['never'],
             output: '(foo: string) => {}'
         },
         {
             code: '(foo ? : string) => {}',
-            errors: [
-                {
-                    message: 'There must be no space before "foo" parameter type annotation colon.'
-                }
-            ],
-            options: [
-                'never'
-            ],
+            errors: [{message: 'There must be no space before "foo" parameter type annotation colon.'}],
+            options: ['never'],
             output: '(foo ?: string) => {}'
         },
         {
             code: '(foo: string) => {}',
-            errors: [
-                {
-                    message: 'There must be a space before "foo" parameter type annotation colon.'
-                }
-            ],
-            options: [
-                'always'
-            ],
+            errors: [{message: 'There must be a space before "foo" parameter type annotation colon.'}],
+            options: ['always'],
             output: '(foo : string) => {}'
         },
         {
             code: '(foo  : string) => {}',
-            errors: [
-                {
-                    message: 'There must be 1 space before "foo" parameter type annotation colon.'
-                }
-            ],
-            options: [
-                'always'
-            ],
+            errors: [{message: 'There must be 1 space before "foo" parameter type annotation colon.'}],
+            options: ['always'],
             output: '(foo : string) => {}'
         },
         {
             code: '(foo?: string) => {}',
-            errors: [
-                {
-                    message: 'There must be a space before "foo" parameter type annotation colon.'
-                }
-            ],
-            options: [
-                'always'
-            ],
+            errors: [{message: 'There must be a space before "foo" parameter type annotation colon.'}],
+            options: ['always'],
             output: '(foo? : string) => {}'
         },
         {
             code: '(foo ?  : string) => {}',
-            errors: [
-                {
-                    message: 'There must be 1 space before "foo" parameter type annotation colon.'
-                }
-            ],
-            options: [
-                'always'
-            ],
+            errors: [{message: 'There must be 1 space before "foo" parameter type annotation colon.'}],
+            options: ['always'],
             output: '(foo ? : string) => {}'
         },
         {
             code: '(foo  ?: string) => {}',
-            errors: [
-                {
-                    message: 'There must be a space before "foo" parameter type annotation colon.'
-                }
-            ],
-            options: [
-                'always'
-            ],
+            errors: [{message: 'There must be a space before "foo" parameter type annotation colon.'}],
+            options: ['always'],
             output: '(foo  ? : string) => {}'
         },
         {
             code: 'function x(foo : string) {}',
-            errors: [
-                {
-                    message: 'There must be no space before "foo" parameter type annotation colon.'
-                }
-            ],
+            errors: [{message: 'There must be no space before "foo" parameter type annotation colon.'}],
             output: 'function x(foo: string) {}'
         },
         {
             code: 'function x(foo: string) {}',
-            errors: [
-                {
-                    message: 'There must be a space before "foo" parameter type annotation colon.'
-                }
-            ],
-            options: [
-                'always'
-            ],
+            errors: [{message: 'There must be a space before "foo" parameter type annotation colon.'}],
+            options: ['always'],
             output: 'function x(foo : string) {}'
         },
         {
             code: 'var x = function (foo : string) {}',
-            errors: [
-                {
-                    message: 'There must be no space before "foo" parameter type annotation colon.'
-                }
-            ],
+            errors: [{message: 'There must be no space before "foo" parameter type annotation colon.'}],
             output: 'var x = function (foo: string) {}'
         },
         {
             code: 'var x = function (foo: string) {}',
-            errors: [
-                {
-                    message: 'There must be a space before "foo" parameter type annotation colon.'
-                }
-            ],
-            options: [
-                'always'
-            ],
+            errors: [{message: 'There must be a space before "foo" parameter type annotation colon.'}],
+            options: ['always'],
             output: 'var x = function (foo : string) {}'
         },
         {
             code: 'class Foo { constructor(foo : string ) {} }',
-            errors: [
-                {
-                    message: 'There must be no space before "foo" parameter type annotation colon.'
-                }
-            ],
+            errors: [{message: 'There must be no space before "foo" parameter type annotation colon.'}],
             output: 'class Foo { constructor(foo: string ) {} }'
         },
         {
             code: 'class Foo { constructor(foo: string ) {} }',
-            errors: [
-                {
-                    message: 'There must be a space before "foo" parameter type annotation colon.'
-                }
-            ],
-            options: [
-                'always'
-            ],
+            errors: [{message: 'There must be a space before "foo" parameter type annotation colon.'}],
+            options: ['always'],
             output: 'class Foo { constructor(foo : string ) {} }'
         },
         {
             code: 'async function foo({ lorem, ipsum, dolor } : SomeType) {}',
-            errors: [
-                {
-                    message: 'There must be no space before "{ lorem, ipsum, dolor }" parameter type annotation colon.'
-                }
-            ],
+            errors: [{message: 'There must be no space before "{ lorem, ipsum, dolor }" parameter type annotation colon.'}],
             output: 'async function foo({ lorem, ipsum, dolor }: SomeType) {}'
         },
         {
             code: '({ lorem, ipsum, dolor } : SomeType) => {}',
-            errors: [
-                {
-                    message: 'There must be no space before "{ lorem, ipsum, dolor }" parameter type annotation colon.'
-                }
-            ],
+            errors: [{message: 'There must be no space before "{ lorem, ipsum, dolor }" parameter type annotation colon.'}],
             output: '({ lorem, ipsum, dolor }: SomeType) => {}'
         },
         {
             code: '(foo : { a: string, b: number }) => {}',
-            errors: [
-                {
-                    message: 'There must be no space before "foo" parameter type annotation colon.'
-                }
-            ],
+            errors: [{message: 'There must be no space before "foo" parameter type annotation colon.'}],
             output: '(foo: { a: string, b: number }) => {}'
         },
         {
             code: '({ a, b } : { a: string, b: number }) => {}',
-            errors: [
-                {
-                    message: 'There must be no space before "{ a, b }" parameter type annotation colon.'
-                }
-            ],
+            errors: [{message: 'There must be no space before "{ a, b }" parameter type annotation colon.'}],
             output: '({ a, b }: { a: string, b: number }) => {}'
         },
         {
             code: '([ a, b ] : string[]) => {}',
-            errors: [
-                {
-                    message: 'There must be no space before "[ a, b ]" parameter type annotation colon.'
-                }
-            ],
+            errors: [{message: 'There must be no space before "[ a, b ]" parameter type annotation colon.'}],
             output: '([ a, b ]: string[]) => {}'
         },
         {
             code: 'type X = { foo : string }',
-            errors: [
-                {
-                    message: 'There must be no space before "foo" type annotation colon.'
-                }
-            ],
+            errors: [{message: 'There must be no space before "foo" type annotation colon.'}],
             output: 'type X = { foo: string }'
         },
         {
             code: 'type X = { foo : string }',
-            errors: [
-                {
-                    message: 'There must be no space before "foo" type annotation colon.'
-                }
-            ],
-            options: [
-                'never'
-            ],
+            errors: [{message: 'There must be no space before "foo" type annotation colon.'}],
+            options: ['never'],
             output: 'type X = { foo: string }'
         },
         {
             code: 'type X = { foo: string }',
-            errors: [
-                {
-                    message: 'There must be a space before "foo" type annotation colon.'
-                }
-            ],
-            options: [
-                'always'
-            ],
+            errors: [{message: 'There must be a space before "foo" type annotation colon.'}],
+            options: ['always'],
             output: 'type X = { foo : string }'
         },
         {
             code: 'type X = { foo  : string }',
-            errors: [
-                {
-                    message: 'There must be 1 space before "foo" type annotation colon.'
-                }
-            ],
-            options: [
-                'always'
-            ],
+            errors: [{message: 'There must be 1 space before "foo" type annotation colon.'}],
+            options: ['always'],
             output: 'type X = { foo : string }'
         },
         {
             code: 'type X = { foo? : string }',
-            errors: [
-                {
-                    message: 'There must be no space before "foo" type annotation colon.'
-                }
-            ],
+            errors: [{message: 'There must be no space before "foo" type annotation colon.'}],
             output: 'type X = { foo?: string }'
         },
         {
             code: 'type X = { foo?: string }',
-            errors: [
-                {
-                    message: 'There must be a space before "foo" type annotation colon.'
-                }
-            ],
-            options: [
-                'always'
-            ],
+            errors: [{message: 'There must be a space before "foo" type annotation colon.'}],
+            options: ['always'],
             output: 'type X = { foo? : string }'
         },
         {
             code: 'type X = { foo?  : string }',
-            errors: [
-                {
-                    message: 'There must be 1 space before "foo" type annotation colon.'
-                }
-            ],
-            options: [
-                'always'
-            ],
+            errors: [{message: 'There must be 1 space before "foo" type annotation colon.'}],
+            options: ['always'],
             output: 'type X = { foo? : string }'
         },
         {
             code: 'type X = { foo   ?: string }',
-            errors: [
-                {
-                    message: 'There must be a space before "foo" type annotation colon.'
-                }
-            ],
-            options: [
-                'always'
-            ],
+            errors: [{message: 'There must be a space before "foo" type annotation colon.'}],
+            options: ['always'],
             output: 'type X = { foo   ? : string }'
         },
         {
             code: 'class X { foo :string }',
-            errors: [
-                {
-                    message: 'There must be no space before "foo" class property type annotation colon.'
-                }
-            ],
+            errors: [{message: 'There must be no space before "foo" class property type annotation colon.'}],
             output: 'class X { foo:string }'
         },
         {
             code: 'class X { foo: string }',
-            errors: [
-                {
-                    message: 'There must be a space before "foo" class property type annotation colon.'
-                }
-            ],
-            options: [
-                'always'
-            ],
+            errors: [{message: 'There must be a space before "foo" class property type annotation colon.'}],
+            options: ['always'],
             output: 'class X { foo : string }'
         },
         {
             code: 'class X { foo :?string }',
-            errors: [
-                {
-                    message: 'There must be no space before "foo" class property type annotation colon.'
-                }
-            ],
+            errors: [{message: 'There must be no space before "foo" class property type annotation colon.'}],
             output: 'class X { foo:?string }'
         },
         {
             code: 'class X { foo: ?string }',
-            errors: [
-                {
-                    message: 'There must be a space before "foo" class property type annotation colon.'
-                }
-            ],
-            options: [
-                'always'
-            ],
+            errors: [{message: 'There must be a space before "foo" class property type annotation colon.'}],
+            options: ['always'],
             output: 'class X { foo : ?string }'
         },
         {
             code: 'type X = (foo :string) => string;',
-            errors: [
-                {
-                    message: 'There must be no space before "foo" parameter type annotation colon.'
-                }
-            ],
+            errors: [{message: 'There must be no space before "foo" parameter type annotation colon.'}],
             output: 'type X = (foo:string) => string;'
         },
         {
             code: 'type X = (foo:string) => string;',
-            errors: [
-                {
-                    message: 'There must be a space before "foo" parameter type annotation colon.'
-                }
-            ],
-            options: [
-                'always'
-            ],
+            errors: [{message: 'There must be a space before "foo" parameter type annotation colon.'}],
+            options: ['always'],
             output: 'type X = (foo :string) => string;'
         },
         {
             code: 'type X = (foo  :string) => string;',
-            errors: [
-                {
-                    message: 'There must be 1 space before "foo" parameter type annotation colon.'
-                }
-            ],
-            options: [
-                'always'
-            ],
+            errors: [{message: 'There must be 1 space before "foo" parameter type annotation colon.'}],
+            options: ['always'],
             output: 'type X = (foo :string) => string;'
         },
         {
             code: 'type X = (foo? :string) => string;',
-            errors: [
-                {
-                    message: 'There must be no space before "foo" parameter type annotation colon.'
-                }
-            ],
+            errors: [{message: 'There must be no space before "foo" parameter type annotation colon.'}],
             output: 'type X = (foo?:string) => string;'
         },
         {
             code: 'type X = (foo?     :string) => string;',
-            errors: [
-                {
-                    message: 'There must be no space before "foo" parameter type annotation colon.'
-                }
-            ],
+            errors: [{message: 'There must be no space before "foo" parameter type annotation colon.'}],
             output: 'type X = (foo?:string) => string;'
         },
         {
             code: 'type X = (foo?:string) => string;',
-            errors: [
-                {
-                    message: 'There must be a space before "foo" parameter type annotation colon.'
-                }
-            ],
-            options: [
-                'always'
-            ],
+            errors: [{message: 'There must be a space before "foo" parameter type annotation colon.'}],
+            options: ['always'],
             output: 'type X = (foo? :string) => string;'
         },
         {
             code: 'type X = (foo? :?string) => string;',
-            errors: [
-                {
-                    message: 'There must be no space before "foo" parameter type annotation colon.'
-                }
-            ],
+            errors: [{message: 'There must be no space before "foo" parameter type annotation colon.'}],
             output: 'type X = (foo?:?string) => string;'
         },
         {
@@ -456,27 +266,19 @@ export default {
         },
         {
             code: '(foo: string) => {}',
-            options: [
-                'never'
-            ]
+            options: ['never']
         },
         {
             code: '(foo : string) => {}',
-            options: [
-                'always'
-            ]
+            options: ['always']
         },
         {
             code: '(foo? : string) => {}',
-            options: [
-                'always'
-            ]
+            options: ['always']
         },
         {
             code: '(foo ? : string) => {}',
-            options: [
-                'always'
-            ]
+            options: ['always']
         },
         {
             code: '(foo  ? : string) => {}',
@@ -487,18 +289,14 @@ export default {
         },
         {
             code: 'function x(foo : string) {}',
-            options: [
-                'always'
-            ]
+            options: ['always']
         },
         {
             code: 'var x = function (foo: string) {}'
         },
         {
             code: 'var x = function (foo : string) {}',
-            options: [
-                'always'
-            ]
+            options: ['always']
         },
         {
             code: 'class X { foo({ bar }: Props = this.props) {} }'
@@ -508,9 +306,7 @@ export default {
         },
         {
             code: 'class Foo { constructor(foo : string ) {} }',
-            options: [
-                'always'
-            ]
+            options: ['always']
         },
         {
             code: 'async function foo({ lorem, ipsum, dolor }: SomeType) {}'
@@ -532,9 +328,7 @@ export default {
         },
         {
             code: '() : { a : number, b : string } => {}',
-            options: [
-                'always'
-            ]
+            options: ['always']
         },
         {
             code: '([ a, b ]: string[]) => {}'
@@ -544,9 +338,7 @@ export default {
         },
         {
             code: 'type X = { foo : string }',
-            options: [
-                'always'
-            ]
+            options: ['always']
         },
         {
             code: 'type X = { foo?: string }'
@@ -556,9 +348,7 @@ export default {
         },
         {
             code: 'type X = { foo? : string }',
-            options: [
-                'always'
-            ]
+            options: ['always']
         },
         {
             code: 'class Foo { bar }'
@@ -577,9 +367,7 @@ export default {
         },
         {
             code: 'class Foo { bar : string }',
-            options: [
-                'always'
-            ]
+            options: ['always']
         },
         {
             code: 'type X = (foo:string) => number;'
@@ -601,15 +389,11 @@ export default {
         },
         {
             code: 'type X = (foo? : string) => number',
-            options: [
-                'always'
-            ]
+            options: ['always']
         },
         {
             code: 'type X = (foo? : ?string) => number',
-            options: [
-                'always'
-            ]
+            options: ['always']
         },
         {
             code: 'class X { static foo:number }'

--- a/tests/rules/assertions/spaceBeforeTypeColon.js
+++ b/tests/rules/assertions/spaceBeforeTypeColon.js
@@ -1,4 +1,6 @@
-export default {
+import _ from 'lodash';
+
+const ARROW_FUNCTION_PARAMS = {
     invalid: [
         {
             code: '(foo : string) => {}',
@@ -43,6 +45,91 @@ export default {
             output: '(foo  ? : string) => {}'
         },
         {
+            code: '({ lorem, ipsum, dolor } : SomeType) => {}',
+            errors: [{message: 'There must be no space before "{ lorem, ipsum, dolor }" parameter type annotation colon.'}],
+            output: '({ lorem, ipsum, dolor }: SomeType) => {}'
+        },
+        {
+            code: '(foo : { a: string, b: number }) => {}',
+            errors: [{message: 'There must be no space before "foo" parameter type annotation colon.'}],
+            output: '(foo: { a: string, b: number }) => {}'
+        },
+        {
+            code: '({ a, b } : { a: string, b: number }) => {}',
+            errors: [{message: 'There must be no space before "{ a, b }" parameter type annotation colon.'}],
+            output: '({ a, b }: { a: string, b: number }) => {}'
+        },
+        {
+            code: '([ a, b ] : string[]) => {}',
+            errors: [{message: 'There must be no space before "[ a, b ]" parameter type annotation colon.'}],
+            output: '([ a, b ]: string[]) => {}'
+        }
+    ],
+    valid: [
+        {
+            code: '(foo) => {}'
+        },
+        {
+            code: '(foo: string) => {}'
+        },
+        {
+            code: '(foo?: string) => {}'
+        },
+        {
+            code: '(foo ?: string) => {}'
+        },
+        {
+            code: '(foo: string) => {}',
+            options: ['never']
+        },
+        {
+            code: '(foo : string) => {}',
+            options: ['always']
+        },
+        {
+            code: '(foo? : string) => {}',
+            options: ['always']
+        },
+        {
+            code: '(foo ? : string) => {}',
+            options: ['always']
+        },
+        {
+            code: '(foo  ? : string) => {}',
+            options: ['always']
+        },
+        {
+            code: '({ lorem, ipsum, dolor }: SomeType) => {}'
+        },
+        {
+            code: '(foo: { a: string, b: number }) => {}'
+        },
+        {
+            code: '({ a, b }: ?{ a: string, b: number }) => {}'
+        },
+        {
+            code: '(): { a: number, b: string } => {}'
+        },
+        {
+            code: '() : { a : number, b : string } => {}',
+            options: ['always']
+        },
+        {
+            code: '([ a, b ]: string[]) => {}'
+        }
+    ]
+};
+
+const ARROW_FUNCTION_RETURN = {
+    invalid: [
+    ],
+    valid: [
+    ]
+};
+
+const FUNCTION_PARAMS = {
+    invalid: [
+        {
             code: 'function x(foo : string) {}',
             errors: [{message: 'There must be no space before "foo" parameter type annotation colon.'}],
             output: 'function x(foo: string) {}'
@@ -79,95 +166,51 @@ export default {
             code: 'async function foo({ lorem, ipsum, dolor } : SomeType) {}',
             errors: [{message: 'There must be no space before "{ lorem, ipsum, dolor }" parameter type annotation colon.'}],
             output: 'async function foo({ lorem, ipsum, dolor }: SomeType) {}'
+        }
+    ],
+    valid: [
+        {
+            code: 'function x(foo: string) {}'
         },
         {
-            code: '({ lorem, ipsum, dolor } : SomeType) => {}',
-            errors: [{message: 'There must be no space before "{ lorem, ipsum, dolor }" parameter type annotation colon.'}],
-            output: '({ lorem, ipsum, dolor }: SomeType) => {}'
+            code: 'function x(foo : string) {}',
+            options: ['always']
         },
         {
-            code: '(foo : { a: string, b: number }) => {}',
-            errors: [{message: 'There must be no space before "foo" parameter type annotation colon.'}],
-            output: '(foo: { a: string, b: number }) => {}'
+            code: 'var x = function (foo: string) {}'
         },
         {
-            code: '({ a, b } : { a: string, b: number }) => {}',
-            errors: [{message: 'There must be no space before "{ a, b }" parameter type annotation colon.'}],
-            output: '({ a, b }: { a: string, b: number }) => {}'
+            code: 'var x = function (foo : string) {}',
+            options: ['always']
         },
         {
-            code: '([ a, b ] : string[]) => {}',
-            errors: [{message: 'There must be no space before "[ a, b ]" parameter type annotation colon.'}],
-            output: '([ a, b ]: string[]) => {}'
+            code: 'class X { foo({ bar }: Props = this.props) {} }'
         },
         {
-            code: 'type X = { foo : string }',
-            errors: [{message: 'There must be no space before "foo" type annotation colon.'}],
-            output: 'type X = { foo: string }'
+            code: 'class Foo { constructor(foo: string ) {} }'
         },
         {
-            code: 'type X = { foo : string }',
-            errors: [{message: 'There must be no space before "foo" type annotation colon.'}],
-            options: ['never'],
-            output: 'type X = { foo: string }'
+            code: 'class Foo { constructor(foo : string ) {} }',
+            options: ['always']
         },
         {
-            code: 'type X = { foo: string }',
-            errors: [{message: 'There must be a space before "foo" type annotation colon.'}],
-            options: ['always'],
-            output: 'type X = { foo : string }'
+            code: 'async function foo({ lorem, ipsum, dolor }: SomeType) {}'
         },
         {
-            code: 'type X = { foo  : string }',
-            errors: [{message: 'There must be 1 space before "foo" type annotation colon.'}],
-            options: ['always'],
-            output: 'type X = { foo : string }'
-        },
-        {
-            code: 'type X = { foo? : string }',
-            errors: [{message: 'There must be no space before "foo" type annotation colon.'}],
-            output: 'type X = { foo?: string }'
-        },
-        {
-            code: 'type X = { foo?: string }',
-            errors: [{message: 'There must be a space before "foo" type annotation colon.'}],
-            options: ['always'],
-            output: 'type X = { foo? : string }'
-        },
-        {
-            code: 'type X = { foo?  : string }',
-            errors: [{message: 'There must be 1 space before "foo" type annotation colon.'}],
-            options: ['always'],
-            output: 'type X = { foo? : string }'
-        },
-        {
-            code: 'type X = { foo   ?: string }',
-            errors: [{message: 'There must be a space before "foo" type annotation colon.'}],
-            options: ['always'],
-            output: 'type X = { foo   ? : string }'
-        },
-        {
-            code: 'class X { foo :string }',
-            errors: [{message: 'There must be no space before "foo" class property type annotation colon.'}],
-            output: 'class X { foo:string }'
-        },
-        {
-            code: 'class X { foo: string }',
-            errors: [{message: 'There must be a space before "foo" class property type annotation colon.'}],
-            options: ['always'],
-            output: 'class X { foo : string }'
-        },
-        {
-            code: 'class X { foo :?string }',
-            errors: [{message: 'There must be no space before "foo" class property type annotation colon.'}],
-            output: 'class X { foo:?string }'
-        },
-        {
-            code: 'class X { foo: ?string }',
-            errors: [{message: 'There must be a space before "foo" class property type annotation colon.'}],
-            options: ['always'],
-            output: 'class X { foo : ?string }'
-        },
+            code: 'function x({ a, b }: { a: string, b: number }) {}'
+        }
+    ]
+};
+
+const FUNCTION_RETURN = {
+    invalid: [
+    ],
+    valid: [
+    ]
+};
+
+const FUNCTION_TYPE_PARAMS = {
+    invalid: [
         {
             code: 'type X = (foo :string) => string;',
             errors: [{message: 'There must be no space before "foo" parameter type annotation colon.'}],
@@ -205,6 +248,61 @@ export default {
             code: 'type X = (foo? :?string) => string;',
             errors: [{message: 'There must be no space before "foo" parameter type annotation colon.'}],
             output: 'type X = (foo?:?string) => string;'
+        }
+    ],
+    valid: [
+        {
+            code: 'type X = (foo:string) => number;'
+        },
+        {
+            code: 'type X = (foo: string) => number;'
+        },
+        {
+            code: 'type X = (foo: ?string) => number;'
+        },
+        {
+            code: 'type X = (foo?: string) => number;'
+        },
+        {
+            code: 'type X = (foo?: ?string) => number;'
+        },
+        {
+            code: 'type X = (foo   ?: string) => number;'
+        },
+        {
+            code: 'type X = (foo? : string) => number',
+            options: ['always']
+        },
+        {
+            code: 'type X = (foo? : ?string) => number',
+            options: ['always']
+        }
+    ]
+};
+
+const CLASS_PROPERTIES = {
+    invalid: [
+        {
+            code: 'class X { foo :string }',
+            errors: [{message: 'There must be no space before "foo" class property type annotation colon.'}],
+            output: 'class X { foo:string }'
+        },
+        {
+            code: 'class X { foo: string }',
+            errors: [{message: 'There must be a space before "foo" class property type annotation colon.'}],
+            options: ['always'],
+            output: 'class X { foo : string }'
+        },
+        {
+            code: 'class X { foo :?string }',
+            errors: [{message: 'There must be no space before "foo" class property type annotation colon.'}],
+            output: 'class X { foo:?string }'
+        },
+        {
+            code: 'class X { foo: ?string }',
+            errors: [{message: 'There must be a space before "foo" class property type annotation colon.'}],
+            options: ['always'],
+            output: 'class X { foo : ?string }'
         },
         {
             code: 'class X { static foo : number }',
@@ -253,104 +351,6 @@ export default {
     ],
     valid: [
         {
-            code: '(foo) => {}'
-        },
-        {
-            code: '(foo: string) => {}'
-        },
-        {
-            code: '(foo?: string) => {}'
-        },
-        {
-            code: '(foo ?: string) => {}'
-        },
-        {
-            code: '(foo: string) => {}',
-            options: ['never']
-        },
-        {
-            code: '(foo : string) => {}',
-            options: ['always']
-        },
-        {
-            code: '(foo? : string) => {}',
-            options: ['always']
-        },
-        {
-            code: '(foo ? : string) => {}',
-            options: ['always']
-        },
-        {
-            code: '(foo  ? : string) => {}',
-            options: ['always']
-        },
-        {
-            code: 'function x(foo: string) {}'
-        },
-        {
-            code: 'function x(foo : string) {}',
-            options: ['always']
-        },
-        {
-            code: 'var x = function (foo: string) {}'
-        },
-        {
-            code: 'var x = function (foo : string) {}',
-            options: ['always']
-        },
-        {
-            code: 'class X { foo({ bar }: Props = this.props) {} }'
-        },
-        {
-            code: 'class Foo { constructor(foo: string ) {} }'
-        },
-        {
-            code: 'class Foo { constructor(foo : string ) {} }',
-            options: ['always']
-        },
-        {
-            code: 'async function foo({ lorem, ipsum, dolor }: SomeType) {}'
-        },
-        {
-            code: '({ lorem, ipsum, dolor }: SomeType) => {}'
-        },
-        {
-            code: '(foo: { a: string, b: number }) => {}'
-        },
-        {
-            code: '({ a, b }: ?{ a: string, b: number }) => {}'
-        },
-        {
-            code: 'function x({ a, b }: { a: string, b: number }) {}'
-        },
-        {
-            code: '(): { a: number, b: string } => {}'
-        },
-        {
-            code: '() : { a : number, b : string } => {}',
-            options: ['always']
-        },
-        {
-            code: '([ a, b ]: string[]) => {}'
-        },
-        {
-            code: 'type X = { foo: string }'
-        },
-        {
-            code: 'type X = { foo : string }',
-            options: ['always']
-        },
-        {
-            code: 'type X = { foo?: string }'
-        },
-        {
-            code: 'type X = { foo   ?: string }'
-        },
-        {
-            code: 'type X = { foo? : string }',
-            options: ['always']
-        },
-        {
             code: 'class Foo { bar }'
         },
         {
@@ -367,32 +367,6 @@ export default {
         },
         {
             code: 'class Foo { bar : string }',
-            options: ['always']
-        },
-        {
-            code: 'type X = (foo:string) => number;'
-        },
-        {
-            code: 'type X = (foo: string) => number;'
-        },
-        {
-            code: 'type X = (foo: ?string) => number;'
-        },
-        {
-            code: 'type X = (foo?: string) => number;'
-        },
-        {
-            code: 'type X = (foo?: ?string) => number;'
-        },
-        {
-            code: 'type X = (foo   ?: string) => number;'
-        },
-        {
-            code: 'type X = (foo? : string) => number',
-            options: ['always']
-        },
-        {
-            code: 'type X = (foo? : ?string) => number',
             options: ['always']
         },
         {
@@ -424,4 +398,89 @@ export default {
             options: ['always']
         }
     ]
+};
+
+const OBJECT_TYPE_PROPERTIES = {
+    invalid: [
+        {
+            code: 'type X = { foo : string }',
+            errors: [{message: 'There must be no space before "foo" type annotation colon.'}],
+            output: 'type X = { foo: string }'
+        },
+        {
+            code: 'type X = { foo : string }',
+            errors: [{message: 'There must be no space before "foo" type annotation colon.'}],
+            options: ['never'],
+            output: 'type X = { foo: string }'
+        },
+        {
+            code: 'type X = { foo: string }',
+            errors: [{message: 'There must be a space before "foo" type annotation colon.'}],
+            options: ['always'],
+            output: 'type X = { foo : string }'
+        },
+        {
+            code: 'type X = { foo  : string }',
+            errors: [{message: 'There must be 1 space before "foo" type annotation colon.'}],
+            options: ['always'],
+            output: 'type X = { foo : string }'
+        },
+        {
+            code: 'type X = { foo? : string }',
+            errors: [{message: 'There must be no space before "foo" type annotation colon.'}],
+            output: 'type X = { foo?: string }'
+        },
+        {
+            code: 'type X = { foo?: string }',
+            errors: [{message: 'There must be a space before "foo" type annotation colon.'}],
+            options: ['always'],
+            output: 'type X = { foo? : string }'
+        },
+        {
+            code: 'type X = { foo?  : string }',
+            errors: [{message: 'There must be 1 space before "foo" type annotation colon.'}],
+            options: ['always'],
+            output: 'type X = { foo? : string }'
+        },
+        {
+            code: 'type X = { foo   ?: string }',
+            errors: [{message: 'There must be a space before "foo" type annotation colon.'}],
+            options: ['always'],
+            output: 'type X = { foo   ? : string }'
+        }
+    ],
+    valid: [
+        {
+            code: 'type X = { foo: string }'
+        },
+        {
+            code: 'type X = { foo : string }',
+            options: ['always']
+        },
+        {
+            code: 'type X = { foo?: string }'
+        },
+        {
+            code: 'type X = { foo   ?: string }'
+        },
+        {
+            code: 'type X = { foo? : string }',
+            options: ['always']
+        }
+    ]
+};
+
+const ALL = [
+    ARROW_FUNCTION_PARAMS,
+    ARROW_FUNCTION_RETURN,
+    FUNCTION_PARAMS,
+    FUNCTION_RETURN,
+    FUNCTION_TYPE_PARAMS,
+    CLASS_PROPERTIES,
+    OBJECT_TYPE_PROPERTIES
+];
+
+export default {
+    invalid: _.flatMap(ALL, (rules) => { return rules.invalid; }),
+    valid: _.flatMap(ALL, (rules) => { return rules.valid; })
 };


### PR DESCRIPTION
Fixes #71

The first two commits here just re-structure the "spacing" tests to keep valid/invalid rules for each supported node type together. So when adding support for a certain syntax (like the next commits do), it's grouped together.

Second two commits are the fixes.