### PR TITLE
fix: require-return-type exception

### DIFF
--- a/src/rules/requireReturnType.js
+++ b/src/rules/requireReturnType.js
@@ -68,7 +68,9 @@ export default (context) => {
     FunctionExpression: registerFunction,
     'FunctionExpression:exit': evaluateFunction,
     ReturnStatement: (node) => {
-      targetNodes[targetNodes.length - 1].returnStatementNode = node;
+      if (targetNodes.length) {
+        targetNodes[targetNodes.length - 1].returnStatementNode = node;
+      }
     }
   };
 };

--- a/tests/rules/assertions/requireReturnType.js
+++ b/tests/rules/assertions/requireReturnType.js
@@ -278,6 +278,9 @@ export default {
   ],
   valid: [
     {
+      code: 'return;'
+    },
+    {
       code: '(foo): string => {}'
     },
     {


### PR DESCRIPTION
Top level `return` statement lead to unhandled exception where `targetNodes` is empty array.

```
     TypeError: Cannot set property 'returnStatementNode' of undefined
      at EventEmitter.ReturnStatement (src/rules/requireReturnType.js:71:7)
      at NodeEventGenerator.enterNode (node_modules/eslint/lib/util/node-event-generator.js:40:22)
      at CodePathAnalyzer.enterNode (node_modules/eslint/lib/code-path-analysis/code-path-analyzer.js:608:23)
      at CommentEventGenerator.enterNode (node_modules/eslint/lib/util/comment-event-generator.js:97:23)
      at Controller.enter (node_modules/eslint/lib/eslint.js:928:36)
      at Controller.__execute (node_modules/estraverse/estraverse.js:397:31)
      at Controller.traverse (node_modules/estraverse/estraverse.js:501:28)
      at Controller.Traverser.controller.traverse (node_modules/eslint/lib/util/traverser.js:36:33)
      at EventEmitter.module.exports.api.verify (node_modules/eslint/lib/eslint.js:925:23)
      at runRuleForItem (node_modules/eslint/lib/testers/rule-tester.js:362:38)
      at testValidTemplate (node_modules/eslint/lib/testers/rule-tester.js:395:28)
      at Context.RuleTester.it (node_modules/eslint/lib/testers/rule-tester.js:493:25)
```