### PR TITLE
fix short style function in ObjectTypeProperty

### DIFF
--- a/src/rules/spaceAfterTypeColon.js
+++ b/src/rules/spaceAfterTypeColon.js
@@ -118,6 +118,14 @@ const functionEvaluators = iterateFunctionNodes((context) => {
   };
 });
 
+// 1) type X = { foo(): A; }
+// 2) type X = { foo: () => A; }
+// the above have identical ASTs (save for their ranges)
+// case 1 doesn't have a type annotation colon and should be ignored
+const isShortPropertyFunction = (objectTypeProperty) => {
+  return objectTypeProperty.value.type === 'FunctionTypeAnnotation' && objectTypeProperty.start === objectTypeProperty.value.start;
+};
+
 const objectTypePropertyEvaluator = (context) => {
   const {always} = parseOptions(context);
 
@@ -132,6 +140,10 @@ const objectTypePropertyEvaluator = (context) => {
   };
 
   return (objectTypeProperty) => {
+    if (isShortPropertyFunction(objectTypeProperty)) {
+      return;
+    }
+
     const colon = getColon(objectTypeProperty);
     const typeAnnotation = sourceCode.getTokenAfter(colon);
 

--- a/tests/rules/assertions/spaceAfterTypeColon.js
+++ b/tests/rules/assertions/spaceAfterTypeColon.js
@@ -586,6 +586,38 @@ const OBJECT_TYPE_PROPERTIES = {
       code: 'type Foo = { barType:  ((string | () => void)) }',
       errors: [{message: 'There must be 1 space after "barType" type annotation colon.'}],
       output: 'type Foo = { barType: ((string | () => void)) }'
+    },
+    {
+      code: 'type X = { get:() => A; }',
+      errors: [{message: 'There must be a space after "get" type annotation colon.'}],
+      output: 'type X = { get: () => A; }'
+    },
+    {
+      code: 'type X = { get:<X>() => A; }',
+      errors: [{message: 'There must be a space after "get" type annotation colon.'}],
+      output: 'type X = { get: <X>() => A; }'
+    },
+    {
+      code: 'type X = { get: () => A; }',
+      errors: [{message: 'There must be no space after "get" type annotation colon.'}],
+      options: ['never'],
+      output: 'type X = { get:() => A; }'
+    },
+    {
+      code: 'type X = { get: <X>() => A; }',
+      errors: [{message: 'There must be no space after "get" type annotation colon.'}],
+      options: ['never'],
+      output: 'type X = { get:<X>() => A; }'
+    },
+    {
+      code: 'type X = { get:  () => A; }',
+      errors: [{message: 'There must be 1 space after "get" type annotation colon.'}],
+      output: 'type X = { get: () => A; }'
+    },
+    {
+      code: 'type X = { get:  <X>() => A; }',
+      errors: [{message: 'There must be 1 space after "get" type annotation colon.'}],
+      output: 'type X = { get: <X>() => A; }'
     }
   ],
   valid: [
@@ -618,6 +650,34 @@ const OBJECT_TYPE_PROPERTIES = {
     },
     {
       code: 'type Foo = { barType:((string | () => void)) }',
+      options: ['never']
+    },
+    {
+      code: 'type X = { get(): A; }'
+    },
+    {
+      code: 'type X = { get<X>(): A; }'
+    },
+    {
+      code: 'type X = { get(): A; }',
+      options: ['never']
+    },
+    {
+      code: 'type X = { get<X>(): A; }',
+      options: ['never']
+    },
+    {
+      code: 'type X = { get: () => A; }'
+    },
+    {
+      code: 'type X = { get: <X>() => A; }'
+    },
+    {
+      code: 'type X = { get:() => A; }',
+      options: ['never']
+    },
+    {
+      code: 'type X = { get:<X>() => A; }',
       options: ['never']
     }
   ]


### PR DESCRIPTION
Fixes #85 

So both these examples produce the same AST, except for the start/end ranges on the nodes

```js
type X = {
  foo(): A;
}

type X = {
  foo: () => A;
}
```

The first case shouldn't apply `spaceAfterTypeColon` to the ObjectTypeProperty as there is no colon. Differentiating them is easy as the first case's ObjectTypeProperty & FunctionTypeAnnotation span the same range.