### PR TITLE
Fix $FlowFixMe comments for eslint 4

### DIFF
--- a/src/rules/noFlowFixMeComments.js
+++ b/src/rules/noFlowFixMeComments.js
@@ -31,8 +31,7 @@ const create = (context) => {
   };
 
   return {
-    BlockComment: handleComment,
-    GenericTypeAnnotation: (node) => {
+    GenericTypeAnnotation (node) {
       if (isIdentifier(node.id, /\$FlowFixMe/)) {
         context.report({
           message,
@@ -40,7 +39,16 @@ const create = (context) => {
         });
       }
     },
-    LineComment: handleComment
+
+    Program () {
+      context
+        .getSourceCode()
+        .getAllComments()
+        .filter((comment) => {
+          return comment.type === 'Block' || comment.type === 'Line';
+        })
+        .forEach(handleComment);
+    }
   };
 };
 


### PR DESCRIPTION
Eslint [stopped](https://eslint.org/docs/user-guide/migrating-to-4.0.0#event-comments) to emit `LineComment` and `BlockComment` events in v4.