### PR TITLE
 Add rule for requiring variable type

### DIFF
--- a/.README/rules/require-variable-type.md
+++ b/.README/rules/require-variable-type.md
@@ -1,0 +1,5 @@
+### `require-variable-type`
+
+Requires that all variable declarators have type annotations.
+
+<!-- assertions requireVariableType -->

--- a/.README/rules/require-variable-type.md
+++ b/.README/rules/require-variable-type.md
@@ -2,4 +2,25 @@
 
 Requires that all variable declarators have type annotations.
 
+#### Options
+
+You can exclude variables that match a certain regex by using `excludeVariableMatch`.
+
+This excludes all parameters that start with an underscore (`_`).
+The default pattern is `a^`, which doesn't match anything, i.e., all parameters are checked.
+
+```js
+{
+    "rules": {
+        "flowtype/require-variable-type": [
+            2,
+            {
+              "excludeVariableMatch": "^_"
+            }
+        ]
+    }
+}
+```
+
+
 <!-- assertions requireVariableType -->

--- a/.README/rules/require-variable-type.md
+++ b/.README/rules/require-variable-type.md
@@ -23,4 +23,28 @@ The default pattern is `a^`, which doesn't match anything, i.e., all parameters 
 ```
 
 
+You can choose specific variable types (`var`, `let`, and `const`) to ignore using `excludeVariableTypes`.
+
+This excludes `var` and `let` declarations from needing type annotations, but forces `const` declarations to have it.
+By default, all declarations are checked.
+
+```js
+{
+    "rules": {
+        "flowtype/require-variable-type": [
+            2,
+            {
+              "excludeVariableTypes": {
+                "var": true,
+                "let": true,
+                "const": false,
+              }
+            }
+        ]
+    }
+}
+```
+
+
+
 <!-- assertions requireVariableType -->

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,7 @@ import noWeakTypes from './rules/noWeakTypes';
 import requireParameterType from './rules/requireParameterType';
 import requireReturnType from './rules/requireReturnType';
 import requireValidFileAnnotation from './rules/requireValidFileAnnotation';
+import requireVariableType from './rules/requireVariableType';
 import semi from './rules/semi';
 import spaceAfterTypeColon from './rules/spaceAfterTypeColon';
 import spaceBeforeGenericBracket from './rules/spaceBeforeGenericBracket';
@@ -34,6 +35,7 @@ export default {
     'require-parameter-type': requireParameterType,
     'require-return-type': requireReturnType,
     'require-valid-file-annotation': requireValidFileAnnotation,
+    'require-variable-type': requireVariableType,
     semi,
     'sort-keys': sortKeys,
     'space-after-type-colon': spaceAfterTypeColon,
@@ -54,6 +56,7 @@ export default {
     'object-type-delimiter': 0,
     'require-parameter-type': 0,
     'require-return-type': 0,
+    'require-variable-type': 0,
     semi: 0,
     'sort-keys': 0,
     'space-after-type-colon': 0,

--- a/src/rules/requireVariableType.js
+++ b/src/rules/requireVariableType.js
@@ -1,0 +1,33 @@
+import _ from 'lodash';
+import {
+    isFlowFile,
+    quoteName
+} from './../utilities';
+
+export default (context) => {
+  const checkThisFile = !_.get(context, 'settings.flowtype.onlyFilesWithFlowAnnotation') || isFlowFile(context);
+
+  if (!checkThisFile) {
+    return () => {};
+  }
+
+  return {
+    VariableDeclaration: (variableDeclaration) => {
+      _.forEach(variableDeclaration.declarations, (variableDeclarator) => {
+        const identifierNode = _.get(variableDeclarator, 'id');
+        const typeAnnotation = _.get(identifierNode, 'typeAnnotation');
+        const identifierName = _.get(identifierNode, 'name');
+
+        if (!typeAnnotation) {
+          context.report({
+            data: {
+              name: quoteName(identifierName)
+            },
+            message: 'Missing {{name}}variable type annotation.',
+            node: identifierNode
+          });
+        }
+      });
+    }
+  };
+};

--- a/src/rules/requireVariableType.js
+++ b/src/rules/requireVariableType.js
@@ -12,9 +12,16 @@ export default (context) => {
   }
 
   const excludeVariableMatch = new RegExp(_.get(context, 'options[0].excludeVariableMatch', 'a^'));
+  const excludeVariableTypes = _.get(context, 'options[0].excludeVariableTypes', {});
 
   return {
     VariableDeclaration: (variableDeclaration) => {
+      const variableType = _.get(variableDeclaration, 'kind');
+
+      if (_.get(excludeVariableTypes, variableType)) {
+        return;
+      }
+
       _.forEach(variableDeclaration.declarations, (variableDeclarator) => {
         const identifierNode = _.get(variableDeclarator, 'id');
         const identifierName = _.get(identifierNode, 'name');

--- a/src/rules/requireVariableType.js
+++ b/src/rules/requireVariableType.js
@@ -11,12 +11,19 @@ export default (context) => {
     return () => {};
   }
 
+  const excludeVariableMatch = new RegExp(_.get(context, 'options[0].excludeVariableMatch', 'a^'));
+
   return {
     VariableDeclaration: (variableDeclaration) => {
       _.forEach(variableDeclaration.declarations, (variableDeclarator) => {
         const identifierNode = _.get(variableDeclarator, 'id');
-        const typeAnnotation = _.get(identifierNode, 'typeAnnotation');
         const identifierName = _.get(identifierNode, 'name');
+
+        if (excludeVariableMatch.test(identifierName)) {
+          return;
+        }
+
+        const typeAnnotation = _.get(identifierNode, 'typeAnnotation');
 
         if (!typeAnnotation) {
           context.report({

--- a/tests/rules/assertions/requireVariableType.js
+++ b/tests/rules/assertions/requireVariableType.js
@@ -28,6 +28,22 @@ export default {
           excludeVariableMatch: '^_'
         }
       ]
+    },
+    {
+      code: 'var foo = "bar", bar = 1; const oob : string = "oob"; let hey = "yah"',
+      errors: [
+        {
+          message: 'Missing "hey" variable type annotation.'
+        }
+      ],
+      options: [
+        {
+          excludeVariableTypes: {
+            let: false,
+            var: true
+          }
+        }
+      ]
     }
   ],
   valid: [
@@ -42,6 +58,27 @@ export default {
       options: [
         {
           excludeVariableMatch: '^_'
+        }
+      ]
+    },
+    {
+      code: 'var foo = "bar", bar = 1',
+      options: [
+        {
+          excludeVariableTypes: {
+            var: true
+          }
+        }
+      ]
+    },
+    {
+      code: 'var foo = "bar", bar = 1; const oob : string = "oob"; let hey = "yah"',
+      options: [
+        {
+          excludeVariableTypes: {
+            let: true,
+            var: true
+          }
         }
       ]
     }

--- a/tests/rules/assertions/requireVariableType.js
+++ b/tests/rules/assertions/requireVariableType.js
@@ -15,8 +15,20 @@ export default {
           message: 'Missing "bar" variable type annotation.'
         }
       ]
+    },
+    {
+      code: 'var _foo = "bar", bar = 1',
+      errors: [
+        {
+          message: 'Missing "bar" variable type annotation.'
+        }
+      ],
+      options: [
+        {
+          excludeVariableMatch: '^_'
+        }
+      ]
     }
-
   ],
   valid: [
     {
@@ -24,6 +36,14 @@ export default {
     },
     {
       code: 'var foo : string = "bar", bar : number = 1'
+    },
+    {
+      code: 'var _foo = "bar", bar : number = 1',
+      options: [
+        {
+          excludeVariableMatch: '^_'
+        }
+      ]
     }
   ]
 };

--- a/tests/rules/assertions/requireVariableType.js
+++ b/tests/rules/assertions/requireVariableType.js
@@ -1,0 +1,29 @@
+export default {
+  invalid: [
+    {
+      code: 'var foo = "bar"',
+      errors: [
+        {
+          message: 'Missing "foo" variable type annotation.'
+        }
+      ]
+    },
+    {
+      code: 'var foo : string = "bar", bar = 1',
+      errors: [
+        {
+          message: 'Missing "bar" variable type annotation.'
+        }
+      ]
+    }
+
+  ],
+  valid: [
+    {
+      code: 'var foo : string = "bar"'
+    },
+    {
+      code: 'var foo : string = "bar", bar : number = 1'
+    }
+  ]
+};

--- a/tests/rules/index.js
+++ b/tests/rules/index.js
@@ -17,6 +17,7 @@ const reportingRules = [
   'require-parameter-type',
   'require-return-type',
   'require-valid-file-annotation',
+  'require-variable-type',
   'semi',
   'sort-keys',
   'space-after-type-colon',


### PR DESCRIPTION
This adds a rule that enforces types for all variable declarations.
It has options to ignore declarations based on type (`var`, `let`, or `const`) and based on identifier name (works the same way as what was added to `require-paramter-type` in #143)

Closes #19 

Edit: Let me know if I should squash my commits. It felt cleaner to have them separate, but it's up to you. :)