### PR TITLE
Fix variance issues with babel 7

### DIFF
--- a/src/rules/sortKeys.js
+++ b/src/rules/sortKeys.js
@@ -70,6 +70,16 @@ const variances = {
   plus: '+'
 };
 
+const getVariance = (node) => {
+  if (_.isString(node.variance)) {
+    return variances[node.variance] || '';
+  } else if (_.get(node, 'variance.type') === 'Variance') {
+    return variances[node.variance.kind] || '';
+  } else {
+    return '';
+  }
+};
+
 const generateOrderedList = (context, sort, properties) => {
   return properties.map((property) => {
     const name = getParameterName(property, context);
@@ -84,7 +94,7 @@ const generateOrderedList = (context, sort, properties) => {
       value = context.getSourceCode().getText(property.value);
     }
 
-    return [(variances[property.variance] || '') + name + (property.optional ? '?' : ''), value];
+    return [name, getVariance(property) + name + (property.optional ? '?' : ''), value];
   })
     .sort((first, second) => {
       return sort(first[0], second[0]) ? -1 : 1;
@@ -94,7 +104,7 @@ const generateOrderedList = (context, sort, properties) => {
         return item[0];
       }
 
-      return item[0] + ': ' + item[1];
+      return item[1] + ': ' + item[2];
     });
 };
 

--- a/tests/rules/assertions/sortKeys.js
+++ b/tests/rules/assertions/sortKeys.js
@@ -231,6 +231,46 @@ export default {
           },
         }
       `
+    },
+    {
+      code: `
+        type FooType = {
+          +c: number,
+          -b: number,
+          a: number,
+        }
+      `,
+      errors: [
+        {message: 'Expected type annotations to be in ascending order. "b" should be before "c".'},
+        {message: 'Expected type annotations to be in ascending order. "a" should be before "b".'}
+      ],
+      output: `
+        type FooType = {
+          a: number,
+          -b: number,
+          +c: number,
+        }
+      `
+    },
+    {
+      code: `
+        type FooType = {|
+          +c: number,
+          -b: number,
+          a: number,
+        |}
+      `,
+      errors: [
+        {message: 'Expected type annotations to be in ascending order. "b" should be before "c".'},
+        {message: 'Expected type annotations to be in ascending order. "a" should be before "b".'}
+      ],
+      output: `
+        type FooType = {|
+          a: number,
+          -b: number,
+          +c: number,
+        |}
+      `
     }
     /* eslint-enable no-restricted-syntax */
   ],


### PR DESCRIPTION
In [Babel parser v7](https://github.com/babel/babel/blob/master/packages/babel-parser/ast/spec.md#babelparser-babylon-v7) the variance is represented as a node instead of a string. Fixes #334. Relates to #336.

I also spotted `ObjectTypeSpreadProperty` case in the rule, but no tests for it. It perhaps relates to Flow's [type extensions](https://github.com/facebook/flow/pull/5973):

```
type One = {| foo: number |};
type Two = {| bar: boolean |};

type Both = {| ...One, ...Two |}
```

So before this is merged, we should probably define how these spread types behave (it is not mentioned in docs), then validate if they work as we want, and if not, fix them.

My proposal is to have them below normal properties if asc is used, i.e.:

```
type Foo = {
     z: number,
     ...Bar,
}
```