### PR TITLE
feat: add no-flow-fix-me-comments

### DIFF
--- a/.README/README.md
+++ b/.README/README.md
@@ -147,6 +147,7 @@ When `true`, only checks files with a [`@flow` annotation](http://flowtype.org/d
 {"gitdown": "include", "file": "./rules/delimiter-dangle.md"}
 {"gitdown": "include", "file": "./rules/generic-spacing.md"}
 {"gitdown": "include", "file": "./rules/no-dupe-keys.md"}
+{"gitdown": "include", "file": "./rules/no-flow-fix-me-comments.md"}
 {"gitdown": "include", "file": "./rules/no-mutable-array.md"}
 {"gitdown": "include", "file": "./rules/no-primitive-constructor-types.md"}
 {"gitdown": "include", "file": "./rules/no-types-missing-file-annotation.md"}

--- a/.README/rules/no-flow-fix-me-comments.md
+++ b/.README/rules/no-flow-fix-me-comments.md
@@ -1,0 +1,22 @@
+### `no-flow-fix-me-comments`
+
+Disallows `$FlowFixMe` comment suppressions.
+
+This is especially useful as a warning to ensure instances of `$FlowFixMe` in your codebase get fixed over time.
+
+#### Options
+
+This rule takes an optional RegExp that comments a text RegExp that makes the supression valid.
+
+```js
+{
+    "rules": {
+        "flowtype/no-flow-fix-me-comments": [
+            1,
+            "TODO\s+[0-9]+"
+        ]
+    }
+}
+```
+
+<!-- assertions no-flow-fix-me-comments -->

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@ import defineFlowType from './rules/defineFlowType';
 import delimiterDangle from './rules/delimiterDangle';
 import genericSpacing from './rules/genericSpacing';
 import noDupeKeys from './rules/noDupeKeys';
+import noFlowFixMeComments from './rules/noFlowFixMeComments';
 import noMutableArray from './rules/noMutableArray';
 import noPrimitiveConstructorTypes from './rules/noPrimitiveConstructorTypes';
 import noTypesMissingFileAnnotation from './rules/noTypesMissingFileAnnotation';
@@ -32,6 +33,7 @@ const rules = {
   'delimiter-dangle': delimiterDangle,
   'generic-spacing': genericSpacing,
   'no-dupe-keys': noDupeKeys,
+  'no-flow-fix-me-comments': noFlowFixMeComments,
   'no-mutable-array': noMutableArray,
   'no-primitive-constructor-types': noPrimitiveConstructorTypes,
   'no-types-missing-file-annotation': noTypesMissingFileAnnotation,
@@ -73,6 +75,7 @@ export default {
     'delimiter-dangle': 0,
     'generic-spacing': 0,
     'no-dupe-keys': 0,
+    'no-flow-fix-me-comments': 0,
     'no-mutable-array': 0,
     'no-weak-types': 0,
     'object-type-delimiter': 0,

--- a/src/rules/noFlowFixMeComments.js
+++ b/src/rules/noFlowFixMeComments.js
@@ -1,0 +1,50 @@
+const schema = [
+  {
+    type: 'string'
+  }
+];
+
+const message = '$FlowFixMe is treated as `any` and should be fixed.';
+
+const isIdentifier = function (node, name) {
+  return node && node.type === 'Identifier' && node.name.match(name);
+};
+
+const create = (context) => {
+  const allowedPattern = context.options[0] ? new RegExp(context.options[0]) : null;
+  const extraMessage = allowedPattern ? ' Fix it or match `' + allowedPattern.toString() + '`.' : '';
+
+  const passesExtraRegex = function (value) {
+    if (!allowedPattern) {
+      return false;
+    }
+
+    return value.match(allowedPattern);
+  };
+
+  const handleComment = function (comment) {
+    const value = comment.value.trim();
+
+    if (value.match(/\$FlowFixMe/) && !passesExtraRegex(value)) {
+      context.report(comment, message + extraMessage);
+    }
+  };
+
+  return {
+    BlockComment: handleComment,
+    GenericTypeAnnotation: (node) => {
+      if (isIdentifier(node.id, /\$FlowFixMe/)) {
+        context.report({
+          message,
+          node: node.id
+        });
+      }
+    },
+    LineComment: handleComment
+  };
+};
+
+export default {
+  create,
+  schema
+};

--- a/tests/rules/assertions/noFlowFixMeComments.js
+++ b/tests/rules/assertions/noFlowFixMeComments.js
@@ -1,0 +1,85 @@
+export default {
+  invalid: [
+    {
+      code: '// $FlowFixMe I am doing something evil here\nconst text = \'HELLO\';',
+      errors: [
+        {
+          message: '$FlowFixMe is treated as `any` and should be fixed.'
+        }
+      ]
+    },
+    {
+      code: '// $FlowFixMe I am doing something evil here\nconst text = \'HELLO\';',
+      errors: [
+        {
+          message: '$FlowFixMe is treated as `any` and should be fixed. Fix it or match `/TODO [0-9]+/`.'
+        }
+      ],
+      options: [
+        'TODO [0-9]+'
+      ]
+    },
+    {
+      code: '// $FlowFixMe TODO abc 47 I am doing something evil here\nconst text = \'HELLO\';',
+      errors: [
+        {
+          message: '$FlowFixMe is treated as `any` and should be fixed. Fix it or match `/TODO [0-9]+/`.'
+        }
+      ],
+      options: [
+        'TODO [0-9]+'
+      ]
+    },
+    {
+      code: '// $$FlowFixMeProps I am doing something evil here\nconst text = \'HELLO\';',
+      errors: [
+        {
+          message: '$FlowFixMe is treated as `any` and should be fixed.'
+        }
+      ]
+    },
+    {
+      code: '// $FlowFixMeProps I am doing something evil here\nconst text = \'HELLO\';',
+      errors: [
+        {
+          message: '$FlowFixMe is treated as `any` and should be fixed. Fix it or match `/TODO [0-9]+/`.'
+        }
+      ],
+      options: [
+        'TODO [0-9]+'
+      ]
+    }
+  ],
+  misconfigured: [
+    {
+      errors: [
+        {
+          data: 7,
+          dataPath: '[0]',
+          keyword: 'type',
+          message: 'should be string',
+          params: {
+            type: 'string'
+          },
+          parentSchema: {
+            type: 'string'
+          },
+          schema: 'string',
+          schemaPath: '#/items/0/type'
+        }
+      ],
+      options: [7]
+    }
+  ],
+  valid: [
+    {
+      code: 'const text = \'HELLO\';'
+    },
+    {
+      code: '// $FlowFixMe TODO 48\nconst text = \'HELLO\';',
+      options: [
+        'TODO [0-9]+'
+      ]
+    }
+  ]
+};

--- a/tests/rules/index.js
+++ b/tests/rules/index.js
@@ -16,6 +16,7 @@ const reportingRules = [
   'delimiter-dangle',
   'generic-spacing',
   'no-dupe-keys',
+  'no-flow-fix-me-comments',
   'no-mutable-array',
   'no-primitive-constructor-types',
   'no-types-missing-file-annotation',


### PR DESCRIPTION
We use this lint rule internally at Facebook to make sure we keep an eye on these flow suppression comments and ensure they get fixed over time. We figure this might be useful to others as well.

cc @bestander