### PR TITLE
[Request For Comments] fix: @flow flag does not need to be first comment

### DIFF
--- a/src/utilities/isFlowFile.js
+++ b/src/utilities/isFlowFile.js
@@ -14,7 +14,10 @@ export default (context, strict = true) => {
     return false;
   }
 
-  const firstComment = comments[0];
-
-  return isFlowFileAnnotation(firstComment.value) && !(strict && /no/.test(firstComment.value));
+  return comments.some((comment) => {
+    return (
+      isFlowFileAnnotation(comment.value) &&
+      !(strict && /no/.test(comment.value))
+    );
+  });
 };

--- a/tests/rules/assertions/noTypesMissingFileAnnotation.js
+++ b/tests/rules/assertions/noTypesMissingFileAnnotation.js
@@ -61,6 +61,9 @@ export default {
     },
     {
       code: '/* @noflow */\nexport type {A} from "a"'
+    },
+    {
+      code: '// an unrelated comment\n// @flow\nexport type {A} from "a"'
     }
   ]
 };


### PR DESCRIPTION
`eslint-plugin-flowtype` rules require that the `// @flow` comment be the first line of a file.

This is stricter than [Flow requires](https://flow.org/en/docs/usage/#toc-prepare-your-code-for-flow) (emphasis in original), which simply requires the comment appear before any code:

> The Flow background process monitors all Flow files. However, how does it know which files are Flow files and, thus, should be checked? Placing the following **before any code** in a JavaScript file is the flag the process uses to answer that question.
> 
> `1 // @flow`

This PR updates `noTypesMissingFileAnnotation` to allows a comment to appear before the `@flow` comment.

This likely has more implications for `requireValidFileAnnotation`, however.