### PR TITLE
feat: add flowtype-errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,9 +19,11 @@
   },
   "license": "BSD-3-Clause",
   "peerDependencies": {
-    "eslint": ">=2.0.0"
+    "eslint": ">=2.0.0",
+    "flow-bin": "^0.37.4"
   },
   "dependencies": {
+    "eslint-plugin-flowtype-errors": "^2.0.3",
     "lodash": "^4.15.0"
   },
   "scripts": {

--- a/src/configs/recommended.json
+++ b/src/configs/recommended.json
@@ -34,8 +34,12 @@
       "always"
     ],
     "flowtype/use-flow-type": 1,
-    "flowtype/valid-syntax": 1
+    "flowtype/valid-syntax": 1,
+    "flowtype-errors/show-errors": 0
   },
+  "plugins": [
+    "flowtype-errors"
+  ],
   "settings": {
     "flowtype": {
       "onlyFilesWithFlowAnnotation": false


### PR DESCRIPTION
@gajus can you test if this works by linking? I'm getting an error saying that `Definition for rule flowtype-errors/show-errors was not found` if i enable `flowtype-errors/show-errors was not found` in my `eslintrc` when using the linked version of this plugin. I haven't worked with a `recommended.json` before I'm not sure how to debug this.