### PR TITLE
Add utility types as globals

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -57,9 +57,35 @@ const rules = {
   'valid-syntax': validSyntax
 };
 
+const globals = [
+  '$Keys',
+  '$Values',
+  '$ReadOnly',
+  '$Exact',
+  '$Diff',
+  '$Rest',
+  '$PropertyType',
+  '$ElementType',
+  '$ObjMap',
+  '$TupleMap',
+  '$Call',
+  'Class',
+  '$Supertype',
+  '$Subtype'
+].reduce((acc, key) => {
+  acc[key] = true;
+
+  return acc;
+}, {});
+
 export default {
   configs: {
     recommended
+  },
+  environments: {
+    globals: {
+      globals
+    }
   },
   rules: _.mapValues(rules, (rule, key) => {
     if (key === 'no-types-missing-file-annotation') {


### PR DESCRIPTION
I ran into #290 so took a naive stab at fixing it. Didn't seem like other utility types were being handled either, so I added them as globals.

Right now you opt-in by putting this in your config:

```
"env": {
    "flowtype/globals": true
},
```

Let me know if I've put it in the wrong place and I'll fix up. Also not sure if you can only specify globals when a file has `@flow` marker...