### PR TITLE
fix: noDupeKeys ignores ObjectTypeSpreadProperty

### DIFF
--- a/src/rules/noDupeKeys.js
+++ b/src/rules/noDupeKeys.js
@@ -59,8 +59,10 @@ const create = (context) => {
 
   const checkForDuplicates = (node) => {
     const haystack = [];
+    // filter out complex object types, like ObjectTypeSpreadProperty
+    const identifierNodes = _.filter(node.properties, {type: 'ObjectTypeProperty'});
 
-    _.forEach(node.properties, (identifierNode) => {
+    _.forEach(identifierNodes, (identifierNode) => {
       const needle = {name: getParameterName(identifierNode, context)};
 
       if (identifierNode.value.type === 'FunctionTypeAnnotation') {


### PR DESCRIPTION
The [new object type spread](https://github.com/facebook/flow/issues/1326) features in Flow cause the noDupeKeys rule to crash. Specifically, `.value` is accessed on the `ObjectTypeSpreadProperty` node, which doesn't have that field.

```javascript
type Foo = {...Bar}; // this would crash noDupeKeyes
```

The workaround is to use the Flow commenting syntax, like this:
/**
type Foo = {...Bar};
*/

I'd love to write tests (and had, in fact), but due to some combination of babylon, babel-eslint, and babel-cli, the object type spread syntax wasn't recognized and would fail tests (most immediately caused by babel-eslint). I tried bumping versions, but ended up going down a bit of a rabbit hole because other tests began failing. Seems like a general version bump refresh is in order.

Would appreciate any feedback, thanks!