### PR TITLE
Prevent crash when using types with spreads

### DIFF
--- a/src/rules/noDupeKeys.js
+++ b/src/rules/noDupeKeys.js
@@ -62,6 +62,10 @@ const create = (context) => {
 
     _.forEach(node.properties, (identifierNode) => {
       const needle = {name: getParameterName(identifierNode, context)};
+      // avoids error for types constructed from spreading others like: type Props = { ...A, ...B }
+      if (identifierNode.type === 'ObjectTypeSpreadProperty') {
+        return
+      }
 
       if (identifierNode.value.type === 'FunctionTypeAnnotation') {
         needle.args = _.map(identifierNode.value.params, (param) => {


### PR DESCRIPTION
Fixes https://github.com/gajus/eslint-plugin-flowtype/issues/293

This just avoids a crash.  It doesn't go any further.  But at least the plugin is usable :)

Oh man, I just saw https://github.com/gajus/eslint-plugin-flowtype/pull/266.  This might be a duplicate although that PR seems more ambitious so I'll leave this PR open
