### PR TITLE
#266 #302 #293 Prevent crash when using types with spreads

### DIFF
--- a/src/rules/noDupeKeys.js
+++ b/src/rules/noDupeKeys.js
@@ -61,6 +61,11 @@ const create = (context) => {
     const haystack = [];
 
     _.forEach(node.properties, (identifierNode) => {
+      // avoids error for types constructed from spreading others like: type Props = { ...A, ...B }
+      if (identifierNode.type === 'ObjectTypeSpreadProperty') {
+        return;
+      }
+
       const needle = {name: getParameterName(identifierNode, context)};
 
       if (identifierNode.value.type === 'FunctionTypeAnnotation') {

--- a/src/rules/sortKeys.js
+++ b/src/rules/sortKeys.js
@@ -123,6 +123,11 @@ const create = (context) => {
     prev = null;
 
     _.forEach(node.properties, (identifierNode) => {
+      // avoids error for types constructed from spreading others like: type Props = { ...A, ...B }
+      if (identifierNode.type === 'ObjectTypeSpreadProperty') {
+        return;
+      }
+
       const current = getParameterName(identifierNode, context);
       const last = prev;
 

--- a/tests/rules/assertions/noDupeKeys.js
+++ b/tests/rules/assertions/noDupeKeys.js
@@ -108,5 +108,9 @@ export default {
     {
       code: 'var a = 1; var b = 1; type f = { get(key: a): string, get(key: b): string }'
     }
+    // TODO: Uncomment when we update the tests to use babel-eslint@^7.2.0.
+    // {
+    //   code: 'type One = { c: number }; type Two = { a: number, b: string, ...One }'
+    // }
   ]
 };

--- a/tests/rules/assertions/sortKeys.js
+++ b/tests/rules/assertions/sortKeys.js
@@ -378,5 +378,9 @@ export default {
         }
       }
     }
+    // TODO: Uncomment when we update the tests to use babel-eslint@^7.2.0.
+    // {
+    //   code: 'type One = { c: number }; type Two = { a: number, b: string, ...One }'
+    // }
   ]
 };


### PR DESCRIPTION
This is solution 1 (so I won't update `babel-eslint` nor add proper tests) from @lydell https://github.com/gajus/eslint-plugin-flowtype/pull/266#issuecomment-326184447. It also fixes crash for sortKeys rule. Not the best solution though, but should work in the meantime.

#266 #302 #293

@gajus any plans to update `babel-eslint`?