### PR TITLE
feat: Add excludeParameterMatch option to require-parameter-type

### DIFF
--- a/.README/rules/require-parameter-type.md
+++ b/.README/rules/require-parameter-type.md
@@ -32,4 +32,22 @@ Alternatively, you can want to exclude only concise arrow functions (e.g. `x => 
 }
 ```
 
+You can exclude parameters that match a certain regex by using `excludeParameterMatch`.
+
+```js
+{
+    "rules": {
+        "flowtype/require-parameter-type": [
+            2,
+            {
+              "excludeParameterMatch": "^_"
+            }
+        ]
+    }
+}
+```
+
+This excludes all parameters that start with an underscore (`_`).
+The default pattern is `a^`, which doesn't match anything, i.e., all parameters are checked.
+
 <!-- assertions requireParameterType -->

--- a/src/rules/requireParameterType.js
+++ b/src/rules/requireParameterType.js
@@ -14,9 +14,16 @@ export default iterateFunctionNodes((context) => {
   }
 
   const skipArrows = _.get(context, 'options[0].excludeArrowFunctions');
+  const excludeParameterMatch = new RegExp(_.get(context, 'options[0].excludeParameterMatch', 'a^'));
 
   return (functionNode) => {
     _.forEach(functionNode.params, (identifierNode) => {
+      const parameterName = getParameterName(identifierNode, context);
+
+      if (excludeParameterMatch.test(parameterName)) {
+        return;
+      }
+
       const typeAnnotation = _.get(identifierNode, 'typeAnnotation') || _.get(identifierNode, 'left.typeAnnotation');
 
       const isArrow = functionNode.type === 'ArrowFunctionExpression';
@@ -29,7 +36,7 @@ export default iterateFunctionNodes((context) => {
       if (!typeAnnotation) {
         context.report({
           data: {
-            name: quoteName(getParameterName(identifierNode, context))
+            name: quoteName(parameterName)
           },
           message: 'Missing {{name}}parameter type annotation.',
           node: identifierNode

--- a/tests/rules/assertions/requireParameterType.js
+++ b/tests/rules/assertions/requireParameterType.js
@@ -107,6 +107,32 @@ export default {
           excludeArrowFunctions: 'expressionsOnly'
         }
       ]
+    },
+    {
+      code: '(_foo: number, bar) => {}',
+      errors: [
+        {
+          message: 'Missing "bar" parameter type annotation.'
+        }
+      ],
+      options: [
+        {
+          excludeParameterMatch: '^_'
+        }
+      ]
+    },
+    {
+      code: '(_foo, bar) => {}',
+      errors: [
+        {
+          message: 'Missing "bar" parameter type annotation.'
+        }
+      ],
+      options: [
+        {
+          excludeParameterMatch: '^_'
+        }
+      ]
     }
   ],
   valid: [
@@ -146,6 +172,22 @@ export default {
       options: [
         {
           excludeArrowFunctions: 'expressionsOnly'
+        }
+      ]
+    },
+    {
+      code: '(_foo, bar: string) => {}',
+      options: [
+        {
+          excludeParameterMatch: '^_'
+        }
+      ]
+    },
+    {
+      code: '(_foo: number, bar: string) => {}',
+      options: [
+        {
+          excludeParameterMatch: '^_'
         }
       ]
     }


### PR DESCRIPTION
This adds the ability to include an option - `excludeParameterMatch` - that takes a regex of parameters to ignore.

This solves the same need as #17/#18, but is (in my opinion) a bit more flexible. (Also, there was no activity on that PR for a few months and I want this ;) )

Closes #17 
Closes #18