### PR TITLE
 fix: array-simple-type should fail gracefully when Array is missing a type parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,6 +380,8 @@ The following patterns are not considered problems:
 ```js
 type X = Array<string>
 
+type X = Array
+
 // Options: ["verbose"]
 type X = Array<string>
 

--- a/src/rules/arrayStyle/index.js
+++ b/src/rules/arrayStyle/index.js
@@ -47,7 +47,7 @@ export default (defaultConfig, simpleType) => {
       // verbose
       GenericTypeAnnotation (node) {
         if (node.id.name === 'Array') {
-          if (node.typeParameters.params.length === 1) {
+          if (node.typeParameters && node.typeParameters.params.length === 1) {
             const elementTypeNode = node.typeParameters.params[0];
             const rawElementType = context.getSourceCode().getText(elementTypeNode);
             const inlinedType = inlineType(rawElementType);

--- a/tests/rules/assertions/arrayStyleSimpleType.js
+++ b/tests/rules/assertions/arrayStyleSimpleType.js
@@ -106,6 +106,9 @@ export default {
       code: 'type X = Array<string>'
     },
     {
+      code: 'type X = Array'
+    },
+    {
       code: 'type X = Array<string>',
       options: ['verbose']
     },


### PR DESCRIPTION
This was causing my linter to crash.