### PR TITLE
Allow uppercase sequences in `type-id-match`

### DIFF
--- a/.README/rules/type-id-match.md
+++ b/.README/rules/type-id-match.md
@@ -11,12 +11,12 @@ This rule needs a text RegExp to operate with Its signature is as follows:
     "rules": {
         "flowtype/type-id-match": [
             2,
-            "^([A-Z][a-z0-9]+)+Type$"
+            "^([A-Z][a-z0-9]*)+Type$"
         ]
     }
 }
 ```
 
-`'^([A-Z][a-z0-9]+)+Type$$'` is the default pattern.
+`'^([A-Z][a-z0-9]*)+Type$$'` is the default pattern.
 
 <!-- assertions typeIdMatch -->

--- a/src/rules/typeIdMatch.js
+++ b/src/rules/typeIdMatch.js
@@ -5,7 +5,7 @@ export const schema = [
 ];
 
 export default (context) => {
-  const pattern = new RegExp(context.options[0] || '^([A-Z][a-z0-9]+)+Type$');
+  const pattern = new RegExp(context.options[0] || '^([A-Z][a-z0-9]*)+Type$');
 
   return {
     TypeAlias (typeAliasNode) {

--- a/tests/rules/assertions/typeIdMatch.js
+++ b/tests/rules/assertions/typeIdMatch.js
@@ -4,7 +4,7 @@ export default {
       code: 'type foo = {};',
       errors: [
         {
-          message: 'Type identifier \'foo\' does not match pattern \'/^([A-Z][a-z0-9]+)+Type$/\'.'
+          message: 'Type identifier \'foo\' does not match pattern \'/^([A-Z][a-z0-9]*)+Type$/\'.'
         }
       ]
     },


### PR DESCRIPTION
Changes the default regular expression used to verify the names
of declared types. Previously, patterns with uppercase sequences
(e.g. `MyABCType`) produced errors, hence disallow the use of
acronyms in types (e.g. `CRM`).

ref https://github.com/gajus/eslint-plugin-flowtype/issues/92