### PR TITLE
add an auto-fix option to sortKeys

### DIFF
--- a/README.md
+++ b/README.md
@@ -2081,6 +2081,8 @@ type FooType = {}
 <a name="eslint-plugin-flowtype-rules-sort-keys"></a>
 ### <code>sort-keys</code>
 
+_The `--fix` option on the command line automatically fixes problems reported by this rule._
+
 Enforces sorting of Object annotations.
 
 This rule mirrors ESlint's [sort-keys](http://eslint.org/docs/rules/sort-keys) rule.

--- a/src/rules/sortKeys.js
+++ b/src/rules/sortKeys.js
@@ -68,9 +68,9 @@ const isValidOrders = {
 const generateOrderedList = (context, sort, properties) => {
   return properties.map((property) => {
     const name = getParameterName(property, context);
-    const value = context.getSourceCode().getFirstToken(property.value).value;
+    const value = context.getSourceCode().getText(property.value);
 
-    return [name, value];
+    return [name + (property.optional ? '?' : ''), value];
   })
     .sort((first, second) => { return sort(first[0], second[0]) ? -1 : 1; })
     .map((item) => { return item[0] + ': ' + item[1]; });

--- a/tests/rules/assertions/sortKeys.js
+++ b/tests/rules/assertions/sortKeys.js
@@ -41,6 +41,28 @@ export default {
       code: 'type FooType = { 1: number, 10: number, 2: boolean }',
       errors: [{message: 'Expected type annotations to be in natural ascending order. "2" should be before "10".'}],
       options: ['asc', {natural: true}]
+    },
+    {
+      code: 'type FooType = { a: number, c: number, b: string }',
+      errors: [{message: 'Expected type annotations to be in ascending order. "b" should be before "c".'}],
+      output: 'type FooType = { a: number, b: string, c: number }'
+    },
+    {
+      code: [
+        'type FooType = {',
+        '  a: number,',
+        '  c: number,',
+        '  b: string,',
+        '}'
+      ].join('\n'),
+      errors: [{message: 'Expected type annotations to be in ascending order. "b" should be before "c".'}],
+      output: [
+        'type FooType = {',
+        '  a: number,',
+        '  b: string,',
+        '  c: number,',
+        '}'
+      ].join('\n')
     }
   ],
   misconfigured: [

--- a/tests/rules/assertions/sortKeys.js
+++ b/tests/rules/assertions/sortKeys.js
@@ -63,6 +63,76 @@ export default {
         '  c: number,',
         '}'
       ].join('\n')
+    },
+    {
+      code: [
+        'type FooType = {',
+        '  a?: number,',
+        '  c: ?number,',
+        '  b: string,',
+        '}'
+      ].join('\n'),
+      errors: [{message: 'Expected type annotations to be in ascending order. "b" should be before "c".'}],
+      output: [
+        'type FooType = {',
+        '  a?: number,',
+        '  b: string,',
+        '  c: ?number,',
+        '}'
+      ].join('\n')
+    },
+    {
+      code: [
+        'type FooType = {',
+        '  a: (number) => void,',
+        '  c: number,',
+        '  b: (param: string) => number,',
+        '}'
+      ].join('\n'),
+      errors: [{message: 'Expected type annotations to be in ascending order. "b" should be before "c".'}],
+      output: [
+        'type FooType = {',
+        '  a: (number) => void,',
+        '  b: (param: string) => number,',
+        '  c: number,',
+        '}'
+      ].join('\n')
+    },
+    {
+      code: [
+        'type FooType = {',
+        '  a: number | string | boolean,',
+        '  c: number,',
+        '  b: (param: string) => number,',
+        '}'
+      ].join('\n'),
+      errors: [{message: 'Expected type annotations to be in ascending order. "b" should be before "c".'}],
+      output: [
+        'type FooType = {',
+        '  a: number | string | boolean,',
+        '  b: (param: string) => number,',
+        '  c: number,',
+        '}'
+      ].join('\n')
+    },
+    {
+      code: [
+        'type FooType = {',
+        '  c: number,',
+        '  a: number ',
+        ' | string | boolean,',
+        '  b: (param: string) => number,',
+        '}'
+      ].join('\n'),
+      errors: [{message: 'Expected type annotations to be in ascending order. "a" should be before "c".'}],
+      output: [
+        'type FooType = {',
+        '  a: number ',
+        ' | string | boolean,',
+        '  b: (param: string) => number,',
+        '  c: number,',
+        '}'
+      ].join('\n')
     }
   ],
   misconfigured: [


### PR DESCRIPTION
This adds an option to `--fix` the `sort-keys` rule.

It would be much cleaner using ESLint v4, because multiple tokens can be replaced. However, this is a fairly good (imo) solution, and it tries hard to maintain code style.

edit: ~this currently does not work in a few cases. Namely, `a: (param: number) => void` (or any function type). It also *doesn't* maintain the `?` in `a?: Object`.~

Alright, I think that covers all the use-cases now. If you can think of any more, please let me know.

Fixes: https://github.com/gajus/eslint-plugin-flowtype/issues/212