### PR TITLE
New rule: Space before generic type annotation bracket

### DIFF
--- a/.README/README.md
+++ b/.README/README.md
@@ -93,6 +93,7 @@ When `true`, only checks files with a [`@flow` annotation](http://flowtype.org/d
 {"gitdown": "include", "file": "./rules/require-valid-file-annotation.md"}
 {"gitdown": "include", "file": "./rules/space-after-type-colon.md"}
 {"gitdown": "include", "file": "./rules/space-before-type-colon.md"}
+{"gitdown": "include", "file": "./rules/space-before-generic-bracket.md"}
 {"gitdown": "include", "file": "./rules/type-id-match.md"}
 {"gitdown": "include", "file": "./rules/use-flow-type.md"}
 {"gitdown": "include", "file": "./rules/valid-syntax.md"}

--- a/.README/rules/space-before-generic-bracket.md
+++ b/.README/rules/space-before-generic-bracket.md
@@ -1,0 +1,11 @@
+### `space-before-generic-bracket`
+
+_The `--fix` option on the command line automatically fixes problems reported by this rule._
+
+Enforces consistent spacing before the opening `<` of generic type annotation parameters.
+
+This rule takes one argument. If it is `'never'` then a problem is raised when there is a space before the `<`. If it is `'always'` then a problem is raised when there is no space before the `<`.
+
+The default value is `'never'`.
+
+<!-- assertions spaceBeforeGenericBracket -->

--- a/README.md
+++ b/README.md
@@ -558,6 +558,12 @@ The following patterns are considered problems:
 // @floweeeeeee
 // Message: Malformed flow file annotation.
 
+// @NoFlow
+// Message: Malformed flow file annotation.
+
+// @nofloweeeeeee
+// Message: Malformed flow file annotation.
+
 // Options: ["always"]
 a;
 // Message: Flow file annotation is missing.
@@ -588,6 +594,9 @@ a;
 // @flow
 // @FLow
 
+// @noflow
+a;
+
 // Options: ["always"]
 a;
 ```
@@ -609,21 +618,6 @@ The following patterns are considered problems:
 (foo: string) => {}
 // Message: There must be no space after "foo" parameter type annotation colon.
 
-// Options: ["never"]
-export default function (foo: string) {}
-// Message: There must be no space after "foo" parameter type annotation colon.
-
-// Options: ["never"]
-function foo (foo: string) {}
-// Message: There must be no space after "foo" parameter type annotation colon.
-
-// Options: ["always"]
-(foo:string) => {}
-// Message: There must be a space after "foo" parameter type annotation colon.
-
-function foo (foo:string) {}
-// Message: There must be a space after "foo" parameter type annotation colon.
-
 // Options: ["always"]
 (foo:  string) => {}
 // Message: There must be 1 space after "foo" parameter type annotation colon.
@@ -639,6 +633,18 @@ function foo (foo:string) {}
 // Options: ["always"]
 (foo:  (() => void)) => {}
 // Message: There must be 1 space after "foo" parameter type annotation colon.
+
+({ lorem, ipsum, dolor } :   SomeType) => {}
+// Message: There must be 1 space after "{ lorem, ipsum, dolor }" parameter type annotation colon.
+
+(foo:{ a: string, b: number }) => {}
+// Message: There must be a space after "foo" parameter type annotation colon.
+
+({ a, b } :{ a: string, b: number }) => {}
+// Message: There must be a space after "{ a, b }" parameter type annotation colon.
+
+([ a, b ] :string[]) => {}
+// Message: There must be a space after "[ a, b ]" parameter type annotation colon.
 
 // Options: ["always"]
 ():Object => {}
@@ -664,47 +670,52 @@ function foo (foo:string) {}
 ():  (() => void) => {}
 // Message: There must be 1 space after return type colon.
 
+// Options: ["never"]
+export default function (foo: string) {}
+// Message: There must be no space after "foo" parameter type annotation colon.
+
+// Options: ["never"]
+function foo (foo: string) {}
+// Message: There must be no space after "foo" parameter type annotation colon.
+
+// Options: ["always"]
+(foo:string) => {}
+// Message: There must be a space after "foo" parameter type annotation colon.
+
+function foo (foo:string) {}
+// Message: There must be a space after "foo" parameter type annotation colon.
+
 async function foo({ lorem, ipsum, dolor }:SomeType) {}
 // Message: There must be a space after "{ lorem, ipsum, dolor }" parameter type annotation colon.
 
-({ lorem, ipsum, dolor } :   SomeType) => {}
-// Message: There must be 1 space after "{ lorem, ipsum, dolor }" parameter type annotation colon.
-
-(foo:{ a: string, b: number }) => {}
+type X = (foo:number) => string
 // Message: There must be a space after "foo" parameter type annotation colon.
 
-({ a, b } :{ a: string, b: number }) => {}
-// Message: There must be a space after "{ a, b }" parameter type annotation colon.
+// Options: ["never"]
+type X = (foo: number) => string
+// Message: There must be no space after "foo" parameter type annotation colon.
 
-([ a, b ] :string[]) => {}
-// Message: There must be a space after "[ a, b ]" parameter type annotation colon.
+type X = (foo:  number) => string
+// Message: There must be 1 space after "foo" parameter type annotation colon.
 
-type X = { foo:string }
-// Message: There must be a space after "foo" type annotation colon.
+type X = (foo:?number) => string
+// Message: There must be a space after "foo" parameter type annotation colon.
 
-// Options: ["always"]
-type X = { foo:string }
-// Message: There must be a space after "foo" type annotation colon.
+type X = (foo:(number)) => string
+// Message: There must be a space after "foo" parameter type annotation colon.
+
+type X = (foo:((number))) => string
+// Message: There must be a space after "foo" parameter type annotation colon.
+
+type X = (foo:  ((number))) => string
+// Message: There must be 1 space after "foo" parameter type annotation colon.
 
 // Options: ["never"]
-type X = { foo: string }
-// Message: There must be no space after "foo" type annotation colon.
+type X = (foo: ((number))) => string
+// Message: There must be no space after "foo" parameter type annotation colon.
 
-type X = { foo:  string }
-// Message: There must be 1 space after "foo" type annotation colon.
-
-type X = { foo?:string }
-// Message: There must be a space after "foo" type annotation colon.
-
-// Options: ["never"]
-type X = { foo?: string }
-// Message: There must be no space after "foo" type annotation colon.
-
-type X = { foo?:?string }
-// Message: There must be a space after "foo" type annotation colon.
-
-type X = { foo?:  ?string }
-// Message: There must be 1 space after "foo" type annotation colon.
+type X = (foo:?(number)) => string
+// Message: There must be a space after "foo" parameter type annotation colon.
 
 class X { foo:string }
 // Message: There must be a space after "foo" class property type annotation colon.
@@ -719,19 +730,6 @@ class X { foo:?string }
 // Options: ["never"]
 class X { foo: ?string }
 // Message: There must be no space after "foo" class property type annotation colon.
-
-type X = (foo:number) => string
-// Message: There must be a space after "foo" parameter type annotation colon.
-
-// Options: ["never"]
-type X = (foo: number) => string
-// Message: There must be no space after "foo" parameter type annotation colon.
-
-type X = (foo:  number) => string
-// Message: There must be 1 space after "foo" parameter type annotation colon.
-
-type X = (foo:?number) => string
-// Message: There must be a space after "foo" parameter type annotation colon.
 
 class X { static foo:number }
 // Message: There must be a space after "foo" class property type annotation colon.
@@ -760,6 +758,49 @@ declare class X { static foo :number }
 // Options: ["never"]
 declare class X { static foo : number }
 // Message: There must be no space after "foo" type annotation colon.
+
+type X = { foo:string }
+// Message: There must be a space after "foo" type annotation colon.
+
+// Options: ["always"]
+type X = { foo:string }
+// Message: There must be a space after "foo" type annotation colon.
+
+// Options: ["never"]
+type X = { foo: string }
+// Message: There must be no space after "foo" type annotation colon.
+
+type X = { foo:  string }
+// Message: There must be 1 space after "foo" type annotation colon.
+
+type X = { foo?:string }
+// Message: There must be a space after "foo" type annotation colon.
+
+// Options: ["never"]
+type X = { foo?: string }
+// Message: There must be no space after "foo" type annotation colon.
+
+type X = { foo?:?string }
+// Message: There must be a space after "foo" type annotation colon.
+
+type X = { foo?:  ?string }
+// Message: There must be 1 space after "foo" type annotation colon.
+
+type Foo = { barType:(string | () => void) }
+// Message: There must be a space after "barType" type annotation colon.
+
+type Foo = { barType:(((string | () => void))) }
+// Message: There must be a space after "barType" type annotation colon.
+
+// Options: ["never"]
+type Foo = { barType: (string | () => void) }
+// Message: There must be no space after "barType" type annotation colon.
+
+type Foo = { barType:  (string | () => void) }
+// Message: There must be 1 space after "barType" type annotation colon.
+
+type Foo = { barType:  ((string | () => void)) }
+// Message: There must be 1 space after "barType" type annotation colon.
 ```
 
 The following patterns are not considered problems:
@@ -769,20 +810,10 @@ The following patterns are not considered problems:
 
 (foo: string) => {}
 
-function x(foo: string) {}
-
-class Foo { constructor(foo: string) {} }
-
 (foo: (string|number)) => {}
 
 // Options: ["never"]
 (foo:string) => {}
-
-// Options: ["never"]
-function x(foo:string) {}
-
-// Options: ["never"]
-class Foo { constructor(foo:string) {} }
 
 // Options: ["always"]
 (foo: string) => {}
@@ -792,6 +823,14 @@ class Foo { constructor(foo:string) {} }
 
 // Options: ["always"]
 (foo: (() => void)) => {}
+
+({ lorem, ipsum, dolor }: SomeType) => {}
+
+(foo: { a: string, b: number }) => {}
+
+({ a, b }: ?{ a: string, b: number }) => {}
+
+([ a, b ]: string[]) => {}
 
 // Options: ["never"]
 ():Object => {}
@@ -823,48 +862,24 @@ class Foo { constructor(foo:string) {} }
 // Options: ["always"]
 (): ( () => void ) => {}
 
-async function foo({ lorem, ipsum, dolor }: SomeType) {}
-
-({ lorem, ipsum, dolor }: SomeType) => {}
-
-(foo: { a: string, b: number }) => {}
-
-({ a, b }: ?{ a: string, b: number }) => {}
-
-function x({ a, b }: { a: string, b: number }) {}
-
 (): { a: number, b: string } => {}
 
 // Options: ["never"]
 () :{ a:number, b:string } => {}
 
-([ a, b ]: string[]) => {}
+function x(foo: string) {}
 
-type X = { foo: string }
-
-// Options: ["never"]
-type X = { foo:string }
-
-type X = { foo?: string }
-
-type X = { foo?: ?string }
+class Foo { constructor(foo: string) {} }
 
 // Options: ["never"]
-type X = { foo?:?string }
-
-class Foo { bar }
-
-class Foo { bar = 3 }
-
-class Foo { bar: string }
-
-class Foo { bar: ?string }
+function x(foo:string) {}
 
 // Options: ["never"]
-class Foo { bar:string }
+class Foo { constructor(foo:string) {} }
 
-// Options: ["never"]
-class Foo { bar:?string }
+async function foo({ lorem, ipsum, dolor }: SomeType) {}
+
+function x({ a, b }: { a: string, b: number }) {}
 
 type X = (foo: number) => string;
 
@@ -882,6 +897,32 @@ type X = (foo:number) => string;
 // Options: ["never"]
 type X = (foo:?{ x:number }) => string;
 
+type X = (foo: (number)) => string
+
+type X = (foo: ((number))) => string
+
+// Options: ["never"]
+type X = (foo:((number))) => string
+
+type X = ?(foo: ((number))) => string
+
+// Options: ["never"]
+type X = ?(foo:((number))) => string
+
+class Foo { bar }
+
+class Foo { bar = 3 }
+
+class Foo { bar: string }
+
+class Foo { bar: ?string }
+
+// Options: ["never"]
+class Foo { bar:string }
+
+// Options: ["never"]
+class Foo { bar:?string }
+
 class X { static foo : number }
 
 // Options: ["never"]
@@ -891,6 +932,28 @@ declare class X { static foo : number }
 
 // Options: ["never"]
 declare class X { static foo :number }
+
+type X = { foo: string }
+
+// Options: ["never"]
+type X = { foo:string }
+
+type X = { foo?: string }
+
+type X = { foo?: ?string }
+
+// Options: ["never"]
+type X = { foo?:?string }
+
+type Foo = { barType: (string | () => void) }
+
+type Foo = { barType: ((string | () => void)) }
+
+// Options: ["never"]
+type Foo = { barType:(string | () => void) }
+
+// Options: ["never"]
+type Foo = { barType:((string | () => void)) }
 ```
 
 
@@ -934,6 +997,18 @@ The following patterns are considered problems:
 (foo  ?: string) => {}
 // Message: There must be a space before "foo" parameter type annotation colon.
 
+({ lorem, ipsum, dolor } : SomeType) => {}
+// Message: There must be no space before "{ lorem, ipsum, dolor }" parameter type annotation colon.
+
+(foo : { a: string, b: number }) => {}
+// Message: There must be no space before "foo" parameter type annotation colon.
+
+({ a, b } : { a: string, b: number }) => {}
+// Message: There must be no space before "{ a, b }" parameter type annotation colon.
+
+([ a, b ] : string[]) => {}
+// Message: There must be no space before "[ a, b ]" parameter type annotation colon.
+
 function x(foo : string) {}
 // Message: There must be no space before "foo" parameter type annotation colon.
 
@@ -958,17 +1033,71 @@ class Foo { constructor(foo: string ) {} }
 async function foo({ lorem, ipsum, dolor } : SomeType) {}
 // Message: There must be no space before "{ lorem, ipsum, dolor }" parameter type annotation colon.
 
-({ lorem, ipsum, dolor } : SomeType) => {}
-// Message: There must be no space before "{ lorem, ipsum, dolor }" parameter type annotation colon.
-
-(foo : { a: string, b: number }) => {}
+type X = (foo :string) => string;
 // Message: There must be no space before "foo" parameter type annotation colon.
 
-({ a, b } : { a: string, b: number }) => {}
-// Message: There must be no space before "{ a, b }" parameter type annotation colon.
+// Options: ["always"]
+type X = (foo:string) => string;
+// Message: There must be a space before "foo" parameter type annotation colon.
 
-([ a, b ] : string[]) => {}
-// Message: There must be no space before "[ a, b ]" parameter type annotation colon.
+// Options: ["always"]
+type X = (foo  :string) => string;
+// Message: There must be 1 space before "foo" parameter type annotation colon.
+
+type X = (foo? :string) => string;
+// Message: There must be no space before "foo" parameter type annotation colon.
+
+type X = (foo?     :string) => string;
+// Message: There must be no space before "foo" parameter type annotation colon.
+
+// Options: ["always"]
+type X = (foo?:string) => string;
+// Message: There must be a space before "foo" parameter type annotation colon.
+
+type X = (foo? :?string) => string;
+// Message: There must be no space before "foo" parameter type annotation colon.
+
+class X { foo :string }
+// Message: There must be no space before "foo" class property type annotation colon.
+
+// Options: ["always"]
+class X { foo: string }
+// Message: There must be a space before "foo" class property type annotation colon.
+
+class X { foo :?string }
+// Message: There must be no space before "foo" class property type annotation colon.
+
+// Options: ["always"]
+class X { foo: ?string }
+// Message: There must be a space before "foo" class property type annotation colon.
+
+class X { static foo : number }
+// Message: There must be no space before "foo" class property type annotation colon.
+
+class X { static foo :number }
+// Message: There must be no space before "foo" class property type annotation colon.
+
+// Options: ["always"]
+class X { static foo: number }
+// Message: There must be a space before "foo" class property type annotation colon.
+
+// Options: ["always"]
+class X { static foo:number }
+// Message: There must be a space before "foo" class property type annotation colon.
+
+declare class Foo { static bar :number; }
+// Message: There must be no space before "bar" type annotation colon.
+
+declare class Foo { static bar : number; }
+// Message: There must be no space before "bar" type annotation colon.
+
+// Options: ["always"]
+declare class Foo { static bar:number; }
+// Message: There must be a space before "bar" type annotation colon.
+
+// Options: ["always"]
+declare class Foo { static bar: number; }
+// Message: There must be a space before "bar" type annotation colon.
 
 type X = { foo : string }
 // Message: There must be no space before "foo" type annotation colon.
@@ -999,72 +1128,6 @@ type X = { foo?  : string }
 // Options: ["always"]
 type X = { foo   ?: string }
 // Message: There must be a space before "foo" type annotation colon.
-
-class X { foo :string }
-// Message: There must be no space before "foo" class property type annotation colon.
-
-// Options: ["always"]
-class X { foo: string }
-// Message: There must be a space before "foo" class property type annotation colon.
-
-class X { foo :?string }
-// Message: There must be no space before "foo" class property type annotation colon.
-
-// Options: ["always"]
-class X { foo: ?string }
-// Message: There must be a space before "foo" class property type annotation colon.
-
-type X = (foo :string) => string;
-// Message: There must be no space before "foo" parameter type annotation colon.
-
-// Options: ["always"]
-type X = (foo:string) => string;
-// Message: There must be a space before "foo" parameter type annotation colon.
-
-// Options: ["always"]
-type X = (foo  :string) => string;
-// Message: There must be 1 space before "foo" parameter type annotation colon.
-
-type X = (foo? :string) => string;
-// Message: There must be no space before "foo" parameter type annotation colon.
-
-type X = (foo?     :string) => string;
-// Message: There must be no space before "foo" parameter type annotation colon.
-
-// Options: ["always"]
-type X = (foo?:string) => string;
-// Message: There must be a space before "foo" parameter type annotation colon.
-
-type X = (foo? :?string) => string;
-// Message: There must be no space before "foo" parameter type annotation colon.
-
-class X { static foo : number }
-// Message: There must be no space before "foo" class property type annotation colon.
-
-class X { static foo :number }
-// Message: There must be no space before "foo" class property type annotation colon.
-
-// Options: ["always"]
-class X { static foo: number }
-// Message: There must be a space before "foo" class property type annotation colon.
-
-// Options: ["always"]
-class X { static foo:number }
-// Message: There must be a space before "foo" class property type annotation colon.
-
-declare class Foo { static bar :number; }
-// Message: There must be no space before "bar" type annotation colon.
-
-declare class Foo { static bar : number; }
-// Message: There must be no space before "bar" type annotation colon.
-
-// Options: ["always"]
-declare class Foo { static bar:number; }
-// Message: There must be a space before "bar" type annotation colon.
-
-// Options: ["always"]
-declare class Foo { static bar: number; }
-// Message: There must be a space before "bar" type annotation colon.
 ```
 
 The following patterns are not considered problems:
@@ -1093,6 +1156,19 @@ The following patterns are not considered problems:
 // Options: ["always"]
 (foo  ? : string) => {}
 
+({ lorem, ipsum, dolor }: SomeType) => {}
+
+(foo: { a: string, b: number }) => {}
+
+({ a, b }: ?{ a: string, b: number }) => {}
+
+(): { a: number, b: string } => {}
+
+// Options: ["always"]
+() : { a : number, b : string } => {}
+
+([ a, b ]: string[]) => {}
+
 function x(foo: string) {}
 
 // Options: ["always"]
@@ -1112,45 +1188,7 @@ class Foo { constructor(foo : string ) {} }
 
 async function foo({ lorem, ipsum, dolor }: SomeType) {}
 
-({ lorem, ipsum, dolor }: SomeType) => {}
-
-(foo: { a: string, b: number }) => {}
-
-({ a, b }: ?{ a: string, b: number }) => {}
-
 function x({ a, b }: { a: string, b: number }) {}
-
-(): { a: number, b: string } => {}
-
-// Options: ["always"]
-() : { a : number, b : string } => {}
-
-([ a, b ]: string[]) => {}
-
-type X = { foo: string }
-
-// Options: ["always"]
-type X = { foo : string }
-
-type X = { foo?: string }
-
-type X = { foo   ?: string }
-
-// Options: ["always"]
-type X = { foo? : string }
-
-class Foo { bar }
-
-class Foo { bar = 3 }
-
-class Foo { bar: string }
-
-class Foo { bar: ?string }
-
-class Foo { bar:?string }
-
-// Options: ["always"]
-class Foo { bar : string }
 
 type X = (foo:string) => number;
 
@@ -1169,6 +1207,19 @@ type X = (foo? : string) => number
 
 // Options: ["always"]
 type X = (foo? : ?string) => number
+
+class Foo { bar }
+
+class Foo { bar = 3 }
+
+class Foo { bar: string }
+
+class Foo { bar: ?string }
+
+class Foo { bar:?string }
+
+// Options: ["always"]
+class Foo { bar : string }
 
 class X { static foo:number }
 
@@ -1189,6 +1240,18 @@ declare class Foo { static bar: number; }
 
 // Options: ["always"]
 declare class Foo { static bar : number; }
+
+type X = { foo: string }
+
+// Options: ["always"]
+type X = { foo : string }
+
+type X = { foo?: string }
+
+type X = { foo   ?: string }
+
+// Options: ["always"]
+type X = { foo? : string }
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
         * [`require-valid-file-annotation`](#eslint-plugin-flowtype-rules-require-valid-file-annotation)
         * [`space-after-type-colon`](#eslint-plugin-flowtype-rules-space-after-type-colon)
         * [`space-before-type-colon`](#eslint-plugin-flowtype-rules-space-before-type-colon)
+        * [`space-before-generic-bracket`](#eslint-plugin-flowtype-rules-space-before-generic-bracket)
         * [`type-id-match`](#eslint-plugin-flowtype-rules-type-id-match)
         * [`use-flow-type`](#eslint-plugin-flowtype-rules-use-flow-type)
         * [`valid-syntax`](#eslint-plugin-flowtype-rules-valid-syntax)
@@ -1252,6 +1253,49 @@ type X = { foo   ?: string }
 
 // Options: ["always"]
 type X = { foo? : string }
+```
+
+
+
+<h3 id="eslint-plugin-flowtype-rules-space-before-generic-bracket"><code>space-before-generic-bracket</code></h3>
+
+_The `--fix` option on the command line automatically fixes problems reported by this rule._
+
+Enforces consistent spacing before the opening `<` of generic type annotation parameters.
+
+This rule takes one argument. If it is `'never'` then a problem is raised when there is a space before the `<`. If it is `'always'` then a problem is raised when there is no space before the `<`.
+
+The default value is `'never'`.
+
+The following patterns are considered problems:
+
+```js
+type X = Promise <string>
+// Message: There must be no space before "Promise" generic type annotation bracket
+
+// Options: ["never"]
+type X = Promise <string>
+// Message: There must be no space before "Promise" generic type annotation bracket
+
+type X = Promise  <string>
+// Message: There must be no space before "Promise" generic type annotation bracket
+
+// Options: ["always"]
+type X = Promise<string>
+// Message: There must be a space before "Promise" generic type annotation bracket
+
+// Options: ["always"]
+type X = Promise  <string>
+// Message: There must be one space before "Promise" generic type annotation bracket
+```
+
+The following patterns are not considered problems:
+
+```js
+type X = Promise<string>
+
+// Options: ["always"]
+type X = Promise <string>
 ```
 
 

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@ import requireParameterType from './rules/requireParameterType';
 import requireReturnType from './rules/requireReturnType';
 import requireValidFileAnnotation from './rules/requireValidFileAnnotation';
 import spaceAfterTypeColon from './rules/spaceAfterTypeColon';
+import spaceBeforeGenericBracket from './rules/spaceBeforeGenericBracket';
 import spaceBeforeTypeColon from './rules/spaceBeforeTypeColon';
 import typeIdMatch from './rules/typeIdMatch';
 import useFlowType from './rules/useFlowType';
@@ -15,6 +16,7 @@ export default {
         'require-return-type': requireReturnType,
         'require-valid-file-annotation': requireValidFileAnnotation,
         'space-after-type-colon': spaceAfterTypeColon,
+        'space-before-generic-bracket': spaceBeforeGenericBracket,
         'space-before-type-colon': spaceBeforeTypeColon,
         'type-id-match': typeIdMatch,
         'use-flow-type': useFlowType,
@@ -25,6 +27,7 @@ export default {
         'require-parameter-type': 0,
         'require-return-type': 0,
         'space-after-type-colon': 0,
+        'space-before-generic-bracket': 0,
         'space-before-type-colon': 0,
         'type-id-match': 0,
         'use-flow-type': 0,

--- a/src/rules/spaceBeforeGenericBracket.js
+++ b/src/rules/spaceBeforeGenericBracket.js
@@ -1,0 +1,47 @@
+import {spacingFixers} from '../utilities';
+
+export default (context) => {
+    const never = (context.options[0] || 'never') === 'never';
+
+    return {
+        GenericTypeAnnotation (node) {
+            const types = node.typeParameters;
+
+            // Promise<foo>
+            // ^^^^^^^^^^^^ GenericTypeAnnotation (with typeParameters)
+            //         ^^^  GenericTypeAnnotation (without typeParameters)
+            if (!types) {
+                return;
+            }
+
+            const spaceBefore = types.start - node.id.end;
+
+            if (never && spaceBefore) {
+                context.report({
+                    data: {name: node.id.name},
+                    fix: spacingFixers.stripSpacesAfter(node.id, spaceBefore),
+                    message: 'There must be no space before "{{name}}" generic type annotation bracket',
+                    node
+                });
+            }
+
+            if (!never && !spaceBefore) {
+                context.report({
+                    data: {name: node.id.name},
+                    fix: spacingFixers.addSpaceAfter(node.id),
+                    message: 'There must be a space before "{{name}}" generic type annotation bracket',
+                    node
+                });
+            }
+
+            if (!never && spaceBefore > 1) {
+                context.report({
+                    data: {name: node.id.name},
+                    fix: spacingFixers.stripSpacesAfter(node.id, spaceBefore - 1),
+                    message: 'There must be one space before "{{name}}" generic type annotation bracket',
+                    node
+                });
+            }
+        }
+    };
+};

--- a/tests/rules/assertions/spaceBeforeGenericBracket.js
+++ b/tests/rules/assertions/spaceBeforeGenericBracket.js
@@ -1,0 +1,41 @@
+export default {
+    invalid: [
+        {
+            code: 'type X = Promise <string>',
+            errors: [{message: 'There must be no space before "Promise" generic type annotation bracket'}],
+            output: 'type X = Promise<string>'
+        },
+        {
+            code: 'type X = Promise <string>',
+            errors: [{message: 'There must be no space before "Promise" generic type annotation bracket'}],
+            options: ['never'],
+            output: 'type X = Promise<string>'
+        },
+        {
+            code: 'type X = Promise  <string>',
+            errors: [{message: 'There must be no space before "Promise" generic type annotation bracket'}],
+            output: 'type X = Promise<string>'
+        },
+        {
+            code: 'type X = Promise<string>',
+            errors: [{message: 'There must be a space before "Promise" generic type annotation bracket'}],
+            options: ['always'],
+            output: 'type X = Promise <string>'
+        },
+        {
+            code: 'type X = Promise  <string>',
+            errors: [{message: 'There must be one space before "Promise" generic type annotation bracket'}],
+            options: ['always'],
+            output: 'type X = Promise <string>'
+        }
+    ],
+    valid: [
+        {
+            code: 'type X = Promise<string>'
+        },
+        {
+            code: 'type X = Promise <string>',
+            options: ['always']
+        }
+    ]
+};

--- a/tests/rules/index.js
+++ b/tests/rules/index.js
@@ -13,6 +13,7 @@ const reportingRules = [
     'require-valid-file-annotation',
     'space-after-type-colon',
     'space-before-type-colon',
+    'space-before-generic-bracket',
     'type-id-match',
     'use-flow-type',
     'valid-syntax'


### PR DESCRIPTION
`space-before-generic-bracket` to enforce spacing before a generic type annotation parameter bracket, defaulting to "never" (no spacing)

e.g. `Promise <string>` vs `Promise<string>`

(first commit updates the readme from previous changes which missed it, second commit is the actual changes)