### PR TITLE
feat: Implement define-flow-type for declare type

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,7 +42,7 @@ Run with `npm run lint`.
 
 ### Adding Documentation
 
-1. Create new file in `./README/rules/[rule-name].md`.
+1. Create new file in `./.README/rules/[rule-name].md`.
   * Use [./.README/rules/require-valid-file-annotation.md](./.README/rules/require-valid-file-annotation.md) as a template.
   * Ensure that rule documentation document includes `<!-- assertions spaceAfterTypeColon -->` declaration.
 1. Update [./.README/README.md](/.README/README.md) to include the new rule.

--- a/src/rules/defineFlowType.js
+++ b/src/rules/defineFlowType.js
@@ -35,6 +35,12 @@ const create = (context) => {
     ClassImplements (node) {
       makeDefined(node.id);
     },
+    DeclareInterface (node) {
+      makeDefined(node.id);
+    },
+    DeclareTypeAlias (node) {
+      makeDefined(node.id);
+    },
     GenericTypeAnnotation (node) {
       if (node.id.type === 'Identifier') {
         makeDefined(node.id);

--- a/tests/rules/assertions/defineFlowType.js
+++ b/tests/rules/assertions/defineFlowType.js
@@ -37,6 +37,12 @@ const VALID_WITH_DEFINE_FLOW_TYPE = [
     ]
   },
   {
+    code: 'declare type A = number',
+    errors: [
+      '\'A\' is not defined.'
+    ]
+  },
+  {
     code: 'function f(a: AType) {}',
     errors: [
       '\'AType\' is not defined.'
@@ -95,6 +101,12 @@ const VALID_WITH_DEFINE_FLOW_TYPE = [
     code: 'interface AType {}',
     errors: [
       '\'AType\' is not defined.'
+    ]
+  },
+  {
+    code: 'declare interface A {}',
+    errors: [
+      '\'A\' is not defined.'
     ]
   },
   {


### PR DESCRIPTION
We weren't covering the `declare` versions of Flow type/interface declarations:

    declare type Foo = 'foo';
    declare interface Foo {};