### PR TITLE
fix: require-return-type excludeMatching for class properties (#217)

### DIFF
--- a/src/rules/requireReturnType.js
+++ b/src/rules/requireReturnType.js
@@ -66,9 +66,10 @@ const create = (context) => {
   const shouldFilterNode = (functionNode) => {
     const isArrow = functionNode.type === 'ArrowFunctionExpression';
     const isMethod = functionNode.parent && functionNode.parent.type === 'MethodDefinition';
+    const isProperty = functionNode.parent && functionNode.parent.type === 'ClassProperty';
     let selector;
 
-    if (isMethod) {
+    if (isMethod || isProperty) {
       selector = 'parent.key.name';
     } else if (isArrow) {
       selector = 'parent.id.name';

--- a/tests/rules/assertions/requireReturnType.js
+++ b/tests/rules/assertions/requireReturnType.js
@@ -240,6 +240,30 @@ export default {
       ]
     },
     {
+      code: 'class Test { foo() { return 42; } }',
+      errors: [
+        {
+          message: 'Missing return type annotation.'
+        }
+      ]
+    },
+    {
+      code: 'class Test { foo = () => { return 42; } }',
+      errors: [
+        {
+          message: 'Missing return type annotation.'
+        }
+      ]
+    },
+    {
+      code: 'class Test { foo = () => 42; }',
+      errors: [
+        {
+          message: 'Missing return type annotation.'
+        }
+      ]
+    },
+    {
       code: 'async () => { return; }',
       errors: [
         {
@@ -644,6 +668,39 @@ export default {
     },
     {
       code: 'class Test { constructor() { } }'
+    },
+    {
+      code: 'class Test { foo() { return 42; } }',
+      options: [
+        'always',
+        {
+          excludeMatching: [ 'foo' ]
+        }
+      ]
+    },
+    {
+      code: 'class Test { foo = () => { return 42; } }',
+      options: [
+        'always',
+        {
+          excludeMatching: [ 'foo' ]
+        }
+      ]
+    },
+    {
+      code: 'class Test { foo = () => 42; }',
+      options: [
+        'always',
+        {
+          excludeMatching: [ 'foo' ]
+        }
+      ]
+    },
+    {
+      code: 'class Test { foo = (): number => { return 42; } }'
+    },
+    {
+      code: 'class Test { foo = (): number => 42; }'
     },
     {
       code: 'async (foo): Promise<number> => { return 3; }'


### PR DESCRIPTION
Fixes the bug with arrow functions as method properties not being excluded (#217)