### PR TITLE
feat: add prefer-read-only-array (fixes #236)

### DIFF
--- a/.README/README.md
+++ b/.README/README.md
@@ -151,6 +151,7 @@ When `true`, only checks files with a [`@flow` annotation](http://flowtype.org/d
 {"gitdown": "include", "file": "./rules/no-types-missing-file-annotation.md"}
 {"gitdown": "include", "file": "./rules/no-weak-types.md"}
 {"gitdown": "include", "file": "./rules/object-type-delimiter.md"}
+{"gitdown": "include", "file": "./rules/prefer-read-only-array.md"}
 {"gitdown": "include", "file": "./rules/require-parameter-type.md"}
 {"gitdown": "include", "file": "./rules/require-return-type.md"}
 {"gitdown": "include", "file": "./rules/require-valid-file-annotation.md"}

--- a/.README/rules/prefer-read-only-array.md
+++ b/.README/rules/prefer-read-only-array.md
@@ -1,0 +1,5 @@
+### `prefer-read-only-array`
+
+Requires to use [`$ReadOnlyArray`](https://github.com/facebook/flow/blob/v0.46.0/lib/core.js#L185) instead of `Array`.
+
+<!-- assertions preferReadOnlyArray -->

--- a/src/index.js
+++ b/src/index.js
@@ -1,27 +1,30 @@
 import _ from 'lodash';
-import {checkFlowFileAnnotation} from './utilities';
+import {
+  checkFlowFileAnnotation
+} from './utilities';
+import booleanStyle from './rules/booleanStyle';
 import defineFlowType from './rules/defineFlowType';
+import delimiterDangle from './rules/delimiterDangle';
 import genericSpacing from './rules/genericSpacing';
-import noWeakTypes from './rules/noWeakTypes';
+import noDupeKeys from './rules/noDupeKeys';
+import noPrimitiveConstructorTypes from './rules/noPrimitiveConstructorTypes';
 import noTypesMissingFileAnnotation from './rules/noTypesMissingFileAnnotation';
+import noWeakTypes from './rules/noWeakTypes';
+import objectTypeDelimiter from './rules/objectTypeDelimiter';
+import preferReadOnlyArray from './rules/preferReadOnlyArray';
 import requireParameterType from './rules/requireParameterType';
 import requireReturnType from './rules/requireReturnType';
 import requireValidFileAnnotation from './rules/requireValidFileAnnotation';
 import requireVariableType from './rules/requireVariableType';
 import semi from './rules/semi';
+import sortKeys from './rules/sortKeys';
 import spaceAfterTypeColon from './rules/spaceAfterTypeColon';
 import spaceBeforeGenericBracket from './rules/spaceBeforeGenericBracket';
 import spaceBeforeTypeColon from './rules/spaceBeforeTypeColon';
-import unionIntersectionSpacing from './rules/unionIntersectionSpacing';
 import typeIdMatch from './rules/typeIdMatch';
+import unionIntersectionSpacing from './rules/unionIntersectionSpacing';
 import useFlowType from './rules/useFlowType';
 import validSyntax from './rules/validSyntax';
-import booleanStyle from './rules/booleanStyle';
-import delimiterDangle from './rules/delimiterDangle';
-import noDupeKeys from './rules/noDupeKeys';
-import noPrimitiveConstructorTypes from './rules/noPrimitiveConstructorTypes';
-import sortKeys from './rules/sortKeys';
-import objectTypeDelimiter from './rules/objectTypeDelimiter';
 import recommended from './configs/recommended.json';
 
 const rules = {
@@ -34,6 +37,7 @@ const rules = {
   'no-types-missing-file-annotation': noTypesMissingFileAnnotation,
   'no-weak-types': noWeakTypes,
   'object-type-delimiter': objectTypeDelimiter,
+  'prefer-read-only-array': preferReadOnlyArray,
   'require-parameter-type': requireParameterType,
   'require-return-type': requireReturnType,
   'require-valid-file-annotation': requireValidFileAnnotation,
@@ -76,6 +80,7 @@ export default {
     'no-dupe-keys': 0,
     'no-weak-types': 0,
     'object-type-delimiter': 0,
+    'prefer-read-only-array': 0,
     'require-parameter-type': 0,
     'require-return-type': 0,
     'require-variable-type': 0,

--- a/src/rules/preferReadOnlyArray.js
+++ b/src/rules/preferReadOnlyArray.js
@@ -1,0 +1,24 @@
+import _ from 'lodash';
+
+export default {
+  create: (context) => {
+    return {
+      GenericTypeAnnotation: (node) => {
+        const name = _.get(node, 'id.name');
+
+        if (name === 'Array') {
+          context.report({
+            data: {
+              name
+            },
+            loc: node.loc,
+            message: 'Unexpected use of {{name}} constructor type.',
+            node
+          });
+        }
+      }
+    };
+  },
+  meta: {},
+  schema: {}
+};

--- a/tests/rules/assertions/preferReadOnlyArray.js
+++ b/tests/rules/assertions/preferReadOnlyArray.js
@@ -1,0 +1,17 @@
+export default {
+  invalid: [
+    {
+      code: 'type FooType = Array<number>;',
+      errors: [
+        {
+          message: 'Use $ReadOnlyArray instead of Array.'
+        }
+      ]
+    }
+  ],
+  valid: [
+    {
+      code: 'type FooType = $ReadOnlyArray<number>;'
+    }
+  ]
+};


### PR DESCRIPTION
Adds a rule that requires to use `$ReadOnlyArray` in place of `Array`.