### PR TITLE
refactor: improve flow file check logic

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,5 @@
+import _ from 'lodash';
+import {checkFlowFileAnnotation} from './utilities';
 import defineFlowType from './rules/defineFlowType';
 import genericSpacing from './rules/genericSpacing';
 import noWeakTypes from './rules/noWeakTypes';
@@ -19,31 +21,43 @@ import sortKeys from './rules/sortKeys';
 import objectTypeDelimiter from './rules/objectTypeDelimiter';
 import recommended from './configs/recommended.json';
 
+const rules = {
+  'boolean-style': booleanStyle,
+  'define-flow-type': defineFlowType,
+  'delimiter-dangle': delimiterDangle,
+  'generic-spacing': genericSpacing,
+  'no-dupe-keys': noDupeKeys,
+  'no-weak-types': noWeakTypes,
+  'object-type-delimiter': objectTypeDelimiter,
+  'require-parameter-type': requireParameterType,
+  'require-return-type': requireReturnType,
+  'require-valid-file-annotation': requireValidFileAnnotation,
+  semi,
+  'sort-keys': sortKeys,
+  'space-after-type-colon': spaceAfterTypeColon,
+  'space-before-generic-bracket': spaceBeforeGenericBracket,
+  'space-before-type-colon': spaceBeforeTypeColon,
+  'type-id-match': typeIdMatch,
+  'union-intersection-spacing': unionIntersectionSpacing,
+  'use-flow-type': useFlowType,
+  'valid-syntax': validSyntax
+};
+
 export default {
   configs: {
     recommended
   },
-  rules: {
-    'boolean-style': booleanStyle,
-    'define-flow-type': defineFlowType,
-    'delimiter-dangle': delimiterDangle,
-    'generic-spacing': genericSpacing,
-    'no-dupe-keys': noDupeKeys,
-    'no-weak-types': noWeakTypes,
-    'object-type-delimiter': objectTypeDelimiter,
-    'require-parameter-type': requireParameterType,
-    'require-return-type': requireReturnType,
-    'require-valid-file-annotation': requireValidFileAnnotation,
-    semi,
-    'sort-keys': sortKeys,
-    'space-after-type-colon': spaceAfterTypeColon,
-    'space-before-generic-bracket': spaceBeforeGenericBracket,
-    'space-before-type-colon': spaceBeforeTypeColon,
-    'type-id-match': typeIdMatch,
-    'union-intersection-spacing': unionIntersectionSpacing,
-    'use-flow-type': useFlowType,
-    'valid-syntax': validSyntax
-  },
+  rules: _.mapValues(rules, (rule) => {
+    // Support current and deprecated rule formats
+    if (_.isPlainObject(rule)) {
+      return {
+        ...rule,
+        create: _.partial(checkFlowFileAnnotation, rule.create)
+      };
+    }
+
+    return _.partial(checkFlowFileAnnotation, rule);
+  }),
   rulesConfig: {
     'boolean-style': 0,
     'define-flow-type': 0,

--- a/src/rules/requireParameterType.js
+++ b/src/rules/requireParameterType.js
@@ -1,18 +1,11 @@
 import _ from 'lodash';
 import {
     getParameterName,
-    isFlowFile,
     iterateFunctionNodes,
     quoteName
 } from './../utilities';
 
 export default iterateFunctionNodes((context) => {
-  const checkThisFile = !_.get(context, 'settings.flowtype.onlyFilesWithFlowAnnotation') || isFlowFile(context);
-
-  if (!checkThisFile) {
-    return () => {};
-  }
-
   const skipArrows = _.get(context, 'options[0].excludeArrowFunctions');
   const excludeParameterMatch = new RegExp(_.get(context, 'options[0].excludeParameterMatch', 'a^'));
 

--- a/src/rules/requireReturnType.js
+++ b/src/rules/requireReturnType.js
@@ -1,15 +1,6 @@
 import _ from 'lodash';
-import {
-    isFlowFile
-} from './../utilities';
 
 export default (context) => {
-  const checkThisFile = !_.get(context, 'settings.flowtype.onlyFilesWithFlowAnnotation') || isFlowFile(context);
-
-  if (!checkThisFile) {
-    return () => {};
-  }
-
   const annotateReturn = (_.get(context, 'options[0]') || 'always') === 'always';
   const annotateUndefined = (_.get(context, 'options[1].annotateUndefined') || 'never') === 'always';
   const skipArrows = _.get(context, 'options[1].excludeArrowFunctions') || false;

--- a/src/rules/requireValidFileAnnotation.js
+++ b/src/rules/requireValidFileAnnotation.js
@@ -1,6 +1,5 @@
 import _ from 'lodash';
 import {
-    isFlowFile,
     isFlowFileAnnotation
 } from './../utilities';
 
@@ -27,12 +26,6 @@ export const schema = [
 ];
 
 export default (context) => {
-  const checkThisFile = !_.get(context, 'settings.flowtype.onlyFilesWithFlowAnnotation') || isFlowFile(context);
-
-  if (!checkThisFile) {
-    return {};
-  }
-
   const always = context.options[0] === 'always';
   const style = _.get(context, 'options[1].annotationStyle', defaults.annotationStyle);
 

--- a/src/utilities/checkFlowFileAnnotation.js
+++ b/src/utilities/checkFlowFileAnnotation.js
@@ -1,0 +1,12 @@
+import _ from 'lodash';
+import isFlowFile from './isFlowFile';
+
+export default (cb, context) => {
+  const checkThisFile = !_.get(context, 'settings.flowtype.onlyFilesWithFlowAnnotation') || isFlowFile(context);
+
+  if (!checkThisFile) {
+    return () => {};
+  }
+
+  return cb(context);
+};

--- a/src/utilities/index.js
+++ b/src/utilities/index.js
@@ -8,3 +8,4 @@ export * as spacingFixers from './spacingFixers';
 export quoteName from './quoteName';
 export getTokenBeforeParens from './getTokenBeforeParens';
 export getTokenAfterParens from './getTokenAfterParens';
+export checkFlowFileAnnotation from './checkFlowFileAnnotation';

--- a/tests/rules/assertions/booleanStyle.js
+++ b/tests/rules/assertions/booleanStyle.js
@@ -29,6 +29,15 @@ export default {
     {
       code: 'type X = bool',
       options: ['bool']
+    },
+    {
+      code: 'type X = bool',
+      options: ['boolean'],
+      settings: {
+        flowtype: {
+          onlyFilesWithFlowAnnotation: true
+        }
+      }
     }
   ]
 };

--- a/tests/rules/assertions/noDupeKeys.js
+++ b/tests/rules/assertions/noDupeKeys.js
@@ -12,6 +12,14 @@ export default {
   valid: [
     {
       code: 'type FooType = { a: number, b: string, c: number }'
+    },
+    {
+      code: 'type FooType = { a: number, b: string, a: number }',
+      settings: {
+        flowtype: {
+          onlyFilesWithFlowAnnotation: true
+        }
+      }
     }
   ]
 };

--- a/tests/rules/assertions/noWeakTypes.js
+++ b/tests/rules/assertions/noWeakTypes.js
@@ -246,6 +246,14 @@ export default {
     {
       code: 'type X = Function',
       options: [{Function: false}]
+    },
+    {
+      code: 'function foo(thing): Function {}',
+      settings: {
+        flowtype: {
+          onlyFilesWithFlowAnnotation: true
+        }
+      }
     }
   ]
 };

--- a/tests/rules/assertions/objectTypeDelimiter.js
+++ b/tests/rules/assertions/objectTypeDelimiter.js
@@ -142,6 +142,15 @@ export default {
     {
       code: 'declare class Foo { (): Foo, }',
       options: ['comma']
+    },
+    {
+      code: 'type Foo = { a: Foo, b: Bar }',
+      options: ['semicolon'],
+      settings: {
+        flowtype: {
+          onlyFilesWithFlowAnnotation: true
+        }
+      }
     }
   ]
 };

--- a/tests/rules/assertions/requireParameterType.js
+++ b/tests/rules/assertions/requireParameterType.js
@@ -190,6 +190,14 @@ export default {
           excludeParameterMatch: '^_'
         }
       ]
+    },
+    {
+      code: '(foo) => {}',
+      settings: {
+        flowtype: {
+          onlyFilesWithFlowAnnotation: true
+        }
+      }
     }
   ]
 };

