### PR TITLE
feat: options to prevent specific types in `noWeakTypes`

### DIFF
--- a/.README/rules/no-weak-types.md
+++ b/.README/rules/no-weak-types.md
@@ -4,4 +4,30 @@ Warns against weak type annotations *any*, *Object* and *Function*.
 These types can cause flow to silently skip over portions of your code,
 which would have otherwise caused type errors.
 
+This rule optionally takes one argument, an object to configure which type warnings to enable. By default, all of the
+warnings are enabled. e.g. to disable the `any` warning (allowing it to exist in your code), while continuing to warn
+about `Object` and `Function`:
+
+```js
+{
+    "rules": {
+        "flowtype/no-weak-types": [2, {
+            "any": false,
+            "Object": true,
+            "Function": true
+        }]
+    }
+}
+
+// or, the following is equivalent as default is true:
+
+{
+    "rules": {
+        "flowtype/no-weak-types": [2, {
+            "any": false
+        }]
+    }
+}
+```
+
 <!-- assertions noWeakTypes -->

--- a/tests/rules/assertions/noWeakTypes.js
+++ b/tests/rules/assertions/noWeakTypes.js
@@ -173,6 +173,24 @@ export default {
       errors: [{
         message: 'Unexpected use of weak type "any"'
       }]
+    },
+    {
+      code: 'type X = any; type Y = Function; type Z = Object',
+      errors: [
+        {message: 'Unexpected use of weak type "any"'},
+        {message: 'Unexpected use of weak type "Object"'}
+      ],
+      options: [{
+        Function: false
+      }]
+    },
+    {
+      code: 'type X = any; type Y = Function; type Z = Object',
+      errors: [{message: 'Unexpected use of weak type "Function"'}],
+      options: [{
+        Object: false,
+        any: false
+      }]
     }
   ],
   valid: [
@@ -217,6 +235,17 @@ export default {
     },
     {
       code: 'class Foo { props: string }'
+    },
+    {
+      code: 'type X = any; type Y = Object',
+      options: [{
+        Object: false,
+        any: false
+      }]
+    },
+    {
+      code: 'type X = Function',
+      options: [{Function: false}]
     }
   ]
 };


### PR DESCRIPTION
e.g. I'd like to initially prevent the "easier" types (`Object` and `Function`), and later start disabling `any`.

This allows me to configure which rules to enable:

```js
{
  any: false,
  Object: true,
  Function: true
}
```

to disable the `any` check, while keeping the `Object` and `Function` checks

_although I can't decide if that reads more as "disallow `any` types, allow `Object`/`Function` types" - the opposite_