### PR TITLE
Don't crash when encountering unparameterized Arrays

### DIFF
--- a/src/rules/arrayStyle/index.js
+++ b/src/rules/arrayStyle/index.js
@@ -47,7 +47,9 @@ export default (defaultConfig, simpleType) => {
       // verbose
       GenericTypeAnnotation (node) {
         if (node.id.name === 'Array') {
-          if (node.typeParameters.params.length === 1) {
+          // Don't report on un-parameterized Array annotations. There are valid cases for this,
+          // but regardless, we should not crash when encountering them.
+          if (node.typeParameters && node.typeParameters.params.length === 1) {
             const elementTypeNode = node.typeParameters.params[0];
             const rawElementType = context.getSourceCode().getText(elementTypeNode);
             const inlinedType = inlineType(rawElementType);

--- a/tests/rules/assertions/arrayStyleSimpleType.js
+++ b/tests/rules/assertions/arrayStyleSimpleType.js
@@ -128,6 +128,16 @@ export default {
           onlyFilesWithFlowAnnotation: true
         }
       }
+    },
+
+    // While this isn't valid flow, we shouldn't disallow it.
+    {
+      code: 'type X = Array'
+    },
+
+    // Valid flow.
+    {
+      code: 'type X = typeof Array'
     }
   ]
 };


### PR DESCRIPTION
While these are disallowed in Flow, `typeof Array` is a valid type,
which could trigger this.

Rather than try to enumerate other possible cases, I simply check to
make sure we don't crash when we hit them.