### PR TITLE
feat: add rule to make sure that object type that is spread has exact type

### DIFF
--- a/.README/README.md
+++ b/.README/README.md
@@ -181,6 +181,7 @@ When `true`, only checks files with a [`@flow` annotation](http://flowtype.org/d
 {"gitdown": "include", "file": "./rules/space-after-type-colon.md"}
 {"gitdown": "include", "file": "./rules/space-before-generic-bracket.md"}
 {"gitdown": "include", "file": "./rules/space-before-type-colon.md"}
+{"gitdown": "include", "file": "./rules/spread-exact-type.md"}
 {"gitdown": "include", "file": "./rules/type-id-match.md"}
 {"gitdown": "include", "file": "./rules/type-import-style.md"}
 {"gitdown": "include", "file": "./rules/union-intersection-spacing.md"}

--- a/.README/rules/spread-exact-type.md
+++ b/.README/rules/spread-exact-type.md
@@ -1,0 +1,5 @@
+### `spread-exact-type`
+
+Enforce object types, that are spread to be exact type explicitly.
+
+<!-- assertions spreadExactType -->

--- a/src/index.js
+++ b/src/index.js
@@ -34,6 +34,7 @@ import typeImportStyle from './rules/typeImportStyle';
 import unionIntersectionSpacing from './rules/unionIntersectionSpacing';
 import useFlowType from './rules/useFlowType';
 import validSyntax from './rules/validSyntax';
+import spreadExactType from './rules/spreadExactType';
 import {checkFlowFileAnnotation} from './utilities';
 
 const rules = {
@@ -66,6 +67,7 @@ const rules = {
   'space-after-type-colon': spaceAfterTypeColon,
   'space-before-generic-bracket': spaceBeforeGenericBracket,
   'space-before-type-colon': spaceBeforeTypeColon,
+  'spread-exact-type': spreadExactType,
   'type-id-match': typeIdMatch,
   'type-import-style': typeImportStyle,
   'union-intersection-spacing': unionIntersectionSpacing,
@@ -109,6 +111,7 @@ export default {
     'space-after-type-colon': 0,
     'space-before-generic-bracket': 0,
     'space-before-type-colon': 0,
+    'spread-exact-type': 0,
     'type-id-match': 0,
     'type-import-style': 0,
     'union-intersection-spacing': 0,

--- a/src/rules/spreadExactType.js
+++ b/src/rules/spreadExactType.js
@@ -1,0 +1,33 @@
+const schema = [
+  {
+    enum: ['always', 'never'],
+    type: 'string'
+  }
+];
+
+const create = (context) => {
+  return {
+    ObjectTypeAnnotation (node) {
+      const {properties} = node;
+
+      properties.forEach((property) => {
+        const {type} = property;
+        if (type === 'ObjectTypeSpreadProperty') {
+          const {argument: {type: argumentType, id: argumentId}} = property;
+          if (
+            argumentType !== 'GenericTypeAnnotation' || argumentId.name !== '$Exact') {
+            context.report({
+              message: 'Use $Exact to make type spreading safe.',
+              node
+            });
+          }
+        }
+      });
+    }
+  };
+};
+
+export default {
+  create,
+  schema
+};

--- a/tests/rules/assertions/spreadExactType.js
+++ b/tests/rules/assertions/spreadExactType.js
@@ -1,0 +1,20 @@
+export default {
+  invalid: [
+    {
+      code: 'type bar = {...{test: string}}',
+      errors: [{message: 'Use $Exact to make type spreading safe.'}]
+    },
+    {
+      code: 'type foo = {test: number}; type bar = {...foo}',
+      errors: [{message: 'Use $Exact to make type spreading safe.'}]
+    }
+  ],
+  valid: [
+    {
+      code: 'type bar = {...$Exact<{test: string}>}'
+    },
+    {
+      code: 'type foo = {test: number}; type bar = {...$Exact<foo>}'
+    }
+  ]
+};

--- a/tests/rules/index.js
+++ b/tests/rules/index.js
@@ -40,6 +40,7 @@ const reportingRules = [
   'space-after-type-colon',
   'space-before-generic-bracket',
   'space-before-type-colon',
+  'spread-exact-type',
   'type-id-match',
   'type-import-style',
   'union-intersection-spacing',


### PR DESCRIPTION
This rule will add possibility to enforce spreading only exact object types, that are explicitly exact. 

When object type is not exact and is spread inside other object annotation, it can lead to resulted type to be dependent on the place, where object type was spread. For example, this case, that from first look is invalid https://flow.org/try/#0C4TwDgpgBAygFgQwE4QCYAUkHtJOASwgGcoBeKAbwCgooAbCAOwHNg4AuKRgVwFsAjCEgA0NLgl4RORYEnwtRAXwDcVKqEhQAchADumHEILEylMQmZSufQSLEA6R-GRoDuY0SWqqAYyyMZKFwif04dfWx3QhJyagBICysAciw6VCSlIA
actually doesn't cause any flow errors. 

One of the way to prevent such cases, is to spread only exact object types.