### PR TITLE
fix: (type-import-style) Support import aliases when fixing

### DIFF
--- a/src/rules/typeImportStyle.js
+++ b/src/rules/typeImportStyle.js
@@ -29,7 +29,13 @@ const create = (context) => {
           context.report({
             fix (fixer) {
               const imports = node.specifiers.map((specifier) => {
-                return 'type ' + specifier.local.name;
+                if (specifier.type === 'ImportDefaultSpecifier') {
+                  return 'type default as ' + specifier.local.name;
+                } else if (specifier.imported.name === specifier.local.name) {
+                  return 'type ' + specifier.local.name;
+                } else {
+                  return 'type ' + specifier.imported.name + ' as ' + specifier.local.name;
+                }
               });
               const source = node.source.value;
 

--- a/tests/rules/assertions/typeImportStyle.js
+++ b/tests/rules/assertions/typeImportStyle.js
@@ -12,6 +12,18 @@ export default {
       output: 'import {type A, type B} from \'a\';'
     },
     {
+      code: 'import type {A, B as C} from \'a\';',
+      errors: [{message: 'Unexpected "import type"'}],
+      options: ['identifier'],
+      output: 'import {type A, type B as C} from \'a\';'
+    },
+    {
+      code: 'import type A from \'a\';',
+      errors: [{message: 'Unexpected "import type"'}],
+      options: ['identifier'],
+      output: 'import {type default as A} from \'a\';'
+    },
+    {
       code: 'import {type A, type B} from \'a\';',
       errors: [
         {message: 'Unexpected type import'},


### PR DESCRIPTION
Fixes a bug in `type-import-style`'s fixer that would drop import aliases. For example:

```jsx
import type {A as B} from 'foo';
```
would be fixed to

```jsx
import type {B} from 'foo';
```

I also fixed it to handle default type imports:

```jsx
import type A from 'foo';
```