### PR TITLE
feat: add object-type-delimiter rule

### DIFF
--- a/.README/README.md
+++ b/.README/README.md
@@ -51,6 +51,10 @@ npm install eslint-plugin-flowtype
       "never"
     ],
     "flowtype/no-weak-types": 2,
+    "flowtype/object-type-delimiter": [
+      2,
+      "comma"
+    ],
     "flowtype/require-parameter-type": 2,
     "flowtype/require-return-type": [
       2,
@@ -142,6 +146,7 @@ When `true`, only checks files with a [`@flow` annotation](http://flowtype.org/d
 {"gitdown": "include", "file": "./rules/generic-spacing.md"}
 {"gitdown": "include", "file": "./rules/no-dupe-keys.md"}
 {"gitdown": "include", "file": "./rules/no-weak-types.md"}
+{"gitdown": "include", "file": "./rules/object-type-delimiter.md"}
 {"gitdown": "include", "file": "./rules/require-parameter-type.md"}
 {"gitdown": "include", "file": "./rules/require-return-type.md"}
 {"gitdown": "include", "file": "./rules/require-valid-file-annotation.md"}

--- a/.README/rules/object-type-delimiter.md
+++ b/.README/rules/object-type-delimiter.md
@@ -1,0 +1,17 @@
+### `object-type-delimiter`
+
+_The `--fix` option on the command line automatically fixes problems reported by this rule._
+
+Enforces consistent separators between properties in Flow object types.
+
+This rule takes one argument.
+
+If it is `'comma'` then a problem is raised when using `;` as a separator.
+
+If it is `'semicolon'` then a problem is raised when using `,` as a separator.
+
+The default value is `'comma'`.
+
+_This rule is ported from `babel/flow-object-type`, however the default option was changed._
+
+<!-- assertions objectTypeDelimiter -->

--- a/src/index.js
+++ b/src/index.js
@@ -16,6 +16,7 @@ import booleanStyle from './rules/booleanStyle';
 import delimiterDangle from './rules/delimiterDangle';
 import noDupeKeys from './rules/noDupeKeys';
 import sortKeys from './rules/sortKeys';
+import objectTypeDelimiter from './rules/objectTypeDelimiter';
 import recommended from './configs/recommended.json';
 
 export default {
@@ -29,6 +30,7 @@ export default {
     'generic-spacing': genericSpacing,
     'no-dupe-keys': noDupeKeys,
     'no-weak-types': noWeakTypes,
+    'object-type-delimiter': objectTypeDelimiter,
     'require-parameter-type': requireParameterType,
     'require-return-type': requireReturnType,
     'require-valid-file-annotation': requireValidFileAnnotation,
@@ -49,6 +51,7 @@ export default {
     'generic-spacing': 0,
     'no-dupe-keys': 0,
     'no-weak-types': 0,
+    'object-type-delimiter': 0,
     'require-parameter-type': 0,
     'require-return-type': 0,
     semi: 0,

--- a/src/rules/objectTypeDelimiter.js
+++ b/src/rules/objectTypeDelimiter.js
@@ -1,0 +1,57 @@
+ // ported from babel/flow-object-type; original author: Nat Mote
+ // https://github.com/babel/eslint-plugin-babel/blob/c0a49d25a97feb12c1d07073a0b37317359a5fe5/rules/flow-object-type.js
+
+const SEMICOLON = {
+  char: ';',
+  name: 'semicolon'
+};
+
+const COMMA = {
+  char: ',',
+  name: 'comma'
+};
+
+const create = (context) => {
+  let GOOD;
+  let BAD;
+
+  if (!context.options[0] || context.options[0] === COMMA.name) {
+    GOOD = COMMA;
+    BAD = SEMICOLON;
+  } else {
+    GOOD = SEMICOLON;
+    BAD = COMMA;
+  }
+
+  const requireProperPunctuation = (node) => {
+    const tokens = context.getSourceCode().getTokens(node);
+    const lastToken = tokens[tokens.length - 1];
+
+    if (lastToken.type === 'Punctuator') {
+      if (lastToken.value === BAD.char) {
+        context.report({
+          fix (fixer) {
+            return fixer.replaceText(lastToken, GOOD.char);
+          },
+          message: 'Prefer ' + GOOD.name + 's to ' + BAD.name + 's in object and class types',
+          node: lastToken
+        });
+      }
+    }
+  };
+
+  return {
+    ObjectTypeProperty: requireProperPunctuation
+  };
+};
+
+const schema = [
+  {
+    enum: ['semicolon', 'comma']
+  }
+];
+
+export default {
+  create,
+  schema
+};

--- a/tests/rules/assertions/objectTypeDelimiter.js
+++ b/tests/rules/assertions/objectTypeDelimiter.js
@@ -1,0 +1,49 @@
+export default {
+  invalid: [
+    {
+      code: 'type Foo = { a: Foo, b: Bar }',
+      errors: [{message: 'Prefer semicolons to commas in object and class types'}],
+      options: ['semicolon'],
+      output: 'type Foo = { a: Foo; b: Bar }'
+    },
+    {
+      code: 'type Foo = { a: Foo; b: Bar }',
+      errors: [{message: 'Prefer commas to semicolons in object and class types'}],
+      options: ['comma'],
+      output: 'type Foo = { a: Foo, b: Bar }'
+    },
+    {
+      code: 'declare class Foo { a: Foo, }',
+      errors: [{message: 'Prefer semicolons to commas in object and class types'}],
+      options: ['semicolon'],
+      output: 'declare class Foo { a: Foo; }'
+    },
+    {
+      code: 'declare class Foo { a: Foo; }',
+      errors: [{message: 'Prefer commas to semicolons in object and class types'}],
+      options: ['comma'],
+      output: 'declare class Foo { a: Foo, }'
+    }
+  ],
+  valid: [
+    {
+      code: 'type Foo = { a: Foo; b: Bar }',
+      options: ['semicolon']
+    },
+    {
+      code: 'type Foo = { a: Foo, b: Bar }',
+      options: ['comma']
+    },
+    {
+      code: 'type Foo = { a: Foo, b: Bar }'
+    },
+    {
+      code: 'declare class Foo { a: Foo; }',
+      options: ['semicolon']
+    },
+    {
+      code: 'declare class Foo { a: Foo, }',
+      options: ['comma']
+    }
+  ]
+};

--- a/tests/rules/index.js
+++ b/tests/rules/index.js
@@ -13,6 +13,7 @@ const reportingRules = [
   'generic-spacing',
   'no-dupe-keys',
   'no-weak-types',
+  'object-type-delimiter',
   'require-parameter-type',
   'require-return-type',
   'require-valid-file-annotation',


### PR DESCRIPTION
Ported from [`babel/flow-object-type`](https://github.com/babel/eslint-plugin-babel).

See #40, https://github.com/babel/eslint-plugin-babel/issues/93.

I did make one change though: I've changed the default from `semicolon` to `comma` - it seems to be much more common.