--- a/tests/rules/assertions/semi.js
+++ b/tests/rules/assertions/semi.js
@@ -50,6 +50,14 @@ export default {
     {
       code: 'type FooType = {}',
       options: ['never']
+    },
+    {
+      code: 'type FooType = {}',
+      settings: {
+        flowtype: {
+          onlyFilesWithFlowAnnotation: true
+        }
+      }
     }
   ]
 };

--- a/tests/rules/assertions/sortKeys.js
+++ b/tests/rules/assertions/sortKeys.js
@@ -79,6 +79,14 @@ export default {
     {
       code: 'type FooType = { 1:number, 2: number, 10: number }',
       options: ['asc', {natural: true}]
+    },
+    {
+      code: 'type FooType = { b: number, a: number }',
+      settings: {
+        flowtype: {
+          onlyFilesWithFlowAnnotation: true
+        }
+      }
     }
   ]
 };

--- a/tests/rules/assertions/typeIdMatch.js
+++ b/tests/rules/assertions/typeIdMatch.js
@@ -29,6 +29,14 @@ export default {
       options: [
         '^foo$'
       ]
+    },
+    {
+      code: 'type foo = {};',
+      settings: {
+        flowtype: {
+          onlyFilesWithFlowAnnotation: true
+        }
+      }
     }
   ]
 };

