### PR TITLE
Fix return type rule for plain object properties

### DIFF
--- a/src/rules/requireReturnType.js
+++ b/src/rules/requireReturnType.js
@@ -72,7 +72,8 @@ const create = (context) => {
   const shouldFilterNode = (functionNode) => {
     const isArrow = functionNode.type === 'ArrowFunctionExpression';
     const isMethod = functionNode.parent && functionNode.parent.type === 'MethodDefinition';
-    const isProperty = functionNode.parent && functionNode.parent.type === 'ClassProperty';
+    const propertyNodes = ['Property', 'ClassProperty'];
+    const isProperty = functionNode.parent && propertyNodes.includes(functionNode.parent.type);
     let selector;
 
     if (isMethod || isProperty) {

--- a/tests/rules/assertions/requireReturnType.js
+++ b/tests/rules/assertions/requireReturnType.js
@@ -926,7 +926,7 @@ export default {
     },
 
     {
-      code: 'const foo = { bar(): number { return 42; } }',
+      code: 'const foo = { baz() { return 42; } }',
       options: [
         'always',
         {
@@ -938,11 +938,6 @@ export default {
     },
     {
       code: 'const foo = { bar() { return 42; } }',
-      errors: [
-        {
-          message: 'Missing return type annotation.'
-        }
-      ],
       options: [
         'always',
         {

--- a/tests/rules/assertions/requireReturnType.js
+++ b/tests/rules/assertions/requireReturnType.js
@@ -363,6 +363,41 @@ export default {
       ]
     },
     {
+      code: 'const foo = { bar() { return 42; }, foobar: function() { return 42; } }',
+      errors: [
+        {
+          message: 'Missing return type annotation.'
+        },
+        {
+          message: 'Missing return type annotation.'
+        }
+      ],
+      options: [
+        'always',
+        {
+          includeOnlyMatching: [
+            'bar'
+          ]
+        }
+      ]
+    },
+    {
+      code: 'const foo = { bar() { return 42; }, baz() { return 42; } }',
+      errors: [
+        {
+          message: 'Missing return type annotation.'
+        }
+      ],
+      options: [
+        'always',
+        {
+          excludeMatching: [
+            'bar'
+          ]
+        }
+      ]
+    },
+    {
       code: 'function * foo() { yield 2; }',
       errors: [
         {
@@ -885,6 +920,34 @@ export default {
         {
           includeOnlyMatching: [
             '^f.*'
+          ]
+        }
+      ]
+    },
+
+    {
+      code: 'const foo = { bar(): number { return 42; } }',
+      options: [
+        'always',
+        {
+          includeOnlyMatching: [
+            'bar'
+          ]
+        }
+      ]
+    },
+    {
+      code: 'const foo = { bar() { return 42; } }',
+      errors: [
+        {
+          message: 'Missing return type annotation.'
+        }
+      ],
+      options: [
+        'always',
+        {
+          excludeMatching: [
+            'bar'
           ]
         }
       ]


### PR DESCRIPTION
Fix #395 by reading the correct property path (parent id name) for "Property" nodes. Fixes the use of include and exclude rules on object properties:

```js
const foo = {
  // Without this PR the name of this node is "undefined" for include/exclude matching
  bar() {
    return 42;
  },

  // Same here
  baz: function() {
    return 42;
  }
}
```