### PR TITLE
Add new rule for warning against use of weak types

### DIFF
--- a/.README/README.md
+++ b/.README/README.md
@@ -38,6 +38,7 @@ npm install eslint-plugin-flowtype
   ],
   "rules": {
     "flowtype/define-flow-type": 1,
+    "flowtype/no-weak-types": 1,
     "flowtype/require-parameter-type": 1,
     "flowtype/require-return-type": [
       1,
@@ -88,6 +89,7 @@ When `true`, only checks files with a [`@flow` annotation](http://flowtype.org/d
 ## Rules
 
 {"gitdown": "include", "file": "./rules/define-flow-type.md"}
+{"gitdown": "include", "file": "./rules/no-weak-types.md"}
 {"gitdown": "include", "file": "./rules/require-parameter-type.md"}
 {"gitdown": "include", "file": "./rules/require-return-type.md"}
 {"gitdown": "include", "file": "./rules/require-valid-file-annotation.md"}

--- a/.README/rules/no-weak-types.md
+++ b/.README/rules/no-weak-types.md
@@ -1,0 +1,7 @@
+### `no-weak-types`
+
+Warns against weak type annotations *any*, *Object* and *Function*.
+These types can cause flow to silently skip over portions of your code,
+which would have otherwise caused type errors.
+
+<!-- assertions noWeakTypes -->

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 import defineFlowType from './rules/defineFlowType';
 import genericSpacing from './rules/genericSpacing';
+import noWeakTypes from './rules/noWeakTypes';
 import requireParameterType from './rules/requireParameterType';
 import requireReturnType from './rules/requireReturnType';
 import requireValidFileAnnotation from './rules/requireValidFileAnnotation';
@@ -15,6 +16,7 @@ export default {
   rules: {
     'define-flow-type': defineFlowType,
     'generic-spacing': genericSpacing,
+    'no-weak-types': noWeakTypes,
     'require-parameter-type': requireParameterType,
     'require-return-type': requireReturnType,
     'require-valid-file-annotation': requireValidFileAnnotation,
@@ -29,6 +31,7 @@ export default {
   rulesConfig: {
     'define-flow-type': 0,
     'generic-spacing': 0,
+    'no-weak-types': 0,
     'require-parameter-type': 0,
     'require-return-type': 0,
     'space-after-type-colon': 0,

--- a/src/rules/noWeakTypes.js
+++ b/src/rules/noWeakTypes.js
@@ -1,4 +1,4 @@
-import {get} from 'lodash';
+import _ from 'lodash';
 
 const reportWeakType = (context, weakType) => {
   return (node) => {
@@ -14,7 +14,7 @@ const genericTypeEvaluator = (context) => {
   const weakTypes = ['Function', 'Object'];
 
   return (node) => {
-    const name = get(node, 'id.name');
+    const name = _.get(node, 'id.name');
     const isWeakType = weakTypes.indexOf(name) >= 0;
 
     if (isWeakType) {

--- a/src/rules/noWeakTypes.js
+++ b/src/rules/noWeakTypes.js
@@ -1,0 +1,31 @@
+import {get} from 'lodash';
+
+const reportWeakType = (context, weakType) => {
+  return (node) => {
+    context.report({
+      data: {weakType},
+      message: 'Unexpected use of weak type "{{weakType}}"',
+      node
+    });
+  };
+};
+
+const genericTypeEvaluator = (context) => {
+  const weakTypes = ['Function', 'Object'];
+
+  return (node) => {
+    const name = get(node, 'id.name');
+    const isWeakType = weakTypes.indexOf(name) >= 0;
+
+    if (isWeakType) {
+      reportWeakType(context, name)(node);
+    }
+  };
+};
+
+export default (context) => {
+  return {
+    AnyTypeAnnotation: reportWeakType(context, 'any'),
+    GenericTypeAnnotation: genericTypeEvaluator(context)
+  };
+};

--- a/tests/rules/assertions/noWeakTypes.js
+++ b/tests/rules/assertions/noWeakTypes.js
@@ -1,0 +1,222 @@
+export default {
+  invalid: [
+    {
+      code: 'function foo(thing): any {}',
+      errors: [{
+        message: 'Unexpected use of weak type "any"'
+      }]
+    },
+    {
+      code: 'function foo(thing): Promise<any> {}',
+      errors: [{
+        message: 'Unexpected use of weak type "any"'
+      }]
+    },
+    {
+      code: 'function foo(thing): Promise<Promise<any>> {}',
+      errors: [{
+        message: 'Unexpected use of weak type "any"'
+      }]
+    },
+    {
+      code: 'function foo(thing): Object {}',
+      errors: [{
+        message: 'Unexpected use of weak type "Object"'
+      }]
+    },
+    {
+      code: 'function foo(thing): Promise<Object> {}',
+      errors: [{
+        message: 'Unexpected use of weak type "Object"'
+      }]
+    },
+    {
+      code: 'function foo(thing): Promise<Promise<Object>> {}',
+      errors: [{
+        message: 'Unexpected use of weak type "Object"'
+      }]
+    },
+    {
+      code: 'function foo(thing): Function {}',
+      errors: [{
+        message: 'Unexpected use of weak type "Function"'
+      }]
+    },
+    {
+      code: 'function foo(thing): Promise<Function> {}',
+      errors: [{
+        message: 'Unexpected use of weak type "Function"'
+      }]
+    },
+    {
+      code: 'function foo(thing): Promise<Promise<Function>> {}',
+      errors: [{
+        message: 'Unexpected use of weak type "Function"'
+      }]
+    },
+    {
+      code: '(foo: any) => {}',
+      errors: [{
+        message: 'Unexpected use of weak type "any"'
+      }]
+    },
+    {
+      code: '(foo: Function) => {}',
+      errors: [{
+        message: 'Unexpected use of weak type "Function"'
+      }]
+    },
+    {
+      code: '(foo?: any) => {}',
+      errors: [{
+        message: 'Unexpected use of weak type "any"'
+      }]
+    },
+    {
+      code: '(foo?: Function) => {}',
+      errors: [{
+        message: 'Unexpected use of weak type "Function"'
+      }]
+    },
+    {
+      code: '(foo: { a: any }) => {}',
+      errors: [{
+        message: 'Unexpected use of weak type "any"'
+      }]
+    },
+    {
+      code: '(foo: { a: Object }) => {}',
+      errors: [{
+        message: 'Unexpected use of weak type "Object"'
+      }]
+    },
+    {
+      code: '(foo: any[]) => {}',
+      errors: [{
+        message: 'Unexpected use of weak type "any"'
+      }]
+    },
+    {
+      code: 'type Foo = any',
+      errors: [{
+        message: 'Unexpected use of weak type "any"'
+      }]
+    },
+    {
+      code: 'type Foo = Function',
+      errors: [{
+        message: 'Unexpected use of weak type "Function"'
+      }]
+    },
+    {
+      code: 'type Foo = { a: any }',
+      errors: [{
+        message: 'Unexpected use of weak type "any"'
+      }]
+    },
+    {
+      code: 'type Foo = { a: Object }',
+      errors: [{
+        message: 'Unexpected use of weak type "Object"'
+      }]
+    },
+    {
+      code: 'type Foo = { (a: Object): string }',
+      errors: [{
+        message: 'Unexpected use of weak type "Object"'
+      }]
+    },
+    {
+      code: 'type Foo = { (a: string): Function }',
+      errors: [{
+        message: 'Unexpected use of weak type "Function"'
+      }]
+    },
+    {
+      code: 'function foo(thing: any) {}',
+      errors: [{
+        message: 'Unexpected use of weak type "any"'
+      }]
+    },
+    {
+      code: 'function foo(thing: Object) {}',
+      errors: [{
+        message: 'Unexpected use of weak type "Object"'
+      }]
+    },
+    {
+      code: 'var foo: Function',
+      errors: [{
+        message: 'Unexpected use of weak type "Function"'
+      }]
+    },
+    {
+      code: 'var foo: Object',
+      errors: [{
+        message: 'Unexpected use of weak type "Object"'
+      }]
+    },
+    {
+      code: 'class Foo { props: any }',
+      errors: [{
+        message: 'Unexpected use of weak type "any"'
+      }]
+    },
+    {
+      code: 'class Foo { props: Object }',
+      errors: [{
+        message: 'Unexpected use of weak type "Object"'
+      }]
+    },
+    {
+      code: 'var foo: any',
+      errors: [{
+        message: 'Unexpected use of weak type "any"'
+      }]
+    }
+  ],
+  valid: [
+    {
+      code: 'function foo(thing): string {}'
+    },
+    {
+      code: 'function foo(thing): Promise<string> {}'
+    },
+    {
+      code: 'function foo(thing): Promise<Promise<string>> {}'
+    },
+    {
+      code: '(foo?: string) => {}'
+    },
+    {
+      code: '(foo: ?string) => {}'
+    },
+    {
+      code: '(foo: { a: string }) => {}'
+    },
+    {
+      code: '(foo: { a: ?string }) => {}'
+    },
+    {
+      code: '(foo: string[]) => {}'
+    },
+    {
+      code: 'type Foo = string'
+    },
+    {
+      code: 'type Foo = { a: string }'
+    },
+    {
+      code: 'type Foo = { (a: string): string }'
+    },
+    {
+      code: 'function foo(thing: string) {}'
+    },
+    {
+      code: 'var foo: string'
+    },
+    {
+      code: 'class Foo { props: string }'
+    }
+  ]
+};

--- a/tests/rules/index.js
+++ b/tests/rules/index.js
@@ -9,6 +9,7 @@ const ruleTester = new RuleTester();
 const reportingRules = [
   'define-flow-type',
   'generic-spacing',
+  'no-weak-types',
   'require-parameter-type',
   'require-return-type',
   'require-valid-file-annotation',


### PR DESCRIPTION
Warns when using weak type annotations **any**, **Object** and **Function**