--- a/tests/rules/assertions/unionIntersectionSpacing.js
+++ b/tests/rules/assertions/unionIntersectionSpacing.js
@@ -74,10 +74,10 @@ const UNION = {
     }
   ],
   valid: [
-        {code: 'type X = string | number;'},
-        {code: 'type X = string | number | boolean;'},
-        {code: 'type X = (string) | number;'},
-        {code: 'type X = ((string)) | (number | foo);'},
+    {code: 'type X = string | number;'},
+    {code: 'type X = string | number | boolean;'},
+    {code: 'type X = (string) | number;'},
+    {code: 'type X = ((string)) | (number | foo);'},
     {
       code: 'type X = string|number',
       options: ['never']
@@ -93,6 +93,14 @@ const UNION = {
         '| number',
         '}'
       ].join('\n')
+    },
+    {
+      code: 'type X = string| number;',
+      settings: {
+        flowtype: {
+          onlyFilesWithFlowAnnotation: true
+        }
+      }
     }
   ]
 };
@@ -173,10 +181,10 @@ const INTERSECTION = {
     }
   ],
   valid: [
-        {code: 'type X = string & number;'},
-        {code: 'type X = string & number & boolean;'},
-        {code: 'type X = (string) & number;'},
-        {code: 'type X = ((string)) & (number & foo);'},
+    {code: 'type X = string & number;'},
+    {code: 'type X = string & number & boolean;'},
+    {code: 'type X = (string) & number;'},
+    {code: 'type X = ((string)) & (number & foo);'},
     {
       code: 'type X = string&number',
       options: ['never']
@@ -192,6 +200,14 @@ const INTERSECTION = {
         '& number',
         '}'
       ].join('\n')
+    },
+    {
+      code: 'type X = string& number;',
+      settings: {
+        flowtype: {
+          onlyFilesWithFlowAnnotation: true
+        }
+      }
     }
   ]
 };


### PR DESCRIPTION
This PR introduces a wrapper around each rule in the exported rules object that handles the `isFlowFile` and  `onlyFilesWithFlowAnnotation` logic.

This should resolve a handful of issues where some rules were not honoring the `onlyFilesWithFlowAnnotation` setting (e.g. sort-keys, type-id-match, #128).

I'm not sure if this is the best way to approach this problem, but it seemed simpler than having the checks in every rule file.

Also, there currently is no way for a rule to 'opt out' of this wrapper - I'm not sure if this is needed but it wouldn't be difficult to add that functionality if that need arises.