### PR TITLE
feat: add 'prefer-declaration' option for type-import-style

### DIFF
--- a/.README/rules/type-import-style.md
+++ b/.README/rules/type-import-style.md
@@ -10,6 +10,9 @@ import {type T, type U, type V} from '...';
 
 // 'declaration' style
 import type {T, U, V} from '...';
+
+// 'mixed' style
+import {T, type U, type V} from '...';
 ```
 
 The rule has a string option:
@@ -17,6 +20,8 @@ The rule has a string option:
 * `"identifier"` (default): Enforces that type imports are all in the
   'identifier' style.
 * `"declaration"`: Enforces that type imports are all in the 'declaration'
-  style.
+* `"prefer-declaration"`: Less restrictive than 'declaration'. Allow mixture of types and non-types imports. But if all
+  imported are types the 'declaration' style is allowed only.
+
 
 <!-- assertions typeImportStyle -->

--- a/src/rules/typeImportStyle.js
+++ b/src/rules/typeImportStyle.js
@@ -1,6 +1,6 @@
 const schema = [
   {
-    enum: ['declaration', 'identifier'],
+    enum: ['declaration', 'identifier', 'prefer-declaration'],
     type: 'string'
   }
 ];
@@ -18,6 +18,37 @@ const create = (context) => {
               });
             }
           });
+        }
+      }
+    };
+  } else if (context.options[0] === 'prefer-declaration') {
+    return {
+      ImportDeclaration (node) {
+        if (node.importKind !== 'type') {
+          if (node.specifiers.length && node.specifiers.every((specifier) => {
+            return specifier.importKind === 'type';
+          })) {
+            context.report({
+              fix (fixer) {
+                const imports = node.specifiers.map((specifier) => {
+                  if (specifier.type === 'ImportDefaultSpecifier') {
+                    return 'default as ' + specifier.local.name;
+                  } else if (specifier.imported.name === specifier.local.name) {
+                    return specifier.local.name;
+                  } else {
+                    return specifier.imported.name + ' as ' + specifier.local.name;
+                  }
+                });
+                const source = node.source.value;
+
+                return fixer.replaceText(node,
+                  'import type {' + imports.join(', ') + '} from \'' + source + '\';'
+                );
+              },
+              message: 'Unexpected type import',
+              node
+            });
+          }
         }
       }
     };

--- a/tests/rules/assertions/typeImportStyle.js
+++ b/tests/rules/assertions/typeImportStyle.js
@@ -30,6 +30,29 @@ export default {
         {message: 'Unexpected type import'}
       ],
       options: ['declaration']
+    },
+    {
+      code: 'import {A, type B} from \'a\';',
+      errors: [
+        {message: 'Unexpected type import'}
+      ],
+      options: ['declaration']
+    },
+    {
+      code: 'import {type A, type B} from \'a\';',
+      errors: [
+        {message: 'Unexpected type import'}
+      ],
+      options: ['prefer-declaration'],
+      output: 'import type {A, B} from \'a\';'
+    },
+    {
+      code: 'import {type A as A2, type B} from \'a\';',
+      errors: [
+        {message: 'Unexpected type import'}
+      ],
+      options: ['prefer-declaration'],
+      output: 'import type {A as A2, B} from \'a\';'
     }
   ],
   valid: [
@@ -43,6 +66,22 @@ export default {
     {
       code: 'import type {A, B} from \'a\';',
       options: ['declaration']
+    },
+    {
+      code: 'import {A, type B} from \'a\';',
+      options: ['prefer-declaration']
+    },
+    {
+      code: 'import A, {type B} from \'a\';',
+      options: ['prefer-declaration']
+    },
+    {
+      code: 'import {A, type B as B2} from \'a\';',
+      options: ['prefer-declaration']
+    },
+    {
+      code: 'import type A, * as B from \'a\';',
+      options: ['prefer-declaration']
     }
   ]
 };


### PR DESCRIPTION
Introduce new option `prefer-declaration` for type-imports-style rule.

Work the same as `declaration` option but allows the mixture of type and non-type imports.

```javascript
import {x, type B} from "x"; // Valid

import {type A, type B} from "x"; // Not Valid 
import type {A, B} from "x"; // Valid

```


**Reason:**
We found a problem in different behavior of types imports and I would like to add a support for it. 

[Long story](https://github.com/babel/babel/issues/6300#issuecomment-331787868) short:
```javascript
import {type A} from "x";

// is an equivalent of 
import "x";
import type {A} from "x";
```
The first import can contains side effects or can cause circular dependencies and that's why we would like to change/add behavior to prefer `import type {AType} from '';` whenever it is possible but don't loose the ability to use syntactic sugar with mixture of type and non-type imports (`import {AClass, type AType} from ''`).