### PR TITLE
Fix semi rule for opaque types

### DIFF
--- a/src/rules/semi.js
+++ b/src/rules/semi.js
@@ -54,6 +54,7 @@ const create = (context) => {
   };
 
   return {
+    OpaqueType: checkForSemicolon,
     TypeAlias: checkForSemicolon
   };
 };

--- a/tests/rules/assertions/semi.js
+++ b/tests/rules/assertions/semi.js
@@ -29,6 +29,16 @@ export default {
       ],
       options: ['never'],
       output: 'type FooType = {}'
+    },
+    {
+      code: 'opaque type FooType = {}',
+      errors: [
+        {
+          message: 'Missing semicolon.'
+        }
+      ],
+      options: [],
+      output: 'opaque type FooType = {};'
     }
   ],
   misconfigured: [
@@ -89,6 +99,9 @@ export default {
           onlyFilesWithFlowAnnotation: true
         }
       }
+    },
+    {
+      code: 'opaque type FooType = {};'
     }
   ]
 };


### PR DESCRIPTION
Docs for this rule speak about type aliases but I take opaque types just as a bit different type aliases so I didn't change the docs. If I should explicitly mention that this rule works for type aliases *and* opaque types, let me know.