### PR TITLE
feat: add no-primitive-constructor-types rule

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -15,6 +15,7 @@ import validSyntax from './rules/validSyntax';
 import booleanStyle from './rules/booleanStyle';
 import delimiterDangle from './rules/delimiterDangle';
 import noDupeKeys from './rules/noDupeKeys';
+import noPrimitiveConstructorTypes from './rules/noPrimitiveConstructorTypes';
 import sortKeys from './rules/sortKeys';
 import objectTypeDelimiter from './rules/objectTypeDelimiter';
 import recommended from './configs/recommended.json';
@@ -29,6 +30,7 @@ export default {
     'delimiter-dangle': delimiterDangle,
     'generic-spacing': genericSpacing,
     'no-dupe-keys': noDupeKeys,
+    'no-primitive-constructor-types': noPrimitiveConstructorTypes,
     'no-weak-types': noWeakTypes,
     'object-type-delimiter': objectTypeDelimiter,
     'require-parameter-type': requireParameterType,

--- a/src/rules/noPrimitiveConstructorTypes.js
+++ b/src/rules/noPrimitiveConstructorTypes.js
@@ -1,0 +1,24 @@
+import _ from 'lodash';
+
+export default {
+  create: (context) => {
+    return {
+      GenericTypeAnnotation: (node) => {
+        const name = _.get(node, 'id.name');
+
+        if (RegExp(/(Boolean|Number|String)/).test(name)) {
+          context.report({
+            data: {
+              name
+            },
+            loc: node.loc,
+            message: 'Unexpected use of {{name}} constructor type.',
+            node
+          });
+        }
+      }
+    };
+  },
+  meta: {},
+  schema: {}
+};

--- a/tests/rules/assertions/noPrimitiveConstructorTypes.js
+++ b/tests/rules/assertions/noPrimitiveConstructorTypes.js
@@ -1,0 +1,69 @@
+export default {
+  invalid: [
+    {
+      code: 'type x = Number',
+      errors: [{message: 'Unexpected use of Number constructor type.'}]
+    },
+    {
+      code: 'type x = String',
+      errors: [{message: 'Unexpected use of String constructor type.'}]
+    },
+    {
+      code: 'type x = Boolean',
+      errors: [{message: 'Unexpected use of Boolean constructor type.'}]
+    },
+    {
+      code: 'type x = { a: Number }',
+      errors: [{message: 'Unexpected use of Number constructor type.'}]
+    },
+    {
+      code: 'type x = { a: String }',
+      errors: [{message: 'Unexpected use of String constructor type.'}]
+    },
+    {
+      code: 'type x = { a: Boolean }',
+      errors: [{message: 'Unexpected use of Boolean constructor type.'}]
+    },
+    {
+      code: '(x: Number) => {}',
+      errors: [{message: 'Unexpected use of Number constructor type.'}]
+    },
+    {
+      code: '(x: String) => {}',
+      errors: [{message: 'Unexpected use of String constructor type.'}]
+    },
+    {
+      code: '(x: Boolean) => {}',
+      errors: [{message: 'Unexpected use of Boolean constructor type.'}]
+    }
+  ],
+  valid: [
+    {
+      code: 'type x = number'
+    },
+    {
+      code: 'type x = string'
+    },
+    {
+      code: 'type x = boolean'
+    },
+    {
+      code: 'type x = { a: number }'
+    },
+    {
+      code: 'type x = { a: string }'
+    },
+    {
+      code: 'type x = { a: boolean }'
+    },
+    {
+      code: '(x: number) => {}'
+    },
+    {
+      code: '(x: string) => {}'
+    },
+    {
+      code: '(x: boolean) => {}'
+    }
+  ]
+};

--- a/tests/rules/index.js
+++ b/tests/rules/index.js
@@ -13,6 +13,7 @@ const reportingRules = [
   'generic-spacing',
   'no-dupe-keys',
   'no-weak-types',
+  'no-primitive-constructor-types',
   'object-type-delimiter',
   'require-parameter-type',
   'require-return-type',


### PR DESCRIPTION
This PR adds a rule that discourages the use of `Number`, `Boolean`, and `String` constructor types in favor of their primitive type counterparts.

Good: `type x = number`
Bad: `type x = Number`

From flowtype docs:

> Note that number and Number are separate types. The former is the type of primitive numbers which appear in programs as literals, like 3.14 and 42, or as the result of expressions like parseFloat(input.value). The latter is the type of Number wrapper objects, which are rarely used.

[More info on primitive types](https://flowtype.org/docs/builtins.html)