### PR TITLE
Implement 'fix' for the require-valid-file-annotation rule

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "eslint": ">=2.0.0"
   },
   "dependencies": {
+    "detect-newline": "^2.1.0",
     "lodash": "^4.15.0"
   },
   "scripts": {

--- a/tests/rules/assertions/requireValidFileAnnotation.js
+++ b/tests/rules/assertions/requireValidFileAnnotation.js
@@ -86,6 +86,68 @@ export default {
           annotationStyle: 'block'
         }
       ]
+    },
+    {
+      code: 'this;',
+      errors: [
+        {
+          message: 'Flow file annotation is missing.'
+        }
+      ],
+      options: [
+        'always'
+      ],
+      output: '/* @flow */\nthis;'
+    }, {
+      code: 'this;\r\n',
+      errors: [
+        {
+          message: 'Flow file annotation is missing.'
+        }
+      ],
+      options: [
+        'always'
+      ],
+      output: '/* @flow */\r\nthis;\r\n'
+    }, {
+      code: 'this;\n',
+      errors: [
+        {
+          message: 'Flow file annotation is missing.'
+        }
+      ],
+      options: [
+        'always'
+      ],
+      output: '/* @flow */\nthis;\n'
+    }, {
+      code: 'this;',
+      errors: [
+        {
+          message: 'Flow file annotation is missing.'
+        }
+      ],
+      options: [
+        'always',
+        {
+          annotationStyle: 'line'
+        }
+      ],
+      output: '// @flow\nthis;'
+    }, {
+      code: 'this;',
+      errors: [
+        {
+          message: 'Flow file annotation is missing.'
+        }
+      ],
+      options: [
+        'always',
+        {
+          annotationStyle: 'block'
+        }
+      ],
+      output: '/* @flow */\nthis;'
     }
   ],
   valid: [


### PR DESCRIPTION
This pr adds `--fix` support for the `require-valid-file-annotation` rule by prepending `/* @flow */` / `// @flow` to the top of the file. It does this by looking at the current file content to determent what line ending to use and uses the `annotationStyle` option to decide between `/* @flow */` and `// @flow`.

I currently have a macro that does this, but it would be nice to have it build it into the rule. This pr aims to solve this.

Hope that helps.