### PR TITLE
fix: skip type-import-style identifier in "declare module"

### DIFF
--- a/src/rules/typeImportStyle.js
+++ b/src/rules/typeImportStyle.js
@@ -34,10 +34,23 @@ const create = (context) => {
     // Default to 'identifier'
     const ignoreTypeDefault = context.options[1] &&
       context.options[1].ignoreTypeDefault;
+    let isInsideDeclareModule = false;
 
     return {
+      DeclareModule () {
+        isInsideDeclareModule = true;
+      },
+      'DeclareModule:exit' () {
+        isInsideDeclareModule = false;
+      },
       ImportDeclaration (node) {
         if (node.importKind !== 'type') {
+          return;
+        }
+
+        // type specifiers are not allowed inside module declarations:
+        // https://github.com/facebook/flow/issues/7609
+        if (isInsideDeclareModule) {
           return;
         }
 

--- a/tests/rules/assertions/typeImportStyle.js
+++ b/tests/rules/assertions/typeImportStyle.js
@@ -51,6 +51,10 @@ export default {
     {
       code: 'import type A from \'a\';',
       options: ['identifier', {ignoreTypeDefault: true}]
+    },
+    {
+      code: 'declare module "m" { import type A from \'a\'; }',
+      options: ['identifier']
     }
   ]
 };


### PR DESCRIPTION
Putting a type specifier in a `declare module` is a syntax error in both Flow and Babel.
See https://github.com/facebook/flow/issues/7609