### PR TITLE
feat: add annotation enforcement option (fixes #126)

### DIFF
--- a/.README/rules/require-valid-file-annotation.md
+++ b/.README/rules/require-valid-file-annotation.md
@@ -1,19 +1,42 @@
 ### `require-valid-file-annotation`
 
-Makes sure that files have a valid `@flow` annotation. It will report annotations with typos (such as `// @floww`) or not placed at the top of the file, and optionaly missing annotations.
+This rule validates Flow file annotations.
+
+This rule can optionally report missing or missed placed annotations, common typos (e.g. `// @floww`), and enforce a consistant annotation style.
 
 #### Options
 
-By default, this rule won't complain if there is no `@flow` annotation at all in the file. Passing a `"always"` option reports files missing those annotations as well.
+The rule has a string option:
+
+* `"never"` (default): Never report files that are missing an `@flow` annotation.
+* `"always"`: Always report files that are missing an `@flow` annotation
+
+This rule has an object option:
+
+* `"annotationStyle"` - Enforce a consistant file annotation style.
+    * `"none"` (default): Either annotation style is accepted.
+    * `"line"`: Require single line annotations (i.e. `// @flow`).
+    * `"block"`: Require block annotations (i.e. `/* @flow */`).
 
 ```js
 {
-    "rules": {
-        "flowtype/require-valid-file-annotation": [
-            2,
-            "always"
-        ]
-    }
+  "rules": {
+    "flowtype/require-valid-file-annotation": [
+      2,
+      "always"
+    ]
+  }
+}
+
+{
+  "rules": {
+    "flowtype/require-valid-file-annotation": [
+      2,
+      "always", {
+        "annotationStyle": "block"
+      }
+    ]
+  }
 }
 ```
 

--- a/tests/rules/assertions/requireValidFileAnnotation.js
+++ b/tests/rules/assertions/requireValidFileAnnotation.js
@@ -58,6 +58,34 @@ export default {
       options: [
         'always'
       ]
+    },
+    {
+      code: '/* @flow */',
+      errors: [
+        {
+          message: 'Flow file annotation style must be `// @flow`'
+        }
+      ],
+      options: [
+        'always',
+        {
+          annotationStyle: 'line'
+        }
+      ]
+    },
+    {
+      code: '// @flow',
+      errors: [
+        {
+          message: 'Flow file annotation style must be `/* @flow */`'
+        }
+      ],
+      options: [
+        'always',
+        {
+          annotationStyle: 'block'
+        }
+      ]
     }
   ],
   valid: [
@@ -93,6 +121,24 @@ export default {
           onlyFilesWithFlowAnnotation: true
         }
       }
+    },
+    {
+      code: '// @flow',
+      options: [
+        'always',
+        {
+          annotationStyle: 'line'
+        }
+      ]
+    },
+    {
+      code: '/* @flow */',
+      options: [
+        'always',
+        {
+          annotationStyle: 'block'
+        }
+      ]
     }
   ]
 };


### PR DESCRIPTION
This PR adds an option to `require-valid-file-annotation` that allows enforcement of an annotation style (default: none) for files.

