### PR TITLE
Support dynamic accessors and callable objects in object-type-delimiter

### DIFF
--- a/src/rules/objectTypeDelimiter.js
+++ b/src/rules/objectTypeDelimiter.js
@@ -41,6 +41,8 @@ const create = (context) => {
   };
 
   return {
+    ObjectTypeCallProperty: requireProperPunctuation,
+    ObjectTypeIndexer: requireProperPunctuation,
     ObjectTypeProperty: requireProperPunctuation
   };
 };

--- a/tests/rules/assertions/objectTypeDelimiter.js
+++ b/tests/rules/assertions/objectTypeDelimiter.js
@@ -13,6 +13,30 @@ export default {
       output: 'type Foo = { a: Foo, b: Bar }'
     },
     {
+      code: 'type Foo = { [a: string]: Foo, [b: string]: Bar }',
+      errors: [{message: 'Prefer semicolons to commas in object and class types'}],
+      options: ['semicolon'],
+      output: 'type Foo = { [a: string]: Foo; [b: string]: Bar }'
+    },
+    {
+      code: 'type Foo = { [a: string]: Foo; [b: string]: Bar }',
+      errors: [{message: 'Prefer commas to semicolons in object and class types'}],
+      options: ['comma'],
+      output: 'type Foo = { [a: string]: Foo, [b: string]: Bar }'
+    },
+    {
+      code: 'type Foo = { (): Foo, (): Bar }',
+      errors: [{message: 'Prefer semicolons to commas in object and class types'}],
+      options: ['semicolon'],
+      output: 'type Foo = { (): Foo; (): Bar }'
+    },
+    {
+      code: 'type Foo = { (): Foo; (): Bar }',
+      errors: [{message: 'Prefer commas to semicolons in object and class types'}],
+      options: ['comma'],
+      output: 'type Foo = { (): Foo, (): Bar }'
+    },
+    {
       code: 'declare class Foo { a: Foo, }',
       errors: [{message: 'Prefer semicolons to commas in object and class types'}],
       options: ['semicolon'],
@@ -23,6 +47,42 @@ export default {
       errors: [{message: 'Prefer commas to semicolons in object and class types'}],
       options: ['comma'],
       output: 'declare class Foo { a: Foo, }'
+    },
+    {
+      code: 'declare class Foo { [a: string]: Foo, }',
+      errors: [{message: 'Prefer semicolons to commas in object and class types'}],
+      options: ['semicolon'],
+      output: 'declare class Foo { [a: string]: Foo; }'
+    },
+    {
+      code: 'declare class Foo { a: Foo; }',
+      errors: [{message: 'Prefer commas to semicolons in object and class types'}],
+      options: ['comma'],
+      output: 'declare class Foo { a: Foo, }'
+    },
+    {
+      code: 'declare class Foo { (): Foo, }',
+      errors: [{message: 'Prefer semicolons to commas in object and class types'}],
+      options: ['semicolon'],
+      output: 'declare class Foo { (): Foo; }'
+    },
+    {
+      code: 'declare class Foo { (): Foo; }',
+      errors: [{message: 'Prefer commas to semicolons in object and class types'}],
+      options: ['comma'],
+      output: 'declare class Foo { (): Foo, }'
+    },
+    {
+      code: 'declare class Foo { static (): Foo, }',
+      errors: [{message: 'Prefer semicolons to commas in object and class types'}],
+      options: ['semicolon'],
+      output: 'declare class Foo { static (): Foo; }'
+    },
+    {
+      code: 'declare class Foo { static (): Foo; }',
+      errors: [{message: 'Prefer commas to semicolons in object and class types'}],
+      options: ['comma'],
+      output: 'declare class Foo { static (): Foo, }'
     }
   ],
   valid: [
@@ -35,7 +95,29 @@ export default {
       options: ['comma']
     },
     {
+      code: 'type Foo = { [a: string]: Foo; [b: string]: Bar }',
+      options: ['semicolon']
+    },
+    {
+      code: 'type Foo = { [a: string]: Foo, [b: string]: Bar }',
+      options: ['comma']
+    },
+    {
+      code: 'type Foo = { (): Foo; (): Bar }',
+      options: ['semicolon']
+    },
+    {
+      code: 'type Foo = { (): Foo, (): Bar }',
+      options: ['comma']
+    },
+    {
       code: 'type Foo = { a: Foo, b: Bar }'
+    },
+    {
+      code: 'type Foo = { [a: string]: Foo, [b: string]: Bar }'
+    },
+    {
+      code: 'type Foo = { (): Foo, (): Bar }'
     },
     {
       code: 'declare class Foo { a: Foo; }',
@@ -43,6 +125,22 @@ export default {
     },
     {
       code: 'declare class Foo { a: Foo, }',
+      options: ['comma']
+    },
+    {
+      code: 'declare class Foo { [a: string]: Foo; }',
+      options: ['semicolon']
+    },
+    {
+      code: 'declare class Foo { [a: string]: Foo, }',
+      options: ['comma']
+    },
+    {
+      code: 'declare class Foo { (): Foo; }',
+      options: ['semicolon']
+    },
+    {
+      code: 'declare class Foo { (): Foo, }',
       options: ['comma']
     }
   ]


### PR DESCRIPTION
I could not figure out how to rebuild the documentation, and had to `git commit --no-verify`. I would love to contribute more to this project, but the setup is so complicated and it's not very debug friendly :(