### PR TITLE
fix: Mark opaque type identifiers as defined with define-flow-type

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,9 @@ var a: AType<BType>
 type A = AType
 // Additional rules: {"no-undef":2}
 
+opaque type A = AType
+// Additional rules: {"no-undef":2}
+
 function f(a: AType) {}
 // Additional rules: {"no-undef":2}
 
@@ -304,6 +307,9 @@ var a: AType<BType>
 // Additional rules: {"no-undef":2,"no-use-before-define":[2,"nofunc"]}
 
 type A = AType
+// Additional rules: {"no-undef":2,"no-use-before-define":[2,"nofunc"]}
+
+opaque type A = AType
 // Additional rules: {"no-undef":2,"no-use-before-define":[2,"nofunc"]}
 
 function f(a: AType) {}

--- a/src/rules/defineFlowType.js
+++ b/src/rules/defineFlowType.js
@@ -58,6 +58,11 @@ const create = (context) => {
     InterfaceDeclaration (node) {
       makeDefined(node.id);
     },
+    OpaqueType (node) {
+      if (node.id.type === 'Identifier') {
+        makeDefined(node.id);
+      }
+    },
     Program () {
       globalScope = context.getScope();
     },

--- a/tests/rules/assertions/defineFlowType.js
+++ b/tests/rules/assertions/defineFlowType.js
@@ -43,6 +43,14 @@ const VALID_WITH_DEFINE_FLOW_TYPE = [
     ]
   },
   {
+    code: 'opaque type A = AType',
+    errors: [
+      // Complaining about 'A' not being defined might be an upstream bug
+      '\'A\' is not defined.',
+      '\'AType\' is not defined.'
+    ]
+  },
+  {
     code: 'function f(a: AType) {}',
     errors: [
       '\'AType\' is not defined.'
@@ -166,6 +174,8 @@ const ALWAYS_VALID = [
   'var a: Array',
   'var a: Array<string>',
   'type A = Array',
+  // This complains about 'A' not being defined. It might be an upstream bug
+  // 'opaque type A = Array',
   'function f(a: string) {}',
   'function f(a): string {}',
   'class C { a: string }',


### PR DESCRIPTION
This PR fixes #260 by suppressing invalid `no-undef` warnings when `define-flow-type` is active.

It seems like there's some upstream problems with opaque types causing `opaque type A = Array` to report `A` as `no-undef`, even though it shouldn't. Does anyone happen to have an idea as to which piece of this dependency graph would be responsible for fixing that?