### PR TITLE
fix: Ensure colon is not null in typeColonSpacing reporter

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "chai": "^3.5.0",
     "conventional-changelog-lint": "^1.0.1",
     "create-index": "^0.1.3",
-    "eslint": "^3.4.0",
+    "eslint": "^3.16.0",
     "eslint-config-canonical": "1.8.1",
     "gitdown": "^2.5.0",
     "husky": "^0.11.7",

--- a/src/rules/typeColonSpacing/reporter.js
+++ b/src/rules/typeColonSpacing/reporter.js
@@ -17,7 +17,7 @@ export default (direction, context, {always, allowLineBreak}) => {
     // Support optional names
     // type X = { [string]: a }
     // type X = string => string
-    if (colon.value !== ':') {
+    if (!colon || colon.value !== ':') {
       return;
     }
 


### PR DESCRIPTION
Something changed between ESLint 3.15.0 and 3.16.0 that caused the token to no longer return. It now returns null, instead of a valid token that had a `value !== ':'`.

This adds a check to make sure that `colon` is not null first.

Could possibly be this refactor: https://github.com/eslint/eslint/commit/834f45d32ed322940dd185a32e5342193fdde914

This fixed #196 as well.