### PR TITLE
Use JSON config for exported configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,8 +31,9 @@
     "documentation-add-assertions": "babel-node ./bin/readmeAssertions",
     "documentation": "gitdown ./.README/README.md --output-file ./README.md; npm run documentation-add-assertions",
     "create-index": "create-index ./src --update-index",
-    "precommit": "npm run lint && npm run test",
-    "commitmsg": "conventional-changelog-lint -e"
+    "precommit": "npm run lint && npm run test && npm run format-json",
+    "commitmsg": "conventional-changelog-lint -e",
+    "format-json": "jsonlint --sort-keys --in-place --indent '  ' ./src/configs/recommended.json && echo '' >> ./src/configs/recommended.json"
   },
   "devDependencies": {
     "babel-cli": "^6.14.0",
@@ -48,6 +49,7 @@
     "eslint-config-canonical": "1.8.1",
     "gitdown": "^2.5.0",
     "husky": "^0.11.7",
+    "jsonlint": "^1.6.2",
     "mocha": "^3.0.2",
     "standard-version": "^2.4.0",
     "travis-after-all": "^1.4.4"

--- a/src/configs/recommended.json
+++ b/src/configs/recommended.json
@@ -1,5 +1,4 @@
-/* eslint-disable */
-export default {
+{
   "parser": "babel-eslint",
   "rules": {
     "flowtype/boolean-style": [
@@ -42,4 +41,4 @@ export default {
       "onlyFilesWithFlowAnnotation": false
     }
   }
-};
+}

--- a/src/index.js
+++ b/src/index.js
@@ -15,7 +15,7 @@ import validSyntax from './rules/validSyntax';
 import booleanStyle from './rules/booleanStyle';
 import delimiterDangle from './rules/delimiterDangle';
 import noDupeKeys from './rules/noDupeKeys';
-import recommended from './configs/recommended';
+import recommended from './configs/recommended.json';
 
 export default {
   configs: {


### PR DESCRIPTION
* Reverts eedcac762eae38cf6030a0b816b86dcb0a2fdfd3.
* Add JSON configuration formatting to a precommit hook.