### PR TITLE
feat: add rules for nullable and optional spacing (WIP)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,8 @@ import {checkFlowFileAnnotation} from './utilities';
 import defineFlowType from './rules/defineFlowType';
 import genericSpacing from './rules/genericSpacing';
 import noWeakTypes from './rules/noWeakTypes';
+import nullableSpacing from './rules/nullableSpacing';
+import optionalSpacing from './rules/optionalSpacing';
 import requireParameterType from './rules/requireParameterType';
 import requireReturnType from './rules/requireReturnType';
 import requireValidFileAnnotation from './rules/requireValidFileAnnotation';
@@ -31,7 +33,9 @@ const rules = {
   'no-dupe-keys': noDupeKeys,
   'no-primitive-constructor-types': noPrimitiveConstructorTypes,
   'no-weak-types': noWeakTypes,
+  'nullable-spacing': nullableSpacing,
   'object-type-delimiter': objectTypeDelimiter,
+  'optional-spacing': optionalSpacing,
   'require-parameter-type': requireParameterType,
   'require-return-type': requireReturnType,
   'require-valid-file-annotation': requireValidFileAnnotation,

--- a/src/rules/nullableSpacing.js
+++ b/src/rules/nullableSpacing.js
@@ -1,0 +1,46 @@
+import _ from 'lodash';
+
+const defaults = {
+  after: false,
+  before: true
+};
+
+export default (context) => {
+  const sourceCode = context.getSourceCode();
+  const after = _.get(context, ['options', '0', 'after'], defaults.after);
+  const before = _.get(context, ['options', '0', 'before'], defaults.before);
+
+  const reporter = (node, data) => {
+    context.report({
+      data,
+      message: '{{error}} whitespace {{direction}} nullable type annotation.',
+      node
+    });
+  };
+
+  const checkNode = (node) => {
+    const annotColon = sourceCode.getTokenBefore(node);
+    const annotType = _.get(node, 'typeAnnotation');
+
+    const spaceBefore = node.start - annotColon.end;
+    const spaceAfter = annotType.start - node.start - 1;
+
+    if (!after && spaceAfter !== 0 || after && spaceAfter > 1) {
+      reporter(node, {
+        direction: 'after',
+        error: 'Unexpected'
+      });
+    }
+
+    if (!before && spaceBefore !== 0 || before && spaceBefore > 1) {
+      reporter(node, {
+        direction: 'before',
+        error: 'Unexpected'
+      });
+    }
+  };
+
+  return {
+    NullableTypeAnnotation: checkNode
+  };
+};

--- a/src/rules/nullableSpacing.js
+++ b/src/rules/nullableSpacing.js
@@ -20,10 +20,19 @@ export default (context) => {
 
   const checkNode = (node) => {
     const annotColon = sourceCode.getTokenBefore(node);
-    const annotType = _.get(node, 'typeAnnotation');
+    const annotNode = _.get(node, 'typeAnnotation');
+
+    let nodeAfter;
+
+    // Union and Intersections types are surrounded by parens
+    if (annotNode.type === 'UnionTypeAnnotation' || annotNode.type === 'IntersectionTypeAnnotation') {
+      nodeAfter = sourceCode.getTokenBefore(annotNode);
+    } else {
+      nodeAfter = annotNode;
+    }
 
     const spaceBefore = node.start - annotColon.end;
-    const spaceAfter = annotType.start - node.start - 1;
+    const spaceAfter = nodeAfter.start - (node.start + 1);
 
     if (!after && spaceAfter !== 0 || after && spaceAfter > 1) {
       reporter(node, {

--- a/src/rules/optionalSpacing.js
+++ b/src/rules/optionalSpacing.js
@@ -1,0 +1,59 @@
+import _ from 'lodash';
+import {
+  getParameterName
+} from './../utilities';
+
+const defaults = {
+  after: false,
+  before: false
+};
+
+export default (context) => {
+  const sourceCode = context.getSourceCode();
+  const after = _.get(context, ['options', '0', 'after'], defaults.after);
+  const before = _.get(context, ['options', '0', 'before'], defaults.before);
+
+  const reporter = (node, data) => {
+    context.report({
+      data,
+      message: '{{error}} whitespace {{direction}} optional type annotation.',
+      node
+    });
+  };
+
+  const checkNode = (node) => {
+    const optional = _.get(node, ['optional'], false);
+
+    if (!optional) {
+      return;
+    }
+
+    const parameterName = getParameterName(node, context);
+    const propText = sourceCode.getText(node);
+
+    const keyText = propText.slice(0, propText.indexOf(':'));
+    const optionalIndex = keyText.indexOf('?');
+
+    const spaceBefore = optionalIndex - parameterName.length;
+    const spaceAfter = keyText.length - (optionalIndex + 1);
+
+    if (!after && spaceAfter !== 0 || after && spaceAfter > 1) {
+      reporter(node, {
+        direction: 'after',
+        error: 'Unexpected'
+      });
+    }
+
+    if (!before && spaceBefore !== 0 || before && spaceBefore > 1) {
+      reporter(node, {
+        direction: 'before',
+        error: 'Unexpected'
+      });
+    }
+  };
+
+  return {
+    Identifier: checkNode,
+    ObjectTypeProperty: checkNode
+  };
+};

--- a/tests/rules/assertions/nullableSpacing.js
+++ b/tests/rules/assertions/nullableSpacing.js
@@ -1,0 +1,63 @@
+export default {
+  invalid: [
+    {
+      code: 'var o: ? string = null;',
+      errors: [{
+        message: 'Unexpected whitespace after nullable type annotation.'
+      }]
+    },
+    {
+      code: 'var o: ?   string = null;',
+      errors: [{
+        message: 'Unexpected whitespace after nullable type annotation.'
+      }],
+      options: [{
+        after: true
+      }]
+    },
+    {
+      code: 'var o: ?string = null;',
+      errors: [{
+        message: 'Unexpected whitespace before nullable type annotation.'
+      }],
+      options: [{
+        before: false
+      }]
+    },
+    {
+      code: 'var o:  ?string = null;',
+      errors: [{
+        message: 'Unexpected whitespace before nullable type annotation.'
+      }],
+      options: [{
+        before: true
+      }]
+    },
+    {
+      code: 'type X = ?   string;',
+      errors: [{
+        message: 'Unexpected whitespace after nullable type annotation.'
+      }]
+    },
+    {
+      code: 'function x(a: ?  e) {};',
+      errors: [{
+        message: 'Unexpected whitespace after nullable type annotation.'
+      }, {
+        message: 'Unexpected whitespace before nullable type annotation.'       ,
+      }],
+      options: [{
+        after: false,
+        before: false
+      }]
+    }
+  ],
+  valid: [
+    {
+      code: 'var o: ?string = null;'
+    },
+    {
+      code: 'function x(a: ?e) {};'
+    }
+  ]
+};

--- a/tests/rules/assertions/nullableSpacing.js
+++ b/tests/rules/assertions/nullableSpacing.js
@@ -44,7 +44,7 @@ export default {
       errors: [{
         message: 'Unexpected whitespace after nullable type annotation.'
       }, {
-        message: 'Unexpected whitespace before nullable type annotation.'       ,
+        message: 'Unexpected whitespace before nullable type annotation.'
       }],
       options: [{
         after: false,
@@ -58,6 +58,16 @@ export default {
     },
     {
       code: 'function x(a: ?e) {};'
+    },
+    {
+      code: 'function foo(n: ?(number | string)) {}'
+    },
+    {
+      code: 'function foo(n:? (number | string)) {}',
+      options: [{
+        after: true,
+        before: false
+      }]
     }
   ]
 };

--- a/tests/rules/assertions/optionalSpacing.js
+++ b/tests/rules/assertions/optionalSpacing.js
@@ -1,0 +1,72 @@
+export default {
+  invalid: [
+    {
+      code: 'type foo = { bar ?: string };',
+      errors: [{
+        message: 'Unexpected whitespace before optional type annotation.'
+      }]
+    },
+    {
+      code: 'type foo = { bar  ?: string };',
+      errors: [{
+        message: 'Unexpected whitespace before optional type annotation.'
+      }],
+      options: [{
+        before: true
+      }]
+    },
+    {
+      code: 'type foo = { bar? : string };',
+      errors: [{
+        message: 'Unexpected whitespace after optional type annotation.'
+      }]
+    },
+    {
+      code: 'type foo = { bar?   : string };',
+      errors: [{
+        message: 'Unexpected whitespace after optional type annotation.'
+      }],
+      options: [{
+        after: true
+      }]
+    },
+    {
+      code: 'function fn(bar ?: number) {}',
+      errors: [{
+        message: 'Unexpected whitespace before optional type annotation.'
+      }]
+    },
+    {
+      code: 'function fn(bar   ?: number) {}',
+      errors: [{
+        message: 'Unexpected whitespace before optional type annotation.'
+      }],
+      options: [{
+        before: true
+      }]
+    },
+    {
+      code: 'function fn(bar? : number) {}',
+      errors: [{
+        message: 'Unexpected whitespace after optional type annotation.'
+      }]
+    },
+    {
+      code: 'function fn(bar?   : number) {}',
+      errors: [{
+        message: 'Unexpected whitespace after optional type annotation.'
+      }],
+      options: [{
+        after: true
+      }]
+    }
+  ],
+  valid: [
+    {
+      code: 'type foo = { bar?: string };'
+    },
+    {
+      code: 'function fn(bar?: number) {}'
+    }
+  ]
+};

--- a/tests/rules/index.js
+++ b/tests/rules/index.js
@@ -11,6 +11,8 @@ const reportingRules = [
   'define-flow-type',
   'delimiter-dangle',
   'generic-spacing',
+  'nullable-spacing',
+  'optional-spacing',
   'no-dupe-keys',
   'no-weak-types',
   'no-primitive-constructor-types',


### PR DESCRIPTION
WIP - Still need to add documentation and additional test cases, I'm sure I've missed some edge case annotations.  Possible refactor.

This PR adds 2 rules for nullable and param optional spacing - similar to how eslint's semi-spacing currently works.  Addresses #164 

It's possible this may conflict with colon spacing rules - needs some test cases.

```javascript
// invalid - Error: "Unexpected whitespace after nullable type annotation."
var o:  ?string = null;
type X = ?   string;
function fn(bar? : number) {}

// valid
function x(a: ?e) {};
function foo(n: ?(number | string)) {}
type foo = { bar?: string };

```