### PR TITLE
feat: add `delimiter-dangle` for trailing commas/semicolons

### DIFF
--- a/.README/README.md
+++ b/.README/README.md
@@ -99,6 +99,7 @@ When `true`, only checks files with a [`@flow` annotation](http://flowtype.org/d
 {"gitdown": "include", "file": "./rules/require-return-type.md"}
 {"gitdown": "include", "file": "./rules/require-valid-file-annotation.md"}
 {"gitdown": "include", "file": "./rules/semi.md"}
+{"gitdown": "include", "file": "./rules/delimiter-dangle.md"}
 {"gitdown": "include", "file": "./rules/space-after-type-colon.md"}
 {"gitdown": "include", "file": "./rules/space-before-type-colon.md"}
 {"gitdown": "include", "file": "./rules/space-before-generic-bracket.md"}

--- a/.README/rules/delimiter-dangle.md
+++ b/.README/rules/delimiter-dangle.md
@@ -1,0 +1,19 @@
+### `delimiter-dangle`
+
+_The `--fix` option on the command line automatically fixes problems reported by this rule._
+
+Enforces consistent use of trailing commas in Object and Tuple annotations.
+
+This rule takes one argument which mirrors ESLint's default `comma-dangle` rule.
+
+If it is `'never'` then a problem is raised when there is a trailing comma.
+
+If it is `'always'` then a problem is raised when there is no trailing comma.
+
+If it is `'always-multiline'` then a problem is raised when there is no trailing comma on a multi-line definition, or there _is_ a trailing comma on a single-line definition.
+
+If it is `'only-multiline'` then a problem is raised when there is a trailing comma on a single-line definition. It allows, but does not enforce, trailing commas on multi-line definitions.
+
+The default value is `'never'`.
+
+<!-- assertions delimiterDangle -->

--- a/src/index.js
+++ b/src/index.js
@@ -13,11 +13,13 @@ import typeIdMatch from './rules/typeIdMatch';
 import useFlowType from './rules/useFlowType';
 import validSyntax from './rules/validSyntax';
 import booleanStyle from './rules/booleanStyle';
+import delimiterDangle from './rules/delimiterDangle';
 
 export default {
   rules: {
     'boolean-style': booleanStyle,
     'define-flow-type': defineFlowType,
+    'delimiter-dangle': delimiterDangle,
     'generic-spacing': genericSpacing,
     'no-weak-types': noWeakTypes,
     'require-parameter-type': requireParameterType,
@@ -35,6 +37,7 @@ export default {
   rulesConfig: {
     'boolean-style': 0,
     'define-flow-type': 0,
+    'delimiter-dangle': 0,
     'generic-spacing': 0,
     'no-weak-types': 0,
     'require-parameter-type': 0,

--- a/src/rules/delimiterDangle.js
+++ b/src/rules/delimiterDangle.js
@@ -1,0 +1,76 @@
+import _ from 'lodash';
+
+export default (context) => {
+  const option = context.options[0] || 'never';
+  const sourceCode = context.getSourceCode();
+
+  const reporter = (node, message, fix) => {
+    return () => {
+      context.report({
+        fix,
+        message,
+        node
+      });
+    };
+  };
+
+  const makeReporters = (node, tokenToFix) => {
+    return {
+      dangle: reporter(node, 'Unexpected trailing delimiter', (fixer) => {
+        return fixer.replaceText(tokenToFix, '');
+      }),
+      noDangle: reporter(node, 'Missing trailing delimiter', (fixer) => {
+        return fixer.insertTextAfter(tokenToFix, ',');
+      })
+    };
+  };
+
+  const evaluate = (node, tokenToFix) => {
+    const [penultimateToken, lastToken] = sourceCode.getLastTokens(node, 2);
+
+    const isDangling = [';', ','].indexOf(penultimateToken.value) > -1;
+    const isMultiLine = penultimateToken.loc.start.line !== lastToken.loc.start.line;
+
+    const report = makeReporters(tokenToFix, penultimateToken);
+
+    if (option === 'always' && !isDangling) {
+      report.noDangle();
+
+      return;
+    }
+
+    if (option === 'never' && isDangling) {
+      report.dangle();
+
+      return;
+    }
+
+    if (option === 'always-multiline' && !isDangling && isMultiLine) {
+      report.noDangle();
+
+      return;
+    }
+
+    if (option === 'always-multiline' && isDangling && !isMultiLine) {
+      report.dangle();
+
+      return;
+    }
+
+    if (option === 'only-multiline' && isDangling && !isMultiLine) {
+      report.dangle();
+
+      return;
+    }
+  };
+
+  return {
+    ObjectTypeAnnotation (node) {
+      evaluate(node, _.last(node.properties));
+    },
+
+    TupleTypeAnnotation (node) {
+      evaluate(node, _.last(node.types));
+    }
+  };
+};

--- a/src/rules/delimiterDangle.js
+++ b/src/rules/delimiterDangle.js
@@ -25,13 +25,17 @@ export default (context) => {
     };
   };
 
-  const evaluate = (node, tokenToFix) => {
+  const evaluate = (node, lastChildNode) => {
+    if (!lastChildNode) {
+      return;
+    }
+
     const [penultimateToken, lastToken] = sourceCode.getLastTokens(node, 2);
 
     const isDangling = [';', ','].indexOf(penultimateToken.value) > -1;
     const isMultiLine = penultimateToken.loc.start.line !== lastToken.loc.start.line;
 
-    const report = makeReporters(tokenToFix, penultimateToken);
+    const report = makeReporters(lastChildNode, penultimateToken);
 
     if (option === 'always' && !isDangling) {
       report.noDangle();
@@ -66,7 +70,7 @@ export default (context) => {
 
   return {
     ObjectTypeAnnotation (node) {
-      evaluate(node, _.last(node.properties));
+      evaluate(node, _.last(node.properties) || _.last(node.indexers));
     },
 
     TupleTypeAnnotation (node) {

--- a/src/rules/delimiterDangle.js
+++ b/src/rules/delimiterDangle.js
@@ -68,9 +68,34 @@ export default (context) => {
     }
   };
 
+  // required for reporting the correct position
+  const getLast = (property, indexer) => {
+    if (!property) {
+      return indexer;
+    }
+
+    if (!indexer) {
+      return property;
+    }
+
+    if (property.loc.end.line > indexer.loc.end.line) {
+      return property;
+    }
+
+    if (indexer.loc.end.line > property.loc.end.line) {
+      return indexer;
+    }
+
+    if (property.loc.end.column > indexer.loc.end.column) {
+      return property;
+    }
+
+    return indexer;
+  };
+
   return {
     ObjectTypeAnnotation (node) {
-      evaluate(node, _.last(node.properties) || _.last(node.indexers));
+      evaluate(node, getLast(_.last(node.properties), _.last(node.indexers)));
     },
 
     TupleTypeAnnotation (node) {

--- a/tests/rules/assertions/delimiterDangle.js
+++ b/tests/rules/assertions/delimiterDangle.js
@@ -88,6 +88,39 @@ const OBJECT_TYPE_ANNOTATION = {
 
     // Indexer, Prop...
     {
+      code: 'type X = { [key: string]: number, foo: string, }',
+      errors: [{
+        // be sure it's reporting the prop, not the indexer
+        column: 35,
+        line: 1,
+        message: 'Unexpected trailing delimiter'
+      }],
+      options: ['never'],
+      output: 'type X = { [key: string]: number, foo: string }'
+    },
+    {
+      code: 'type X = {\n[key: string]: number,\nfoo: string,\n}',
+      errors: [{
+        // be sure it's reporting the prop, not the indexer
+        column: 1,
+        line: 3,
+        message: 'Unexpected trailing delimiter'
+      }],
+      options: ['never'],
+      output: 'type X = {\n[key: string]: number,\nfoo: string\n}'
+    },
+    {
+      code: 'type X = {\n[key: string]: number,\naReallyLongPropertyNameHere: string,\n}',
+      errors: [{
+        // be sure it's reporting the prop, not the indexer
+        column: 1,
+        line: 3,
+        message: 'Unexpected trailing delimiter'
+      }],
+      options: ['never'],
+      output: 'type X = {\n[key: string]: number,\naReallyLongPropertyNameHere: string\n}'
+    },
+    {
       code: 'type X = { [key: string]: number, foo: string }',
       errors: [{message: 'Missing trailing delimiter'}],
       options: ['always'],
@@ -119,6 +152,39 @@ const OBJECT_TYPE_ANNOTATION = {
     },
 
     // Prop, Indexer...
+    {
+      code: 'type X = { foo: string, [key: string]: number, }',
+      errors: [{
+        // be sure it's reporting the indexer, not the prop
+        column: 25,
+        line: 1,
+        message: 'Unexpected trailing delimiter'
+      }],
+      options: ['never'],
+      output: 'type X = { foo: string, [key: string]: number }'
+    },
+    {
+      code: 'type X = {\nfoo: string,\n[key: string]: number,\n}',
+      errors: [{
+        // be sure it's reporting the prop, not the indexer
+        column: 1,
+        line: 3,
+        message: 'Unexpected trailing delimiter'
+      }],
+      options: ['never'],
+      output: 'type X = {\nfoo: string,\n[key: string]: number\n}'
+    },
+    {
+      code: 'type X = {\naReallyLongPropertyNameHere: string,\n[key: string]: number,\n}',
+      errors: [{
+        // be sure it's reporting the prop, not the indexer
+        column: 1,
+        line: 3,
+        message: 'Unexpected trailing delimiter'
+      }],
+      options: ['never'],
+      output: 'type X = {\naReallyLongPropertyNameHere: string,\n[key: string]: number\n}'
+    },
     {
       code: 'type X = { foo: string, [key: string]: number }',
       errors: [{message: 'Missing trailing delimiter'}],

--- a/tests/rules/assertions/delimiterDangle.js
+++ b/tests/rules/assertions/delimiterDangle.js
@@ -1,0 +1,214 @@
+const OBJECT_TYPE_ANNOTATION = {
+  invalid: [
+    {
+      code: 'type X = { foo: string, }',
+      errors: [{message: 'Unexpected trailing delimiter'}],
+      output: 'type X = { foo: string }'
+    },
+    {
+      code: 'type X = { foo: string, }',
+      errors: [{message: 'Unexpected trailing delimiter'}],
+      options: ['never'],
+      output: 'type X = { foo: string }'
+    },
+    {
+      code: 'type X = { foo: string; }',
+      errors: [{message: 'Unexpected trailing delimiter'}],
+      options: ['never'],
+      output: 'type X = { foo: string }'
+    },
+    {
+      code: 'type X = {\nfoo: string,\n}',
+      errors: [{message: 'Unexpected trailing delimiter'}],
+      options: ['never'],
+      output: 'type X = {\nfoo: string\n}'
+    },
+    {
+      code: 'type X = { foo: string }',
+      errors: [{message: 'Missing trailing delimiter'}],
+      options: ['always'],
+      output: 'type X = { foo: string, }'
+    },
+    {
+      code: 'type X = {\nfoo: string\n}',
+      errors: [{message: 'Missing trailing delimiter'}],
+      options: ['always'],
+      output: 'type X = {\nfoo: string,\n}'
+    },
+    {
+      code: 'type X = { foo: string, }',
+      errors: [{message: 'Unexpected trailing delimiter'}],
+      options: ['always-multiline'],
+      output: 'type X = { foo: string }'
+    },
+    {
+      code: 'type X = {\nfoo: string\n}',
+      errors: [{message: 'Missing trailing delimiter'}],
+      options: ['always-multiline'],
+      output: 'type X = {\nfoo: string,\n}'
+    },
+    {
+      code: 'type X = { foo: string; }',
+      errors: [{message: 'Unexpected trailing delimiter'}],
+      options: ['only-multiline'],
+      output: 'type X = { foo: string }'
+    }
+  ],
+  valid: [
+    {
+      code: 'type X = { foo: string }'
+    },
+    {
+      code: 'type X = { foo: string }',
+      options: ['never']
+    },
+    {
+      code: 'type X = { foo: string, }',
+      options: ['always']
+    },
+    {
+      code: 'type X = { foo: string; }',
+      options: ['always']
+    },
+    {
+      code: 'type X = {\nfoo: string\n}',
+      options: ['never']
+    },
+    {
+      code: 'type X = {\nfoo: string,\n}',
+      options: ['always']
+    },
+    {
+      code: 'type X = { foo: string }',
+      options: ['always-multiline']
+    },
+    {
+      code: 'type X = {\nfoo: string,\n}',
+      options: ['always-multiline']
+    },
+    {
+      code: 'type X = {\nfoo: string;\n}',
+      options: ['always-multiline']
+    },
+    {
+      code: 'type X = { foo: string }',
+      options: ['only-multiline']
+    },
+    {
+      code: 'type X = {\nfoo: string\n}',
+      options: ['only-multiline']
+    },
+    {
+      code: 'type X = {\nfoo: string,\n}',
+      options: ['only-multiline']
+    },
+    {
+      code: 'type X = {\nfoo: string;\n}',
+      options: ['only-multiline']
+    }
+  ]
+};
+
+const TUPLE_TYPE_ANNOTATION = {
+  invalid: [
+    {
+      code: 'type X = [string, number,]',
+      errors: [{message: 'Unexpected trailing delimiter'}],
+      output: 'type X = [string, number]'
+    },
+    {
+      code: 'type X = [string, number,]',
+      errors: [{message: 'Unexpected trailing delimiter'}],
+      options: ['never'],
+      output: 'type X = [string, number]'
+    },
+    {
+      code: 'type X = [\nstring,\nnumber,\n]',
+      errors: [{message: 'Unexpected trailing delimiter'}],
+      options: ['never'],
+      output: 'type X = [\nstring,\nnumber\n]'
+    },
+    {
+      code: 'type X = [string, number]',
+      errors: [{message: 'Missing trailing delimiter'}],
+      options: ['always'],
+      output: 'type X = [string, number,]'
+    },
+    {
+      code: 'type X = [\nstring,\nnumber\n]',
+      errors: [{message: 'Missing trailing delimiter'}],
+      options: ['always'],
+      output: 'type X = [\nstring,\nnumber,\n]'
+    },
+    {
+      code: 'type X = [string, number,]',
+      errors: [{message: 'Unexpected trailing delimiter'}],
+      options: ['always-multiline'],
+      output: 'type X = [string, number]'
+    },
+    {
+      code: 'type X = [\nfoo, string\n]',
+      errors: [{message: 'Missing trailing delimiter'}],
+      options: ['always-multiline'],
+      output: 'type X = [\nfoo, string,\n]'
+    },
+    {
+      code: 'type X = [ number, string, ]',
+      errors: [{message: 'Unexpected trailing delimiter'}],
+      options: ['only-multiline'],
+      output: 'type X = [ number, string ]'
+    }
+  ],
+  valid: [
+    {
+      code: 'type X = [string, number]'
+    },
+    {
+      code: 'type X = [string, number]',
+      options: ['never']
+    },
+    {
+      code: 'type X = [\nstring,\nnumber\n]',
+      options: ['never']
+    },
+    {
+      code: 'type X = [string, number,]',
+      options: ['always']
+    },
+    {
+      code: 'type X = [\nstring,\nnumber,\n]',
+      options: ['always']
+    },
+    {
+      code: 'type X = [ foo, string ]',
+      options: ['always-multiline']
+    },
+    {
+      code: 'type X = [\nfoo, string,\n]',
+      options: ['always-multiline']
+    },
+    {
+      code: 'type X = [ number, string ]',
+      options: ['only-multiline']
+    },
+    {
+      code: 'type X = [\nnumber,\nstring\n]',
+      options: ['only-multiline']
+    },
+    {
+      code: 'type X = [\nnumber,\nstring,\n]',
+      options: ['only-multiline']
+    }
+  ]
+};
+
+export default {
+  invalid: [
+    ...OBJECT_TYPE_ANNOTATION.invalid,
+    ...TUPLE_TYPE_ANNOTATION.invalid
+  ],
+  valid: [
+    ...OBJECT_TYPE_ANNOTATION.valid,
+    ...TUPLE_TYPE_ANNOTATION.valid
+  ]
+};

--- a/tests/rules/assertions/delimiterDangle.js
+++ b/tests/rules/assertions/delimiterDangle.js
@@ -52,6 +52,102 @@ const OBJECT_TYPE_ANNOTATION = {
       errors: [{message: 'Unexpected trailing delimiter'}],
       options: ['only-multiline'],
       output: 'type X = { foo: string }'
+    },
+
+    // Only indexers...
+    {
+      code: 'type X = { [key: string]: number, }',
+      errors: [{message: 'Unexpected trailing delimiter'}],
+      options: ['never'],
+      output: 'type X = { [key: string]: number }'
+    },
+    {
+      code: 'type X = { [key: string]: number }',
+      errors: [{message: 'Missing trailing delimiter'}],
+      options: ['always'],
+      output: 'type X = { [key: string]: number, }'
+    },
+    {
+      code: 'type X = { [key: string]: number, }',
+      errors: [{message: 'Unexpected trailing delimiter'}],
+      options: ['always-multiline'],
+      output: 'type X = { [key: string]: number }'
+    },
+    {
+      code: 'type X = {\n[key: string]: number\n}',
+      errors: [{message: 'Missing trailing delimiter'}],
+      options: ['always-multiline'],
+      output: 'type X = {\n[key: string]: number,\n}'
+    },
+    {
+      code: 'type X = { [key: string]: number; }',
+      errors: [{message: 'Unexpected trailing delimiter'}],
+      options: ['only-multiline'],
+      output: 'type X = { [key: string]: number }'
+    },
+
+    // Indexer, Prop...
+    {
+      code: 'type X = { [key: string]: number, foo: string }',
+      errors: [{message: 'Missing trailing delimiter'}],
+      options: ['always'],
+      output: 'type X = { [key: string]: number, foo: string, }'
+    },
+    {
+      code: 'type X = {\n[key: string]: number;\nfoo: string\n}',
+      errors: [{message: 'Missing trailing delimiter'}],
+      options: ['always'],
+      output: 'type X = {\n[key: string]: number;\nfoo: string,\n}'
+    },
+    {
+      code: 'type X = { [key: string]: number, foo: string, }',
+      errors: [{message: 'Unexpected trailing delimiter'}],
+      options: ['always-multiline'],
+      output: 'type X = { [key: string]: number, foo: string }'
+    },
+    {
+      code: 'type X = {\n[key: string]: number,\nfoo: string\n}',
+      errors: [{message: 'Missing trailing delimiter'}],
+      options: ['always-multiline'],
+      output: 'type X = {\n[key: string]: number,\nfoo: string,\n}'
+    },
+    {
+      code: 'type X = { [key: string]: number, foo: string, }',
+      errors: [{message: 'Unexpected trailing delimiter'}],
+      options: ['only-multiline'],
+      output: 'type X = { [key: string]: number, foo: string }'
+    },
+
+    // Prop, Indexer...
+    {
+      code: 'type X = { foo: string, [key: string]: number }',
+      errors: [{message: 'Missing trailing delimiter'}],
+      options: ['always'],
+      output: 'type X = { foo: string, [key: string]: number, }'
+    },
+    {
+      code: 'type X = { foo: string; [key: string]: number }',
+      errors: [{message: 'Missing trailing delimiter'}],
+      options: ['always'],
+      output: 'type X = { foo: string; [key: string]: number, }'
+    },
+    {
+      code: 'type X = { foo: string, [key: string]: number; }',
+      errors: [{message: 'Unexpected trailing delimiter'}],
+      options: ['always-multiline'],
+      output: 'type X = { foo: string, [key: string]: number }'
+    },
+    {
+      code: 'type X = {\nfoo: string,\n[key: string]: number\n}',
+      errors: [{message: 'Missing trailing delimiter'}],
+      options: ['always-multiline'],
+      output: 'type X = {\nfoo: string,\n[key: string]: number,\n}'
+    },
+    {
+      code: 'type X = { foo: string, [key: string]: number; }',
+      errors: [{message: 'Unexpected trailing delimiter'}],
+      options: ['only-multiline'],
+      output: 'type X = { foo: string, [key: string]: number }'
     }
   ],
   valid: [
@@ -104,6 +200,126 @@ const OBJECT_TYPE_ANNOTATION = {
     },
     {
       code: 'type X = {\nfoo: string;\n}',
+      options: ['only-multiline']
+    },
+
+    // Empty...
+    {
+      code: 'type X = {}',
+      options: ['never']
+    },
+    {
+      code: 'type X = {}',
+      options: ['always']
+    },
+    {
+      code: 'type X = {}',
+      options: ['always-multiline']
+    },
+    {
+      code: 'type X = {}',
+      options: ['only-multiline']
+    },
+
+    // Only indexers...
+    {
+      code: 'type X = { [key: string]: number }',
+      options: ['never']
+    },
+    {
+      code: 'type X = { [key: string]: number, }',
+      options: ['always']
+    },
+    {
+      code: 'type X = { [key: string]: number; }',
+      options: ['always']
+    },
+    {
+      code: 'type X = { [key: string]: number }',
+      options: ['always-multiline']
+    },
+    {
+      code: 'type X = {\n[key: string]: number,\n}',
+      options: ['always-multiline']
+    },
+    {
+      code: 'type X = {\n[key: string]: number,\n}',
+      options: ['only-multiline']
+    },
+    {
+      code: 'type X = {\n[key: string]: number\n}',
+      options: ['only-multiline']
+    },
+    {
+      code: 'type X = { [key: string]: number }',
+      options: ['only-multiline']
+    },
+
+    // Indexer, Prop...
+    {
+      code: 'type X = { [key: string]: number, foo: string }',
+      options: ['never']
+    },
+    {
+      code: 'type X = { [key: string]: number, foo: string, }',
+      options: ['always']
+    },
+    {
+      code: 'type X = { [key: string]: number; foo: string; }',
+      options: ['always']
+    },
+    {
+      code: 'type X = { [key: string]: number, foo: string }',
+      options: ['always-multiline']
+    },
+    {
+      code: 'type X = {\n[key: string]: number,\nfoo: string,\n}',
+      options: ['always-multiline']
+    },
+    {
+      code: 'type X = {\n[key: string]: number,\nfoo: string,\n}',
+      options: ['only-multiline']
+    },
+    {
+      code: 'type X = {\n[key: string]: number;\nfoo: string\n}',
+      options: ['only-multiline']
+    },
+    {
+      code: 'type X = { [key: string]: number, foo: string }',
+      options: ['only-multiline']
+    },
+
+    // Prop, Indexer...
+    {
+      code: 'type X = { foo: string, [key: string]: number }',
+      options: ['never']
+    },
+    {
+      code: 'type X = { foo: string, [key: string]: number, }',
+      options: ['always']
+    },
+    {
+      code: 'type X = { foo: string; [key: string]: number; }',
+      options: ['always']
+    },
+    {
+      code: 'type X = { foo: string, [key: string]: number }',
+      options: ['always-multiline']
+    },
+    {
+      code: 'type X = {\nfoo: string,\n[key: string]: number,\n}',
+      options: ['always-multiline']
+    },
+    {
+      code: 'type X = {\nfoo: string,\n[key: string]: number,\n}',
+      options: ['only-multiline']
+    },
+    {
+      code: 'type X = {\nfoo: string;\n[key: string]: number\n}',
+      options: ['only-multiline']
+    },
+    {
+      code: 'type X = { foo: string, [key: string]: number }',
       options: ['only-multiline']
     }
   ]
@@ -197,6 +413,22 @@ const TUPLE_TYPE_ANNOTATION = {
     },
     {
       code: 'type X = [\nnumber,\nstring,\n]',
+      options: ['only-multiline']
+    },
+    {
+      code: 'type X = []',
+      options: ['never']
+    },
+    {
+      code: 'type X = []',
+      options: ['always']
+    },
+    {
+      code: 'type X = []',
+      options: ['always-multiline']
+    },
+    {
+      code: 'type X = []',
       options: ['only-multiline']
     }
   ]

--- a/tests/rules/index.js
+++ b/tests/rules/index.js
@@ -9,6 +9,7 @@ const ruleTester = new RuleTester();
 const reportingRules = [
   'boolean-style',
   'define-flow-type',
+  'delimiter-dangle',
   'generic-spacing',
   'no-weak-types',
   'require-parameter-type',


### PR DESCRIPTION
See https://github.com/gajus/eslint-plugin-flowtype/issues/40

Trailing delimiters in `ObjectTypeAnnotation` and `TupleTypeAnnotation`.

To mirror ESLint's `comma-dangle` rule, it has the following options: `never` (default), `always`, `always-multiline`, `only-multiline`.

For the multiline rules, I'm pretty sure I'm correctly mirroring the logic of `comma-dangle` - it's multiline if the last property & closing brace are on separate lines.

For `ObjectTypeAnnotation`, I haven't added in the option of comma vs semi-colon. Another rule can handle that (hopefully the one from `eslint-plugin-babel`)