### PR TITLE
docs: Add docs about require-compound-type-alias to readme

### DIFF
--- a/.README/README.md
+++ b/.README/README.md
@@ -164,6 +164,7 @@ When `true`, only checks files with a [`@flow` annotation](http://flowtype.org/d
 {"gitdown": "include", "file": "./rules/no-unused-expressions.md"}
 {"gitdown": "include", "file": "./rules/no-weak-types.md"}
 {"gitdown": "include", "file": "./rules/object-type-delimiter.md"}
+{"gitdown": "include", "file": "./rules/require-compound-type-alias.md"}
 {"gitdown": "include", "file": "./rules/require-exact-type.md"}
 {"gitdown": "include", "file": "./rules/require-parameter-type.md"}
 {"gitdown": "include", "file": "./rules/require-return-type.md"}

--- a/.README/rules/require-compound-type-alias.md
+++ b/.README/rules/require-compound-type-alias.md
@@ -11,4 +11,4 @@ The rule has a string option:
 
 The default value is `"always"`.
 
-<!-- assertions require-compound-type-alias -->
+<!-- assertions requireCompoundTypeAlias -->


### PR DESCRIPTION
I apologize but I didn't add the docs of the rule to the readme. I should have tried to generate the docs locally...