### PR TITLE
fix: make require-exact-type ignore indexers in map types

### DIFF
--- a/src/rules/requireExactType.js
+++ b/src/rules/requireExactType.js
@@ -10,10 +10,10 @@ const create = (context) => {
 
   return {
     TypeAlias (node) {
-      const {id: {name}, right: {type, exact}} = node;
+      const {id: {name}, right: {type, exact, indexers}} = node;
 
       if (type === 'ObjectTypeAnnotation') {
-        if (always && !exact) {
+        if (always && !exact && indexers.length === 0) {
           context.report({
             data: {name},
             message: 'Type identifier \'{{name}}\' must be exact.',

--- a/tests/rules/assertions/requireExactType.js
+++ b/tests/rules/assertions/requireExactType.js
@@ -70,6 +70,9 @@ export default {
       code: 'type foo = {| bar: string |};'
     },
     {
+      code: 'type foo = { [key: string]: string };'
+    },
+    {
       code: 'type foo = number;'
     },
     {


### PR DESCRIPTION
When indexers are used to create Object Map types, it does not normally make sense for them to be exact (see [here](https://github.com/facebook/flow/issues/3162)).
With `require-exact-type` enabled you end up with lots of `eslint-ignore` comments.
I think it would be better to ignore types with indexers in this rule.