### PR TITLE
allow class methods to be excluded from require-return-type

### DIFF
--- a/tests/rules/assertions/requireReturnType.js
+++ b/tests/rules/assertions/requireReturnType.js
@@ -226,6 +226,20 @@ export default {
       ]
     },
     {
+      code: 'class Test { constructor() { } }',
+      errors: [
+        {
+          message: 'Must annotate undefined return type.'
+        }
+      ],
+      options: [
+        'always',
+        {
+          annotateUndefined: 'always'
+        }
+      ]
+    },
+    {
       code: 'async () => { return; }',
       errors: [
         {
@@ -617,6 +631,19 @@ export default {
           annotateUndefined: 'always'
         }
       ]
+    },
+    {
+      code: 'class Test { constructor() { } }',
+      options: [
+        'always',
+        {
+          annotateUndefined: 'always',
+          excludeMatching: [ 'constructor' ]
+        }
+      ]
+    },
+    {
+      code: 'class Test { constructor() { } }'
     },
     {
       code: 'async (foo): Promise<number> => { return 3; }'


### PR DESCRIPTION
Fixes #281. In fixing this I realised that class methods as a whole could not be matched by the `excludeMatching`.