### PR TITLE
feat: enforce a certain flow type mode

### DIFF
--- a/.README/rules/require-valid-file-annotation.md
+++ b/.README/rules/require-valid-file-annotation.md
@@ -18,6 +18,11 @@ This rule has an object option:
     * `"line"`: Require single line annotations (i.e. `// @flow`).
     * `"block"`: Require block annotations (i.e. `/* @flow */`).
 
+* `"mode"` - Enforce a consistent file annotation mode level.
+    * `"noflow"` (default): Any flow level is acceptable.
+    * `"flow weak"`: Require flow weak or strict mode.
+    * `"flow"`: Require flow strict mode.
+
 ```js
 {
   "rules": {
@@ -33,7 +38,8 @@ This rule has an object option:
     "flowtype/require-valid-file-annotation": [
       2,
       "always", {
-        "annotationStyle": "block"
+        "annotationStyle": "block",
+        "mode": "flow"
       }
     ]
   }

--- a/src/utilities/flowFileAnnotationMode.js
+++ b/src/utilities/flowFileAnnotationMode.js
@@ -1,0 +1,15 @@
+const FLOW_MATCHER = /@(no)?flow( weak)?/;
+
+export default (comment) => {
+  const match = comment.match(FLOW_MATCHER);
+
+  if (!match) {
+    return null;
+  } else if (match[1]) {
+    return 'noflow';
+  } else if (match[2]) {
+    return 'flow weak';
+  } else {
+    return 'flow';
+  }
+};

--- a/src/utilities/index.js
+++ b/src/utilities/index.js
@@ -10,3 +10,4 @@ export getTokenBeforeParens from './getTokenBeforeParens';
 export getTokenAfterParens from './getTokenAfterParens';
 export fuzzyStringMatch from './fuzzyStringMatch';
 export checkFlowFileAnnotation from './checkFlowFileAnnotation';
+export flowFileAnnotationMode from './flowFileAnnotationMode';

--- a/tests/rules/assertions/requireValidFileAnnotation.js
+++ b/tests/rules/assertions/requireValidFileAnnotation.js
@@ -122,6 +122,48 @@ export default {
           annotationStyle: 'block'
         }
       ]
+    },
+    {
+      code: '/* @noflow */',
+      errors: [
+        {
+          message: 'Flow file annotation must be `@flow` or ``@flow weak`'
+        }
+      ],
+      options: [
+        'always',
+        {
+          mode: 'flow weak'
+        }
+      ]
+    },
+    {
+      code: '/* @noflow */',
+      errors: [
+        {
+          message: 'Flow file annotation must be `@flow`'
+        }
+      ],
+      options: [
+        'always',
+        {
+          mode: 'flow'
+        }
+      ]
+    },
+    {
+      code: '/* @flow weak */',
+      errors: [
+        {
+          message: 'Flow file annotation must be `@flow`'
+        }
+      ],
+      options: [
+        'always',
+        {
+          mode: 'flow'
+        }
+      ]
     }
   ],
   valid: [
@@ -175,8 +217,51 @@ export default {
           annotationStyle: 'block'
         }
       ]
+    },
+    {
+      code: '/* @noflow */',
+      options: [
+        'always',
+        {
+          mode: 'noflow'
+        }
+      ]
+    },
+    {
+      code: '/* @flow */',
+      options: [
+        'always',
+        {
+          mode: 'noflow'
+        }
+      ]
+    },
+    {
+      code: '/* @flow weak */',
+      options: [
+        'always',
+        {
+          mode: 'flow weak'
+        }
+      ]
+    },
+    {
+      code: '/* @flow */',
+      options: [
+        'always',
+        {
+          mode: 'flow weak'
+        }
+      ]
+    },
+    {
+      code: '/* @flow */',
+      options: [
+        'always',
+        {
+          mode: 'flow'
+        }
+      ]
     }
   ]
 };
-
-


### PR DESCRIPTION
This feature allows a certain flow mode to be enforce across files. For an example, you may not want anyone to use `@noflow` on files. Or after you've completed your project's flow transition, you want to prevent the use of `@flow weak` and enforce that a strict `@flow` comment be on every file.

Initially I chose to extend the existing `require-valid-file-annotation` rule as a new option. I'm not sure if this is *right* or if we'd rather define it as a completely separate rule.

Feedback appreciated, thanks!

##

To: @danharper 