### PR TITLE
feat: add "ignoreTypeDefault" option to "type-import-style"

### DIFF
--- a/.README/rules/type-import-style.md
+++ b/.README/rules/type-import-style.md
@@ -12,11 +12,17 @@ import {type T, type U, type V} from '...';
 import type {T, U, V} from '...';
 ```
 
+#### Options
+
 The rule has a string option:
 
 * `"identifier"` (default): Enforces that type imports are all in the
   'identifier' style.
 * `"declaration"`: Enforces that type imports are all in the 'declaration'
   style.
+
+This rule has an object option:
+
+* `ignoreTypeDefault` - if `true`, when in "identifier" mode, default type imports will be ignored. Default is `false`.
 
 <!-- assertions typeImportStyle -->

--- a/src/rules/typeImportStyle.js
+++ b/src/rules/typeImportStyle.js
@@ -2,6 +2,15 @@ const schema = [
   {
     enum: ['declaration', 'identifier'],
     type: 'string'
+  },
+  {
+    additionalProperties: false,
+    properties: {
+      ignoreTypeDefault: {
+        type: 'boolean'
+      }
+    },
+    type: 'object'
   }
 ];
 
@@ -23,28 +32,41 @@ const create = (context) => {
     };
   } else {
     // Default to 'identifier'
+    const ignoreTypeDefault = context.options[1] &&
+      context.options[1].ignoreTypeDefault;
+
     return {
       ImportDeclaration (node) {
-        if (node.importKind === 'type') {
-          context.report({
-            fix (fixer) {
-              const imports = node.specifiers.map((specifier) => {
-                if (specifier.type === 'ImportDefaultSpecifier') {
-                  return 'type default as ' + specifier.local.name;
-                } else if (specifier.imported.name === specifier.local.name) {
-                  return 'type ' + specifier.local.name;
-                } else {
-                  return 'type ' + specifier.imported.name + ' as ' + specifier.local.name;
-                }
-              });
-              const source = node.source.value;
-
-              return fixer.replaceText(node, 'import {' + imports.join(', ') + '} from \'' + source + '\';');
-            },
-            message: 'Unexpected "import type"',
-            node
-          });
+        if (node.importKind !== 'type') {
+          return;
         }
+
+        if (
+          ignoreTypeDefault &&
+          node.specifiers[0] &&
+          node.specifiers[0].type === 'ImportDefaultSpecifier'
+        ) {
+          return;
+        }
+
+        context.report({
+          fix (fixer) {
+            const imports = node.specifiers.map((specifier) => {
+              if (specifier.type === 'ImportDefaultSpecifier') {
+                return 'type default as ' + specifier.local.name;
+              } else if (specifier.imported.name === specifier.local.name) {
+                return 'type ' + specifier.local.name;
+              } else {
+                return 'type ' + specifier.imported.name + ' as ' + specifier.local.name;
+              }
+            });
+            const source = node.source.value;
+
+            return fixer.replaceText(node, 'import {' + imports.join(', ') + '} from \'' + source + '\';');
+          },
+          message: 'Unexpected "import type"',
+          node
+        });
       }
     };
   }

--- a/tests/rules/assertions/typeImportStyle.js
+++ b/tests/rules/assertions/typeImportStyle.js
@@ -43,6 +43,14 @@ export default {
     {
       code: 'import type {A, B} from \'a\';',
       options: ['declaration']
+    },
+    {
+      code: 'import typeof * as A from \'a\';',
+      options: ['identifier']
+    },
+    {
+      code: 'import type A from \'a\';',
+      options: ['identifier', {ignoreTypeDefault: true}]
     }
   ]
 };


### PR DESCRIPTION
The newly added `ignoreTypeDefault` option, lets you avoid cases where the
rule would normally complain for `import type foo from "...";` when in
"identifier" mode. This is desirable because
`import {type default as foo} from '...';` is kinda long, when you would
otherwise prefer `import type foo from '...';`. Also, `type default as foo`
conflicts with `eslint-plugin-import`'s `import/no-named-default`
https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-named-default.md