### PR TITLE
Clarify excludeArrowFunction option in docs

### DIFF
--- a/.README/rules/require-parameter-type.md
+++ b/.README/rules/require-parameter-type.md
@@ -6,7 +6,7 @@ Requires that all function parameters have type annotations.
 
 You can skip all arrow functions by providing the `excludeArrowFunctions` option with `true`.
 
-Alternatively, you can want to exclude only function expressions (e.g. `x => x * 2`). Provide `excludeArrowFunctions` with `expressionsOnly` for this. 
+Alternatively, you can want to exclude only concise arrow functions (e.g. `x => x * 2`). Provide `excludeArrowFunctions` with `expressionsOnly` for this.
 
 ```js
 {

--- a/.README/rules/require-return-type.md
+++ b/.README/rules/require-return-type.md
@@ -6,7 +6,7 @@ Requires that functions have return type annotation.
 
 You can skip all arrow functions by providing the `excludeArrowFunctions` option with `true`.
 
-Alternatively, you can want to exclude only function expressions (e.g. `() => 2`). Provide `excludeArrowFunctions` with `expressionsOnly` for this. 
+Alternatively, you can want to exclude only concise arrow function (e.g. `() => 2`). Provide `excludeArrowFunctions` with `expressionsOnly` for this.
 
 ```js
 {

--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ Requires that all function parameters have type annotations.
 
 You can skip all arrow functions by providing the `excludeArrowFunctions` option with `true`.
 
-Alternatively, you can want to exclude only function expressions (e.g. `x => x * 2`). Provide `excludeArrowFunctions` with `expressionsOnly` for this. 
+Alternatively, you can want to exclude only concise arrow functions (e.g. `x => x * 2`). Provide `excludeArrowFunctions` with `expressionsOnly` for this.
 
 ```js
 {
@@ -329,7 +329,7 @@ Requires that functions have return type annotation.
 
 You can skip all arrow functions by providing the `excludeArrowFunctions` option with `true`.
 
-Alternatively, you can want to exclude only function expressions (e.g. `() => 2`). Provide `excludeArrowFunctions` with `expressionsOnly` for this. 
+Alternatively, you can want to exclude only concise arrow function (e.g. `() => 2`). Provide `excludeArrowFunctions` with `expressionsOnly` for this.
 
 ```js
 {


### PR DESCRIPTION
just the clarification part of #59, i don't feel there's much value yet in renaming the value.