### PR TITLE
Update `looksLikeFlowFileAnnotation` regex to match only @flow

### DIFF
--- a/src/rules/requireValidFileAnnotation.js
+++ b/src/rules/requireValidFileAnnotation.js
@@ -9,7 +9,7 @@ const defaults = {
 };
 
 const looksLikeFlowFileAnnotation = (comment) => {
-  return /@(?:no)?f/i.test(comment);
+  return /@(?:no)?flo/i.test(comment);
 };
 
 const isValidAnnotationStyle = (node, style) => {

--- a/tests/rules/assertions/requireValidFileAnnotation.js
+++ b/tests/rules/assertions/requireValidFileAnnotation.js
@@ -168,6 +168,19 @@ export default {
       ]
     },
     {
+      code: '// @function',
+      options: [
+        'never',
+        {
+          annotationStyle: 'none'
+        }
+      ]
+    },
+    {
+      code: '// @fixable',
+      options: [ 'error', 'never' ]
+    },
+    {
       code: '/* @flow */',
       options: [
         'always',
@@ -178,5 +191,3 @@ export default {
     }
   ]
 };
-
-


### PR DESCRIPTION
The `looksLikeFlowFileAnnotation` regex was too broad and would catch
jsdoc comments like `@fixable` and `@function`, causing eslint errors
in projects that don't use flow (in my case).

I updated the regex to only check for anything beginning with
`@flo`. Is there any reason not to full on match `@flow`? I'm not
familiar with how flow works.

This should fix #165.
