### PR TITLE
feat: `require-return-type` include / exclude filter support (fixes #149)

### DIFF
--- a/.README/rules/require-return-type.md
+++ b/.README/rules/require-return-type.md
@@ -34,4 +34,41 @@ Alternatively, you can want to exclude only concise arrow function (e.g. `() => 
 }
 ```
 
+You can exclude or include specific tests with the `includeOnlyMatching` and `excludeMatching` rules.
+
+```js
+{
+    "rules": {
+        "flowtype/require-return-type": [
+            2,
+            "always",
+            {
+              "includeOnlyMatching": [
+                  "^F.*",
+                  "Ba(r|z)"
+              ]
+            }
+        ]
+    }
+}
+
+{
+    "rules": {
+        "flowtype/require-return-type": [
+            2,
+            "always",
+            {
+              "excludeMatching": [
+                  "^F.*",
+                  "Ba(r|z)"
+              ]
+            }
+        ]
+    }
+}
+
+```
+
+Both rules take an array that can contain either strings or valid RegExp statements.
+
 <!-- assertions requireReturnType -->

--- a/src/rules/requireReturnType.js
+++ b/src/rules/requireReturnType.js
@@ -5,6 +5,19 @@ export default (context) => {
   const annotateUndefined = (_.get(context, 'options[1].annotateUndefined') || 'never') === 'always';
   const skipArrows = _.get(context, 'options[1].excludeArrowFunctions') || false;
 
+  const getRegExp = (str) => {
+    return new RegExp(str);
+  };
+
+  let excludeMatching;
+  let includeOnlyMatching;
+
+  excludeMatching = _.get(context, 'options[1].excludeMatching', []);
+  includeOnlyMatching = _.get(context, 'options[1].includeOnlyMatching', []);
+
+  excludeMatching = _.map(excludeMatching, getRegExp);
+  includeOnlyMatching = _.map(includeOnlyMatching, getRegExp);
+
   const targetNodes = [];
 
   const registerFunction = (functionNode) => {
@@ -22,6 +35,25 @@ export default (context) => {
     const isReturnTypeAnnotationVoid = _.get(targetNode, 'functionNode.returnType.typeAnnotation.type') === 'VoidTypeAnnotation';
 
     return isReturnTypeAnnotationLiteralUndefined || isReturnTypeAnnotationVoid;
+  };
+
+  const getShouldFilterNode = (functionNode) => {
+    const isArrow = functionNode.type === 'ArrowFunctionExpression';
+    const identiferName = _.get(functionNode, isArrow ? 'parent.id.name' : 'id.name');
+
+    const checkRegExp = _.partial((str, re) => {
+      return re.test(str);
+    }, identiferName);
+
+    if (excludeMatching.length && _.some(excludeMatching, checkRegExp)) {
+      return true;
+    }
+
+    if (includeOnlyMatching.length && !_.some(includeOnlyMatching, checkRegExp)) {
+      return true;
+    }
+
+    return false;
   };
 
   const evaluateFunction = (functionNode) => {
@@ -46,7 +78,9 @@ export default (context) => {
     } else if (isFunctionReturnUndefined && !isReturnTypeAnnotationUndefined && annotateUndefined) {
       context.report(functionNode, 'Must annotate undefined return type.');
     } else if (!isFunctionReturnUndefined && !isReturnTypeAnnotationUndefined) {
-      if (annotateReturn && !functionNode.returnType) {
+      const shouldFilterNode = getShouldFilterNode(functionNode);
+
+      if (annotateReturn && !functionNode.returnType && !shouldFilterNode) {
         context.report(functionNode, 'Missing return type annotation.');
       }
     }

--- a/tests/rules/assertions/requireReturnType.js
+++ b/tests/rules/assertions/requireReturnType.js
@@ -274,6 +274,38 @@ export default {
           excludeArrowFunctions: 'expressionsOnly'
         }
       ]
+    },
+    {
+      code: 'function foo() { return 42; }\nfunction bar() { return 42; }',
+      errors: [
+        {
+          message: 'Missing return type annotation.'
+        }
+      ],
+      options: [
+        'always',
+        {
+          includeOnlyMatching: [
+            'bar'
+          ]
+        }
+      ]
+    },
+    {
+      code: 'const foo = () => { return 42; };\nconst bar = () => { return 42; }',
+      errors: [
+        {
+          message: 'Missing return type annotation.'
+        }
+      ],
+      options: [
+        'always',
+        {
+          includeOnlyMatching: [
+            'bar'
+          ]
+        }
+      ]
     }
   ],
   valid: [
@@ -472,6 +504,74 @@ export default {
         'always',
         {
           excludeArrowFunctions: 'expressionsOnly'
+        }
+      ]
+    },
+    {
+      code: 'function foo() { return 42; }',
+      options: [
+        'always',
+        {
+          excludeMatching: [
+            'foo'
+          ]
+        }
+      ]
+    },
+    {
+      code: 'function foo() { return 42; }',
+      options: [
+        'always',
+        {
+          includeOnlyMatching: [
+            'bar'
+          ]
+        }
+      ]
+    },
+    {
+      code: 'function foo(): number { return 42; }\nfunction bar() { return 42; }',
+      options: [
+        'always',
+        {
+          excludeMatching: [
+            'bar'
+          ]
+        }
+      ]
+    },
+    {
+      code: 'function foo(): number { return 42; }\nfunction bar() { return 42; }',
+      options: [
+        'always',
+        {
+          includeOnlyMatching: [
+            'foo',
+            'baz'
+          ]
+        }
+      ]
+    },
+    {
+      code: 'function foo(): number { return 42; }\nfunction bar() { return 42; }',
+      options: [
+        'always',
+        {
+          excludeMatching: [
+            '^b.*',
+            'qux'
+          ]
+        }
+      ]
+    },
+    {
+      code: 'function foo(): number { return 42; }\nfunction bar() { return 42; }',
+      options: [
+        'always',
+        {
+          includeOnlyMatching: [
+            '^f.*'
+          ]
         }
       ]
     }


### PR DESCRIPTION
This PR addresses #149 - adding the ability to include and exclude functions by name or regex patterns to the `require-return-type` rule.

Ex:
```js
{
    "rules": {
        "flowtype/require-return-type": [
            2,
            "always",
            {
              "includeOnlyMatching": [
                  "Ba(r|z)"
              ]
            }
        ]
    }
}

{
    "rules": {
        "flowtype/require-return-type": [
            2,
            "always",
            {
              "excludeMatching": [
                  "^F.*",
              ]
            }
        ]
    }
}

```