### PR TITLE
feat: Add no-existential-type rule

### DIFF
--- a/.README/README.md
+++ b/.README/README.md
@@ -148,6 +148,7 @@ When `true`, only checks files with a [`@flow` annotation](http://flowtype.org/d
 {"gitdown": "include", "file": "./rules/generic-spacing.md"}
 {"gitdown": "include", "file": "./rules/newline-after-flow-annotation"}
 {"gitdown": "include", "file": "./rules/no-dupe-keys.md"}
+{"gitdown": "include", "file": "./rules/no-existential-type.md"}
 {"gitdown": "include", "file": "./rules/no-flow-fix-me-comments.md"}
 {"gitdown": "include", "file": "./rules/no-mutable-array.md"}
 {"gitdown": "include", "file": "./rules/no-primitive-constructor-types.md"}

--- a/.README/rules/no-existential-type.md
+++ b/.README/rules/no-existential-type.md
@@ -1,0 +1,15 @@
+### `no-existential-type`
+
+Disallows use of the existential type (*). [See more](https://flow.org/en/docs/types/utilities/#toc-existential-type)
+
+```js
+{
+  "rules": {
+    "flowtype/no-existential-type": 2
+  }
+}
+```
+
+
+<!-- assertions newlineAfterFlowAnnotation -->
+

--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,7 @@ import delimiterDangle from './rules/delimiterDangle';
 import genericSpacing from './rules/genericSpacing';
 import newlineAfterFlowAnnotation from './rules/newlineAfterFlowAnnotation';
 import noDupeKeys from './rules/noDupeKeys';
+import noExistentialType from './rules/noExistentialType';
 import noFlowFixMeComments from './rules/noFlowFixMeComments';
 import noMutableArray from './rules/noMutableArray';
 import noPrimitiveConstructorTypes from './rules/noPrimitiveConstructorTypes';
@@ -36,6 +37,7 @@ const rules = {
   'generic-spacing': genericSpacing,
   'newline-after-flow-annotation': newlineAfterFlowAnnotation,
   'no-dupe-keys': noDupeKeys,
+  'no-existential-type': noExistentialType,
   'no-flow-fix-me-comments': noFlowFixMeComments,
   'no-mutable-array': noMutableArray,
   'no-primitive-constructor-types': noPrimitiveConstructorTypes,

--- a/src/rules/noExistentialType.js
+++ b/src/rules/noExistentialType.js
@@ -1,0 +1,22 @@
+// Support both node types for existential type
+// https://github.com/babel/babylon/issues/319
+const reporter = (context) => {
+  return (node) => {
+    context.report({
+      message: 'Unexpected use of existential type (*).',
+      node
+    });
+  };
+};
+
+const create = (context) => {
+  return {
+    ExistentialTypeParam: reporter(context),
+    ExistsTypeAnnotation: reporter(context)
+  };
+};
+
+export default {
+  create
+};
+

--- a/tests/rules/assertions/noExistentialType.js
+++ b/tests/rules/assertions/noExistentialType.js
@@ -1,0 +1,27 @@
+export default {
+  invalid: [
+    {
+      code: 'type T = *;',
+      errors: [{message: 'Unexpected use of existential type (*).'}]
+    },
+    {
+      code: 'type T = U<*, *>;',
+      errors: [
+        {column: 12,
+          message: 'Unexpected use of existential type (*).'},
+        {column: 15,
+          message: 'Unexpected use of existential type (*).'}
+      ]
+    },
+    {
+      code: 'const f: (*) => null = () => null;',
+      errors: [{message: 'Unexpected use of existential type (*).'}]
+    }
+  ],
+  valid: [
+    {
+      code: 'type T = string | null'
+    }
+  ]
+};
+


### PR DESCRIPTION
This ensures that the existential type (`*`) is not used. This is valuable in large codebases with developers unfamiliar with Flow; it's easily misinterpreted and misused.

Due to differences in flow/babylon[0], there are two potential node names.

[0] https://github.com/babel/babylon/issues/319