### PR TITLE
new rule: union & intersection spacing

### DIFF
--- a/.README/README.md
+++ b/.README/README.md
@@ -94,6 +94,7 @@ When `true`, only checks files with a [`@flow` annotation](http://flowtype.org/d
 {"gitdown": "include", "file": "./rules/space-after-type-colon.md"}
 {"gitdown": "include", "file": "./rules/space-before-type-colon.md"}
 {"gitdown": "include", "file": "./rules/space-before-generic-bracket.md"}
+{"gitdown": "include", "file": "./rules/union-intersection-spacing.md"}
 {"gitdown": "include", "file": "./rules/type-id-match.md"}
 {"gitdown": "include", "file": "./rules/use-flow-type.md"}
 {"gitdown": "include", "file": "./rules/valid-syntax.md"}

--- a/.README/rules/union-intersection-spacing.md
+++ b/.README/rules/union-intersection-spacing.md
@@ -1,0 +1,11 @@
+### `union-intersection-spacing`
+
+_The `--fix` option on the command line automatically fixes problems reported by this rule._
+
+Enforces consistent spacing around union and intersection type separators (`|` and `&`).
+
+This rule takes one argument. If it is `'always'` then a problem is raised when there is no space around the separator. If it is `'never'` then a problem is raised when there is a space around the separator.
+
+The default value is `'always'`.
+
+<!-- assertions unionIntersectionSpacing -->

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@
         * [`space-after-type-colon`](#eslint-plugin-flowtype-rules-space-after-type-colon)
         * [`space-before-type-colon`](#eslint-plugin-flowtype-rules-space-before-type-colon)
         * [`space-before-generic-bracket`](#eslint-plugin-flowtype-rules-space-before-generic-bracket)
+        * [`union-intersection-spacing`](#eslint-plugin-flowtype-rules-union-intersection-spacing)
         * [`type-id-match`](#eslint-plugin-flowtype-rules-type-id-match)
         * [`use-flow-type`](#eslint-plugin-flowtype-rules-use-flow-type)
         * [`valid-syntax`](#eslint-plugin-flowtype-rules-valid-syntax)
@@ -1296,6 +1297,152 @@ type X = Promise<string>
 
 // Options: ["always"]
 type X = Promise <string>
+```
+
+
+
+<h3 id="eslint-plugin-flowtype-rules-union-intersection-spacing"><code>union-intersection-spacing</code></h3>
+
+_The `--fix` option on the command line automatically fixes problems reported by this rule._
+
+Enforces consistent spacing around union and intersection type separators (`|` and `&`).
+
+This rule takes one argument. If it is `'always'` then a problem is raised when there is no space around the separator. If it is `'never'` then a problem is raised when there is a space around the separator.
+
+The default value is `'always'`.
+
+The following patterns are considered problems:
+
+```js
+type X = string| number;
+// Message: There must be a space before union type annotation separator
+
+// Options: ["always"]
+type X = string| number;
+// Message: There must be a space before union type annotation separator
+
+type X = string |number;
+// Message: There must be a space after union type annotation separator
+
+type X = string|number;
+// Message: There must be a space before union type annotation separator
+// Message: There must be a space after union type annotation separator
+
+type X = {x: string}|{y: number};
+// Message: There must be a space before union type annotation separator
+// Message: There must be a space after union type annotation separator
+
+type X = string | number |boolean;
+// Message: There must be a space after union type annotation separator
+
+type X = string|number|boolean;
+// Message: There must be a space before union type annotation separator
+// Message: There must be a space after union type annotation separator
+// Message: There must be a space before union type annotation separator
+// Message: There must be a space after union type annotation separator
+
+type X = (string)| number;
+// Message: There must be a space before union type annotation separator
+
+type X = ((string))|(number | foo);
+// Message: There must be a space before union type annotation separator
+// Message: There must be a space after union type annotation separator
+
+// Options: ["never"]
+type X = string |number;
+// Message: There must be no space before union type annotation separator
+
+// Options: ["never"]
+type X = string| number;
+// Message: There must be no space after union type annotation separator
+
+type X = string& number;
+// Message: There must be a space before intersection type annotation separator
+
+// Options: ["always"]
+type X = string& number;
+// Message: There must be a space before intersection type annotation separator
+
+type X = string &number;
+// Message: There must be a space after intersection type annotation separator
+
+type X = {x: string}&{y: number};
+// Message: There must be a space before intersection type annotation separator
+// Message: There must be a space after intersection type annotation separator
+
+type X = string&number;
+// Message: There must be a space before intersection type annotation separator
+// Message: There must be a space after intersection type annotation separator
+
+type X = string & number &boolean;
+// Message: There must be a space after intersection type annotation separator
+
+type X = string&number&boolean;
+// Message: There must be a space before intersection type annotation separator
+// Message: There must be a space after intersection type annotation separator
+// Message: There must be a space before intersection type annotation separator
+// Message: There must be a space after intersection type annotation separator
+
+type X = (string)& number;
+// Message: There must be a space before intersection type annotation separator
+
+type X = ((string))&(number & foo);
+// Message: There must be a space before intersection type annotation separator
+// Message: There must be a space after intersection type annotation separator
+
+// Options: ["never"]
+type X = string &number;
+// Message: There must be no space before intersection type annotation separator
+
+// Options: ["never"]
+type X = string& number;
+// Message: There must be no space after intersection type annotation separator
+```
+
+The following patterns are not considered problems:
+
+```js
+type X = string | number;
+
+type X = string | number | boolean;
+
+type X = (string) | number;
+
+type X = ((string)) | (number | foo);
+
+// Options: ["never"]
+type X = string|number
+
+type X =
+| string
+| number
+
+function x() {
+	type X =
+	| string
+	| number
+}
+
+type X = string & number;
+
+type X = string & number & boolean;
+
+type X = (string) & number;
+
+type X = ((string)) & (number & foo);
+
+// Options: ["never"]
+type X = string&number
+
+type X =
+& string
+& number
+
+function x() {
+	type X =
+	& string
+	& number
+}
 ```
 
 

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@ import requireValidFileAnnotation from './rules/requireValidFileAnnotation';
 import spaceAfterTypeColon from './rules/spaceAfterTypeColon';
 import spaceBeforeGenericBracket from './rules/spaceBeforeGenericBracket';
 import spaceBeforeTypeColon from './rules/spaceBeforeTypeColon';
+import unionIntersectionSpacing from './rules/unionIntersectionSpacing';
 import typeIdMatch from './rules/typeIdMatch';
 import useFlowType from './rules/useFlowType';
 import validSyntax from './rules/validSyntax';
@@ -19,6 +20,7 @@ export default {
         'space-before-generic-bracket': spaceBeforeGenericBracket,
         'space-before-type-colon': spaceBeforeTypeColon,
         'type-id-match': typeIdMatch,
+        'union-intersection-spacing': unionIntersectionSpacing,
         'use-flow-type': useFlowType,
         'valid-syntax': validSyntax
     },
@@ -30,6 +32,7 @@ export default {
         'space-before-generic-bracket': 0,
         'space-before-type-colon': 0,
         'type-id-match': 0,
+        'union-intersection-spacing': 0,
         'use-flow-type': 0,
         'valid-syntax': 0
     }

--- a/src/rules/unionIntersectionSpacing.js
+++ b/src/rules/unionIntersectionSpacing.js
@@ -1,0 +1,79 @@
+import {spacingFixers} from '../utilities';
+
+export default (context) => {
+    const sourceCode = context.getSourceCode();
+
+    const always = (context.options[0] || 'always') === 'always';
+
+    const getTokenAfterParens = (node) => {
+        let sep;
+
+        sep = sourceCode.getTokenAfter(node);
+
+        while (sep.type === 'Punctuator' && sep.value === ')') {
+            sep = sourceCode.getTokenAfter(sep);
+        }
+
+        return sep;
+    };
+
+    const check = (node) => {
+        node.types.forEach((type, index) => {
+            if (index + 1 === node.types.length) {
+                return;
+            }
+
+            const separator = getTokenAfterParens(type);
+            const endOfType = sourceCode.getTokenBefore(separator);
+            const nextType = sourceCode.getTokenAfter(separator);
+
+            const spaceBefore = separator.start - endOfType.end;
+            const spaceAfter = nextType.start - separator.end;
+
+            const data = {type: node.type === 'UnionTypeAnnotation' ? 'union' : 'intersection'};
+
+            if (always) {
+                if (!spaceBefore) {
+                    context.report({
+                        data,
+                        fix: spacingFixers.addSpaceAfter(endOfType),
+                        message: 'There must be a space before {{type}} type annotation separator',
+                        node
+                    });
+                }
+
+                if (!spaceAfter) {
+                    context.report({
+                        data,
+                        fix: spacingFixers.addSpaceAfter(separator),
+                        message: 'There must be a space after {{type}} type annotation separator',
+                        node
+                    });
+                }
+            } else {
+                if (spaceBefore) {
+                    context.report({
+                        data,
+                        fix: spacingFixers.stripSpacesAfter(endOfType, spaceBefore),
+                        message: 'There must be no space before {{type}} type annotation separator',
+                        node
+                    });
+                }
+
+                if (spaceAfter) {
+                    context.report({
+                        data,
+                        fix: spacingFixers.stripSpacesAfter(separator, spaceAfter),
+                        message: 'There must be no space after {{type}} type annotation separator',
+                        node
+                    });
+                }
+            }
+        });
+    };
+
+    return {
+        IntersectionTypeAnnotation: check,
+        UnionTypeAnnotation: check
+    };
+};

--- a/tests/rules/assertions/unionIntersectionSpacing.js
+++ b/tests/rules/assertions/unionIntersectionSpacing.js
@@ -1,0 +1,202 @@
+const UNION = {
+    invalid: [
+        {
+            code: 'type X = string| number;',
+            errors: [{message: 'There must be a space before union type annotation separator'}],
+            output: 'type X = string | number;'
+        },
+        {
+            code: 'type X = string| number;',
+            errors: [{message: 'There must be a space before union type annotation separator'}],
+            options: ['always'],
+            output: 'type X = string | number;'
+        },
+        {
+            code: 'type X = string |number;',
+            errors: [{message: 'There must be a space after union type annotation separator'}],
+            output: 'type X = string | number;'
+        },
+        {
+            code: 'type X = string|number;',
+            errors: [
+                {message: 'There must be a space before union type annotation separator'},
+                {message: 'There must be a space after union type annotation separator'}
+            ],
+            output: 'type X = string | number;'
+        },
+        {
+            code: 'type X = {x: string}|{y: number};',
+            errors: [
+                {message: 'There must be a space before union type annotation separator'},
+                {message: 'There must be a space after union type annotation separator'}
+            ],
+            output: 'type X = {x: string} | {y: number};'
+        },
+        {
+            code: 'type X = string | number |boolean;',
+            errors: [{message: 'There must be a space after union type annotation separator'}],
+            output: 'type X = string | number | boolean;'
+        },
+        {
+            code: 'type X = string|number|boolean;',
+            errors: [
+                {message: 'There must be a space before union type annotation separator'},
+                {message: 'There must be a space after union type annotation separator'},
+                {message: 'There must be a space before union type annotation separator'},
+                {message: 'There must be a space after union type annotation separator'}
+            ],
+            output: 'type X = string | number | boolean;'
+        },
+        {
+            code: 'type X = (string)| number;',
+            errors: [{message: 'There must be a space before union type annotation separator'}],
+            output: 'type X = (string) | number;'
+        },
+        {
+            code: 'type X = ((string))|(number | foo);',
+            errors: [
+                {message: 'There must be a space before union type annotation separator'},
+                {message: 'There must be a space after union type annotation separator'}
+            ],
+            output: 'type X = ((string)) | (number | foo);'
+        },
+        {
+            code: 'type X = string |number;',
+            errors: [{message: 'There must be no space before union type annotation separator'}],
+            options: ['never'],
+            output: 'type X = string|number;'
+        },
+        {
+            code: 'type X = string| number;',
+            errors: [{message: 'There must be no space after union type annotation separator'}],
+            options: ['never'],
+            output: 'type X = string|number;'
+        }
+    ],
+    valid: [
+        {code: 'type X = string | number;'},
+        {code: 'type X = string | number | boolean;'},
+        {code: 'type X = (string) | number;'},
+        {code: 'type X = ((string)) | (number | foo);'},
+        {
+            code: 'type X = string|number',
+            options: ['never']
+        },
+        {
+            code: 'type X =\n| string\n| number'
+        },
+        {
+            code: [
+                'function x() {',
+                '	type X =',
+                '	| string',
+                '	| number',
+                '}'
+            ].join('\n')
+        }
+    ]
+};
+
+const INTERSECTION = {
+    invalid: [
+        {
+            code: 'type X = string& number;',
+            errors: [{message: 'There must be a space before intersection type annotation separator'}],
+            output: 'type X = string & number;'
+        },
+        {
+            code: 'type X = string& number;',
+            errors: [{message: 'There must be a space before intersection type annotation separator'}],
+            options: ['always'],
+            output: 'type X = string & number;'
+        },
+        {
+            code: 'type X = string &number;',
+            errors: [{message: 'There must be a space after intersection type annotation separator'}],
+            output: 'type X = string & number;'
+        },
+        {
+            code: 'type X = {x: string}&{y: number};',
+            errors: [
+                {message: 'There must be a space before intersection type annotation separator'},
+                {message: 'There must be a space after intersection type annotation separator'}
+            ],
+            output: 'type X = {x: string} & {y: number};'
+        },
+        {
+            code: 'type X = string&number;',
+            errors: [
+                {message: 'There must be a space before intersection type annotation separator'},
+                {message: 'There must be a space after intersection type annotation separator'}
+            ],
+            output: 'type X = string & number;'
+        },
+        {
+            code: 'type X = string & number &boolean;',
+            errors: [{message: 'There must be a space after intersection type annotation separator'}],
+            output: 'type X = string & number & boolean;'
+        },
+        {
+            code: 'type X = string&number&boolean;',
+            errors: [
+                {message: 'There must be a space before intersection type annotation separator'},
+                {message: 'There must be a space after intersection type annotation separator'},
+                {message: 'There must be a space before intersection type annotation separator'},
+                {message: 'There must be a space after intersection type annotation separator'}
+            ],
+            output: 'type X = string & number & boolean;'
+        },
+        {
+            code: 'type X = (string)& number;',
+            errors: [{message: 'There must be a space before intersection type annotation separator'}],
+            output: 'type X = (string) & number;'
+        },
+        {
+            code: 'type X = ((string))&(number & foo);',
+            errors: [
+                {message: 'There must be a space before intersection type annotation separator'},
+                {message: 'There must be a space after intersection type annotation separator'}
+            ],
+            output: 'type X = ((string)) & (number & foo);'
+        },
+        {
+            code: 'type X = string &number;',
+            errors: [{message: 'There must be no space before intersection type annotation separator'}],
+            options: ['never'],
+            output: 'type X = string&number;'
+        },
+        {
+            code: 'type X = string& number;',
+            errors: [{message: 'There must be no space after intersection type annotation separator'}],
+            options: ['never'],
+            output: 'type X = string&number;'
+        }
+    ],
+    valid: [
+        {code: 'type X = string & number;'},
+        {code: 'type X = string & number & boolean;'},
+        {code: 'type X = (string) & number;'},
+        {code: 'type X = ((string)) & (number & foo);'},
+        {
+            code: 'type X = string&number',
+            options: ['never']
+        },
+        {
+            code: 'type X =\n& string\n& number'
+        },
+        {
+            code: [
+                'function x() {',
+                '	type X =',
+                '	& string',
+                '	& number',
+                '}'
+            ].join('\n')
+        }
+    ]
+};
+
+export default {
+    invalid: [...UNION.invalid, ...INTERSECTION.invalid],
+    valid: [...UNION.valid, ...INTERSECTION.valid]
+};

--- a/tests/rules/index.js
+++ b/tests/rules/index.js
@@ -14,6 +14,7 @@ const reportingRules = [
     'space-after-type-colon',
     'space-before-type-colon',
     'space-before-generic-bracket',
+    'union-intersection-spacing',
     'type-id-match',
     'use-flow-type',
     'valid-syntax'


### PR DESCRIPTION
`union-intersection-spacing`

e.g. `string | number` vs `string|number`

not enforcing against multiple spaces so that it allows multi-line unions like:

```
type X =
| string
| number
```