### PR TITLE
ci(.travis.yml): remove node 6 build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: node_js
 node_js:
   - node
   - 8
-  - 6
 before_install:
   - npm config set depth 0
 notifications:


### PR DESCRIPTION
fix #388 

not sure if you want this yet, but semantic-release is requiring node >= 8.3 and Node 6 will reach end-of-life this April.