### PR TITLE
fix: remove deprecated rule from recommended config

### DIFF
--- a/src/configs/recommended.json
+++ b/src/configs/recommended.json
@@ -38,7 +38,6 @@
       "always"
     ],
     "flowtype/use-flow-type": 1,
-    "flowtype/valid-syntax": 1
   },
   "settings": {
     "flowtype": {

--- a/src/configs/recommended.json
+++ b/src/configs/recommended.json
@@ -38,7 +38,7 @@
       2,
       "always"
     ],
-    "flowtype/use-flow-type": 1,
+    "flowtype/use-flow-type": 1
   },
   "settings": {
     "flowtype": {


### PR DESCRIPTION
The [documentation](https://github.com/gajus/eslint-plugin-flowtype#eslint-plugin-flowtype-rules) states that the rule `flowtype/valid-syntax` is deprecated since Babylon (the Babel parser) v6.10.0 fixes parsing of the invalid syntax this plugin warned against.