### PR TITLE
fix: Properly check line breaks in space-after-type-colon

### DIFF
--- a/src/rules/typeColonSpacing/reporter.js
+++ b/src/rules/typeColonSpacing/reporter.js
@@ -1,5 +1,15 @@
 import {spacingFixers} from '../../utilities';
 
+const hasLineBreak = (direction, colon, context) => {
+  const sourceCode = context.getSourceCode();
+
+  if (direction === 'before') {
+    return colon.loc.start.line !== sourceCode.getTokenBefore(colon).loc.end.line;
+  } else {
+    return sourceCode.getTokenAfter(colon).loc.start.line !== colon.loc.end.line;
+  }
+};
+
 const getSpaces = (direction, colon, context) => {
   const sourceCode = context.getSourceCode();
 
@@ -12,7 +22,7 @@ const getSpaces = (direction, colon, context) => {
 
 export default (direction, context, {always, allowLineBreak}) => {
   return ({colon, node, name = '', type = 'type annotation'}) => {
-    let spaces;
+    let lineBreak, spaces;
 
     // Support optional names
     // type X = { [string]: a }
@@ -27,15 +37,25 @@ export default (direction, context, {always, allowLineBreak}) => {
       type
     };
 
-    const charAfter = context.getSourceCode().getText(colon, 0, 1).slice(1);
-
-    if (allowLineBreak && RegExp(/(\n|\r)+/).test(charAfter)) {
-      spaces = 1;
+    if (hasLineBreak(direction, colon, context)) {
+      if (allowLineBreak) {
+        spaces = 1;
+      } else {
+        lineBreak = true;
+        spaces = getSpaces(direction, colon, context);
+      }
     } else {
       spaces = getSpaces(direction, colon, context);
     }
 
-    if (always && spaces > 1) {
+    if (always && lineBreak) {
+      context.report({
+        data,
+        fix: spacingFixers.replaceWithSpace(direction, colon, spaces),
+        message: 'There must not be a line break {{direction}} {{name}}{{type}} colon.',
+        node
+      });
+    } else if (always && spaces > 1) {
       context.report({
         data,
         fix: spacingFixers.stripSpaces(direction, colon, spaces - 1),

--- a/src/utilities/spacingFixers.js
+++ b/src/utilities/spacingFixers.js
@@ -22,6 +22,18 @@ export const addSpaceAfter = (node) => {
   };
 };
 
+export const replaceWithSpaceBefore = (node, spaces) => {
+  return (fixer) => {
+    return fixer.replaceTextRange([node.start - spaces, node.start], ' ');
+  };
+};
+
+export const replaceWithSpaceAfter = (node, spaces) => {
+  return (fixer) => {
+    return fixer.replaceTextRange([node.end, node.end + spaces], ' ');
+  };
+};
+
 export const stripSpaces = (direction, node, spaces) => {
   if (direction === 'before') {
     return stripSpacesBefore(node, spaces);
@@ -35,5 +47,13 @@ export const addSpace = (direction, node) => {
     return addSpaceBefore(node);
   } else {
     return addSpaceAfter(node);
+  }
+};
+
+export const replaceWithSpace = (direction, node, spaces) => {
+  if (direction === 'before') {
+    return replaceWithSpaceBefore(node, spaces);
+  } else {
+    return replaceWithSpaceAfter(node, spaces);
   }
 };

--- a/tests/rules/assertions/spaceAfterTypeColon.js
+++ b/tests/rules/assertions/spaceAfterTypeColon.js
@@ -70,7 +70,17 @@ const ARROW_FUNCTION_PARAMS = {
     },
     {
       code: '(foo:\n  { a: string, b: number }) => {}',
-      errors: [{message: 'There must be 1 space after "foo" parameter type annotation colon.'}],
+      errors: [{message: 'There must not be a line break after "foo" parameter type annotation colon.'}],
+      output: '(foo: { a: string, b: number }) => {}'
+    },
+    {
+      code: '(foo:\n{ a: string, b: number }) => {}',
+      errors: [{message: 'There must not be a line break after "foo" parameter type annotation colon.'}],
+      output: '(foo: { a: string, b: number }) => {}'
+    },
+    {
+      code: '(foo: \n{ a: string, b: number }) => {}',
+      errors: [{message: 'There must not be a line break after "foo" parameter type annotation colon.'}],
       output: '(foo: { a: string, b: number }) => {}'
     }
   ],


### PR DESCRIPTION
Previously, there was no explicit check for line breaks, and getSpaces
would count line breaks as spaces. That meant that if there only was a
line break between the colon and the type (the first of then new test
cases), the rule would pass even if allowLineBreak was false.

Now it checks if there is a line break between the colon and the type,
and handles that explicitly so it passes if allowLineBreak is true and
fails otherwise.