### PR TITLE
fix: object-type-delimeter with new babel-eslint

### DIFF
--- a/src/rules/objectTypeDelimiter.js
+++ b/src/rules/objectTypeDelimiter.js
@@ -24,8 +24,18 @@ const create = (context) => {
   }
 
   const requireProperPunctuation = (node) => {
-    const tokens = context.getSourceCode().getTokens(node);
-    const lastToken = tokens[tokens.length - 1];
+    const sourceCode = context.getSourceCode();
+    const tokens = sourceCode.getTokens(node);
+    let lastToken;
+
+    lastToken = tokens[tokens.length - 1];
+    if (lastToken.type !== 'Punctuator' ||
+        !(lastToken.value === SEMICOLON.char ||
+          lastToken.value === COMMA.char)) {
+      const parentTokens = sourceCode.getTokens(node.parent);
+
+      lastToken = parentTokens[parentTokens.indexOf(lastToken) + 1];
+    }
 
     if (lastToken.type === 'Punctuator') {
       if (lastToken.value === BAD.char) {


### PR DESCRIPTION
Using babel-eslint 8.2.1, the object-type-delimeter rule does nothing, apparently because the `ObjectType{CallProperty,Indexer,Property}` nodes no longer contain trailing semicolons/commas, but their parent `ObjectTypeAnnotation` nodes do.

I could not find a changelog or git commit entry in any of the associated projects for where/why this was changed...

I tried to keep compatibility with both cases, because it's not clear what version this project is targeting. However, I don't know of a good way to test the new behavior given the version of babel-eslint now locked in devDependencies.