### PR TITLE
Deprecate `validSyntax`, Babylon has been fixed

### DIFF
--- a/.README/rules/valid-syntax.md
+++ b/.README/rules/valid-syntax.md
@@ -1,5 +1,5 @@
 ### `valid-syntax`
 
-Checks for simple Flow syntax errors.
+**Deprecated** Babylon (the Babel parser) v6.10.0 fixes parsing of the invalid syntax this plugin warned against.
 
-<!-- assertions validSyntax -->
+Checks for simple Flow syntax errors.

--- a/tests/rules/assertions/validSyntax.js
+++ b/tests/rules/assertions/validSyntax.js
@@ -1,24 +1,6 @@
 export default {
   invalid: [
-    {
-      code: 'function x(foo = "1": string) {}',
-      errors: [
-        {
-          message: '"foo" parameter type annotation must be placed on left-hand side of assignment.'
-        }
-      ]
-    },
-    {
-      code: 'function x(foo = bar(): Type, baz = []: []) {}',
-      errors: [
-        {
-          message: '"foo" parameter type annotation must be placed on left-hand side of assignment.'
-        },
-        {
-          message: '"baz" parameter type annotation must be placed on left-hand side of assignment.'
-        }
-      ]
-    }
+    // removed, as Babylon now prevents the invalid syntax
   ],
   valid: [
     {


### PR DESCRIPTION
Removed the "invalid" tests as they fail in the parser now.

May want to add an actual deprecation notice as a `console.log`, like this: https://github.com/yannickcr/eslint-plugin-react/blob/6a94967e9fe9dd97bf88244489f672ebe549605d/lib/rules/wrap-multilines.js#L45-L54