### PR TITLE
fix: Don't crash on type spread in no-dupe-keys

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "devDependencies": {
     "ajv": "^5.2.1",
     "babel-cli": "^6.14.0",
-    "babel-eslint": "^6.1.2",
+    "babel-eslint": "^7.2.3",
     "babel-plugin-add-module-exports": "^0.2.1",
     "babel-plugin-transform-object-rest-spread": "^6.23.0",
     "babel-preset-env": "^1.1.10",

--- a/src/rules/defineFlowType.js
+++ b/src/rules/defineFlowType.js
@@ -49,9 +49,6 @@ const create = (context) => {
         makeDefined(qid);
       }
     },
-    InterfaceDeclaration (node) {
-      makeDefined(node.id);
-    },
     Program () {
       globalScope = context.getScope();
     },

--- a/src/rules/noDupeKeys.js
+++ b/src/rules/noDupeKeys.js
@@ -61,6 +61,10 @@ const create = (context) => {
     const haystack = [];
 
     _.forEach(node.properties, (identifierNode) => {
+      if (identifierNode.type === 'ObjectTypeSpreadProperty') {
+        return;
+      }
+
       const needle = {name: getParameterName(identifierNode, context)};
 
       if (identifierNode.value.type === 'FunctionTypeAnnotation') {

--- a/src/rules/useFlowType.js
+++ b/src/rules/useFlowType.js
@@ -9,29 +9,7 @@ const create = (context) => {
     DeclareClass: markTypeAsUsed,
     DeclareFunction: markTypeAsUsed,
     DeclareModule: markTypeAsUsed,
-    DeclareVariable: markTypeAsUsed,
-    GenericTypeAnnotation (node) {
-      let typeId;
-      let scope;
-      let variable;
-
-      if (node.id.type === 'Identifier') {
-        typeId = node.id;
-      } else if (node.id.type === 'QualifiedTypeIdentifier') {
-        typeId = node.id;
-        do {
-          typeId = typeId.qualification;
-        } while (typeId.qualification);
-      }
-
-      for (scope = context.getScope(); scope; scope = scope.upper) {
-        variable = scope.set.get(typeId.name);
-        if (variable && variable.defs.length) {
-          context.markVariableAsUsed(typeId.name);
-          break;
-        }
-      }
-    }
+    DeclareVariable: markTypeAsUsed
   };
 };
 

--- a/tests/rules/assertions/defineFlowType.js
+++ b/tests/rules/assertions/defineFlowType.js
@@ -92,12 +92,6 @@ const VALID_WITH_DEFINE_FLOW_TYPE = [
     ]
   },
   {
-    code: 'interface AType {}',
-    errors: [
-      '\'AType\' is not defined.'
-    ]
-  },
-  {
     code: '({ a: ({b() {}}: AType) })',
         // `AType` appears twice in `globalScope.through` as distinct
         // references, this may be a babel-eslint bug.
@@ -108,13 +102,6 @@ const VALID_WITH_DEFINE_FLOW_TYPE = [
   },
   {
     code: 'type X = {Y<AType>(): BType}',
-    errors: [
-      '\'AType\' is not defined.',
-      '\'BType\' is not defined.'
-    ]
-  },
-  {
-    code: 'interface AType<BType> {}',
     errors: [
       '\'AType\' is not defined.',
       '\'BType\' is not defined.'
@@ -158,7 +145,9 @@ const ALWAYS_VALID = [
   'function f(a): string {}',
   'class C { a: string }',
   'var AType = {}; class C { a: AType.a }',
-  'declare module A { declare var a: AType }'
+  'declare module A { declare var a: AType }',
+  'interface AType {}',
+  'interface AType<BType> {}'
 ];
 
 /**

--- a/tests/rules/assertions/noDupeKeys.js
+++ b/tests/rules/assertions/noDupeKeys.js
@@ -107,6 +107,9 @@ export default {
     },
     {
       code: 'var a = 1; var b = 1; type f = { get(key: a): string, get(key: b): string }'
+    },
+    {
+      code: 'type One = { c: number }; type Two = { a: number, b: string, ...One }'
     }
   ]
 };

--- a/tests/rules/assertions/useFlowType.js
+++ b/tests/rules/assertions/useFlowType.js
@@ -34,62 +34,6 @@ const VALID_WITH_USE_FLOW_TYPE = [
     errors: [
       '\'A\' is defined but never used.'
     ]
-  },
-  {
-    code: 'import type A from "a"; (function<T: A>(): T {})',
-    errors: [
-      '\'A\' is defined but never used.'
-    ]
-  },
-  {
-    code: '(function<T: A>(): T {}); import type A from "a"',
-    errors: [
-      '\'A\' is defined but never used.'
-    ]
-  },
-  {
-    code: 'import type {A} from "a"; (function<T: A>(): T {})',
-    errors: [
-      '\'A\' is defined but never used.'
-    ]
-  },
-  {
-    code: '(function<T: A>(): T {}); import type {A} from "a"',
-    errors: [
-      '\'A\' is defined but never used.'
-    ]
-  },
-  {
-    code: '(function<T: A>(): T {}); import type {a as A} from "a"',
-    errors: [
-      '\'A\' is defined but never used.'
-    ]
-  },
-  {
-    code: 'type A = {}; function x<Y: A>(i: Y) { i }; x()',
-    errors: [
-      '\'A\' is defined but never used.'
-    ]
-  },
-  {
-    code: 'function x<Y: A>(i: Y) { i }; type A = {}; x()',
-    errors: [
-      '\'A\' is defined but never used.'
-    ]
-  },
-  {
-    code: 'type A = {}; function x<Y: A.B.C>(i: Y) { i }; x()',
-        // QualifiedTypeIdentifier -------^
-    errors: [
-      '\'A\' is defined but never used.'
-    ]
-  },
-  {
-    code: 'function x<Y: A.B.C>(i: Y) { i }; type A = {}; x()',
-        //                   ^- QualifiedTypeIdentifier
-    errors: [
-      '\'A\' is defined but never used.'
-    ]
   }
 ];
 
@@ -125,7 +69,18 @@ const ALWAYS_VALID = [
   'import type A from "a"; (function(): A {})',
   '(function(): A {}); import type A from "a";',
   'declare interface A {}',
-  'declare type A = {}'
+  'declare type A = {}',
+  'import type A from "a"; (function<T: A>(): T {})',
+  '(function<T: A>(): T {}); import type A from "a"',
+  'import type {A} from "a"; (function<T: A>(): T {})',
+  '(function<T: A>(): T {}); import type {A} from "a"',
+  '(function<T: A>(): T {}); import type {a as A} from "a"',
+  'type A = {}; function x<Y: A>(i: Y) { i }; x()',
+  'function x<Y: A>(i: Y) { i }; type A = {}; x()',
+  'type A = {}; function x<Y: A.B.C>(i: Y) { i }; x()',
+      // QualifiedTypeIdentifier -------^
+  'function x<Y: A.B.C>(i: Y) { i }; type A = {}; x()'
+      //                   ^- QualifiedTypeIdentifier
 ];
 
 /**
@@ -187,4 +142,3 @@ export default {
     })
   ]
 };
-


### PR DESCRIPTION
The no-dupe-keys rule used to crash when encountering type spread
(`type A = { ...B }`) with "TypeError: Cannot read property 'type' of
undefined". This commit makes it no longer crash.

For reference, I’ve encountered this in some real world code and had to use this workaround for now:

```js
// Use Flow’s comment syntax here to avoid a problem in eslint-plugin-flowtype:
/* ::
type Two {
  a: number,
  ...One
}
*/
```