### PR TITLE
feat: check TypeCastExpressions in type colon spacing rules

### DIFF
--- a/src/rules/spaceAfterTypeColon.js
+++ b/src/rules/spaceAfterTypeColon.js
@@ -179,26 +179,28 @@ const objectTypePropertyEvaluator = (context) => {
 };
 
 const typeCastEvaluator = (context) => {
+  const sourceCode = context.getSourceCode();
   const {always} = parseOptions(context);
 
   return (typeCastExpression) => {
-    const spaces = typeCastExpression.typeAnnotation.typeAnnotation.start - typeCastExpression.typeAnnotation.start - 1;
+    const [, firstTokenOfType] = sourceCode.getFirstTokens(typeCastExpression.typeAnnotation, 2);
+    const spaces = firstTokenOfType.start - typeCastExpression.typeAnnotation.start - 1;
 
     if (always && spaces > 1) {
       context.report({
-        fix: spacingFixers.stripSpacesBefore(typeCastExpression.typeAnnotation.typeAnnotation, spaces - 1),
+        fix: spacingFixers.stripSpacesBefore(firstTokenOfType, spaces - 1),
         message: 'There must be 1 space after type cast colon.',
         node: typeCastExpression
       });
     } else if (always && spaces === 0) {
       context.report({
-        fix: spacingFixers.addSpaceBefore(typeCastExpression.typeAnnotation.typeAnnotation),
+        fix: spacingFixers.addSpaceBefore(firstTokenOfType),
         message: 'There must be a space after type cast colon.',
         node: typeCastExpression
       });
     } else if (!always && spaces > 0) {
       context.report({
-        fix: spacingFixers.stripSpacesBefore(typeCastExpression.typeAnnotation.typeAnnotation, spaces),
+        fix: spacingFixers.stripSpacesBefore(firstTokenOfType, spaces),
         message: 'There must be no space after type cast colon.',
         node: typeCastExpression
       });

--- a/src/rules/spaceAfterTypeColon.js
+++ b/src/rules/spaceAfterTypeColon.js
@@ -178,10 +178,39 @@ const objectTypePropertyEvaluator = (context) => {
   };
 };
 
+const typeCastEvaluator = (context) => {
+  const {always} = parseOptions(context);
+
+  return (typeCastExpression) => {
+    const spaces = typeCastExpression.typeAnnotation.typeAnnotation.start - typeCastExpression.typeAnnotation.start - 1;
+
+    if (always && spaces > 1) {
+      context.report({
+        fix: spacingFixers.stripSpacesBefore(typeCastExpression.typeAnnotation.typeAnnotation, spaces - 1),
+        message: 'There must be 1 space after type cast colon.',
+        node: typeCastExpression
+      });
+    } else if (always && spaces === 0) {
+      context.report({
+        fix: spacingFixers.addSpaceBefore(typeCastExpression.typeAnnotation.typeAnnotation),
+        message: 'There must be a space after type cast colon.',
+        node: typeCastExpression
+      });
+    } else if (!always && spaces > 0) {
+      context.report({
+        fix: spacingFixers.stripSpacesBefore(typeCastExpression.typeAnnotation.typeAnnotation, spaces),
+        message: 'There must be no space after type cast colon.',
+        node: typeCastExpression
+      });
+    }
+  };
+};
+
 export default (context) => {
   return {
     ...functionEvaluators(context),
     ClassProperty: propertyEvaluator(context, 'class property'),
-    ObjectTypeProperty: objectTypePropertyEvaluator(context)
+    ObjectTypeProperty: objectTypePropertyEvaluator(context),
+    TypeCastExpression: typeCastEvaluator(context)
   };
 };

--- a/src/rules/spaceBeforeTypeColon.js
+++ b/src/rules/spaceBeforeTypeColon.js
@@ -134,26 +134,28 @@ const objectTypePropertyEvaluator = (context) => {
 };
 
 const typeCastEvaluator = (context) => {
+  const sourceCode = context.getSourceCode();
   const {always} = parseOptions(context);
 
   return (typeCastExpression) => {
-    const spaces = typeCastExpression.typeAnnotation.start - typeCastExpression.expression.end;
+    const lastTokenOfIdentifier = sourceCode.getTokenBefore(typeCastExpression.typeAnnotation);
+    const spaces = typeCastExpression.typeAnnotation.start - lastTokenOfIdentifier.end;
 
     if (always && spaces > 1) {
       context.report({
-        fix: spacingFixers.stripSpacesAfter(typeCastExpression.expression, spaces - 1),
+        fix: spacingFixers.stripSpacesAfter(lastTokenOfIdentifier, spaces - 1),
         message: 'There must be 1 space before type cast colon.',
         node: typeCastExpression
       });
     } else if (always && spaces === 0) {
       context.report({
-        fix: spacingFixers.addSpaceAfter(typeCastExpression.expression),
+        fix: spacingFixers.addSpaceAfter(lastTokenOfIdentifier),
         message: 'There must be a space before type cast colon.',
         node: typeCastExpression
       });
     } else if (!always && spaces > 0) {
       context.report({
-        fix: spacingFixers.stripSpacesAfter(typeCastExpression.expression, spaces),
+        fix: spacingFixers.stripSpacesAfter(lastTokenOfIdentifier, spaces),
         message: 'There must be no space before type cast colon.',
         node: typeCastExpression
       });

--- a/src/rules/spaceBeforeTypeColon.js
+++ b/src/rules/spaceBeforeTypeColon.js
@@ -133,10 +133,39 @@ const objectTypePropertyEvaluator = (context) => {
   };
 };
 
+const typeCastEvaluator = (context) => {
+  const {always} = parseOptions(context);
+
+  return (typeCastExpression) => {
+    const spaces = typeCastExpression.typeAnnotation.start - typeCastExpression.expression.end;
+
+    if (always && spaces > 1) {
+      context.report({
+        fix: spacingFixers.stripSpacesAfter(typeCastExpression.expression, spaces - 1),
+        message: 'There must be 1 space before type cast colon.',
+        node: typeCastExpression
+      });
+    } else if (always && spaces === 0) {
+      context.report({
+        fix: spacingFixers.addSpaceAfter(typeCastExpression.expression),
+        message: 'There must be a space before type cast colon.',
+        node: typeCastExpression
+      });
+    } else if (!always && spaces > 0) {
+      context.report({
+        fix: spacingFixers.stripSpacesAfter(typeCastExpression.expression, spaces),
+        message: 'There must be no space before type cast colon.',
+        node: typeCastExpression
+      });
+    }
+  };
+};
+
 export default (context) => {
   return {
     ...functionEvaluators(context),
     ClassProperty: propertyEvaluator(context, 'class property'),
-    ObjectTypeProperty: objectTypePropertyEvaluator(context)
+    ObjectTypeProperty: objectTypePropertyEvaluator(context),
+    TypeCastExpression: typeCastEvaluator(context)
   };
 };

--- a/src/utilities/spacingFixers.js
+++ b/src/utilities/spacingFixers.js
@@ -1,6 +1,18 @@
+export const stripSpacesBefore = (node, spaces) => {
+  return (fixer) => {
+    return fixer.removeRange([node.start - spaces, node.start]);
+  };
+};
+
 export const stripSpacesAfter = (node, spaces) => {
   return (fixer) => {
     return fixer.removeRange([node.end, node.end + spaces]);
+  };
+};
+
+export const addSpaceBefore = (node) => {
+  return (fixer) => {
+    return fixer.insertTextBefore(node, ' ');
   };
 };
 

--- a/tests/rules/assertions/spaceAfterTypeColon.js
+++ b/tests/rules/assertions/spaceAfterTypeColon.js
@@ -703,6 +703,24 @@ const TYPE_CAST_EXPRESSIONS = {
       errors: [{message: 'There must be 1 space after type cast colon.'}],
       options: ['always'],
       output: 'const x = ({}: {})'
+    },
+    {
+      code: '((x): (string))',
+      errors: [{message: 'There must be no space after type cast colon.'}],
+      options: ['never'],
+      output: '((x):(string))'
+    },
+    {
+      code: '((x):(string))',
+      errors: [{message: 'There must be a space after type cast colon.'}],
+      options: ['always'],
+      output: '((x): (string))'
+    },
+    {
+      code: '((x):  (string))',
+      errors: [{message: 'There must be 1 space after type cast colon.'}],
+      options: ['always'],
+      output: '((x): (string))'
     }
   ],
   valid: [
@@ -712,6 +730,14 @@ const TYPE_CAST_EXPRESSIONS = {
     },
     {
       code: 'const x = ({}: {})',
+      options: ['always']
+    },
+    {
+      code: '((x):(string))',
+      options: ['never']
+    },
+    {
+      code: '((x): (string))',
       options: ['always']
     }
   ]

--- a/tests/rules/assertions/spaceAfterTypeColon.js
+++ b/tests/rules/assertions/spaceAfterTypeColon.js
@@ -683,6 +683,40 @@ const OBJECT_TYPE_PROPERTIES = {
   ]
 };
 
+
+const TYPE_CAST_EXPRESSIONS = {
+  invalid: [
+    {
+      code: 'const x = ({}: {})',
+      errors: [{message: 'There must be no space after type cast colon.'}],
+      options: ['never'],
+      output: 'const x = ({}:{})'
+    },
+    {
+      code: 'const x = ({}:{})',
+      errors: [{message: 'There must be a space after type cast colon.'}],
+      options: ['always'],
+      output: 'const x = ({}: {})'
+    },
+    {
+      code: 'const x = ({}:  {})',
+      errors: [{message: 'There must be 1 space after type cast colon.'}],
+      options: ['always'],
+      output: 'const x = ({}: {})'
+    }
+  ],
+  valid: [
+    {
+      code: 'const x = ({}:{})',
+      options: ['never']
+    },
+    {
+      code: 'const x = ({}: {})',
+      options: ['always']
+    }
+  ]
+};
+
 const ALL = [
   ARROW_FUNCTION_PARAMS,
   ARROW_FUNCTION_RETURN,
@@ -690,7 +724,8 @@ const ALL = [
   FUNCTION_RETURN,
   FUNCTION_TYPE_PARAMS,
   CLASS_PROPERTIES,
-  OBJECT_TYPE_PROPERTIES
+  OBJECT_TYPE_PROPERTIES,
+  TYPE_CAST_EXPRESSIONS
 ];
 
 export default {

--- a/tests/rules/assertions/spaceBeforeTypeColon.js
+++ b/tests/rules/assertions/spaceBeforeTypeColon.js
@@ -470,6 +470,39 @@ const OBJECT_TYPE_PROPERTIES = {
   ]
 };
 
+const TYPE_CAST_EXPRESSIONS = {
+  invalid: [
+    {
+      code: 'const x = ({} :{})',
+      errors: [{message: 'There must be no space before type cast colon.'}],
+      options: ['never'],
+      output: 'const x = ({}:{})'
+    },
+    {
+      code: 'const x = ({}:{})',
+      errors: [{message: 'There must be a space before type cast colon.'}],
+      options: ['always'],
+      output: 'const x = ({} :{})'
+    },
+    {
+      code: 'const x = ({}  :{})',
+      errors: [{message: 'There must be 1 space before type cast colon.'}],
+      options: ['always'],
+      output: 'const x = ({} :{})'
+    }
+  ],
+  valid: [
+    {
+      code: 'const x = ({}:{})',
+      options: ['never']
+    },
+    {
+      code: 'const x = ({} :{})',
+      options: ['always']
+    }
+  ]
+};
+
 const ALL = [
   ARROW_FUNCTION_PARAMS,
   ARROW_FUNCTION_RETURN,
@@ -477,7 +510,8 @@ const ALL = [
   FUNCTION_RETURN,
   FUNCTION_TYPE_PARAMS,
   CLASS_PROPERTIES,
-  OBJECT_TYPE_PROPERTIES
+  OBJECT_TYPE_PROPERTIES,
+  TYPE_CAST_EXPRESSIONS
 ];
 
 export default {

--- a/tests/rules/assertions/spaceBeforeTypeColon.js
+++ b/tests/rules/assertions/spaceBeforeTypeColon.js
@@ -489,6 +489,24 @@ const TYPE_CAST_EXPRESSIONS = {
       errors: [{message: 'There must be 1 space before type cast colon.'}],
       options: ['always'],
       output: 'const x = ({} :{})'
+    },
+    {
+      code: '((x) : string)',
+      errors: [{message: 'There must be no space before type cast colon.'}],
+      options: ['never'],
+      output: '((x): string)'
+    },
+    {
+      code: '((x): string)',
+      errors: [{message: 'There must be a space before type cast colon.'}],
+      options: ['always'],
+      output: '((x) : string)'
+    },
+    {
+      code: '((x)  : string)',
+      errors: [{message: 'There must be 1 space before type cast colon.'}],
+      options: ['always'],
+      output: '((x) : string)'
     }
   ],
   valid: [
@@ -498,6 +516,14 @@ const TYPE_CAST_EXPRESSIONS = {
     },
     {
       code: 'const x = ({} :{})',
+      options: ['always']
+    },
+    {
+      code: '((x): string)',
+      options: ['never']
+    },
+    {
+      code: '((x) : string)',
       options: ['always']
     }
   ]


### PR DESCRIPTION
For #114.

Leaving open as a PR for a few days while I make sure there's no edge cases to be covered, but I don't think there are.

**Edit:** parens need to be accounted for.. `((x): string)`