### PR TITLE
Parse docblock more robustly for onlyFilesWithFlowAnnotation usage

### DIFF
--- a/src/utilities/isFlowFile.js
+++ b/src/utilities/isFlowFile.js
@@ -15,9 +15,6 @@ export default (context, strict = true) => {
   }
 
   return comments.some((comment) => {
-    return (
-      isFlowFileAnnotation(comment.value) &&
-      !(strict && /no/.test(comment.value))
-    );
+    return isFlowFileAnnotation(comment.value, strict);
   });
 };

--- a/src/utilities/isFlowFileAnnotation.js
+++ b/src/utilities/isFlowFileAnnotation.js
@@ -2,12 +2,18 @@ import _ from 'lodash';
 
 const FLOW_MATCHER = /^@(?:no)?flow$/;
 
-export default (comment) => {
+export default (comment, strict) => {
   // eslint-disable-next-line flowtype/require-valid-file-annotation
   // The flow parser splits comments with the following regex to look for the @flow flag.
   // See https://github.com/facebook/flow/blob/a96249b93541f2f7bfebd8d62085bf7a75de02f2/src/parsing/docblock.ml#L39
   return _.some(comment.split(/[ \t\r\n\\*/]+/), (commentPart) => {
-    return FLOW_MATCHER.test(commentPart);
+    const match = commentPart.match(FLOW_MATCHER);
+
+    if (match === null) {
+      return false;
+    }
+
+    return !strict || match[0] === '@flow';
   });
 };
 

--- a/tests/rules/assertions/defineFlowType.js
+++ b/tests/rules/assertions/defineFlowType.js
@@ -127,6 +127,25 @@ const VALID_WITH_DEFINE_FLOW_TYPE = [
       '\'AType\' is not defined.',
       '\'BType\' is not defined.'
     ]
+  },
+
+  // This tests to ensure we have a robust handling of @flow comments
+  {
+    // eslint-disable-next-line no-restricted-syntax
+    code: `
+/**
+* Copyright 2019 no corp
+* @flow
+*/
+type Foo = $ReadOnly<{}>`,
+    errors: [
+      '\'$ReadOnly\' is not defined.'
+    ],
+    settings: {
+      flowtype: {
+        onlyFilesWithFlowAnnotation: true
+      }
+    }
   }
 ];
 
@@ -211,7 +230,8 @@ export default {
         code: subject.code,
         rules: {
           'no-undef': 2
-        }
+        },
+        settings: subject.settings
       };
     }),
     ...VALID_WITH_DEFINE_FLOW_TYPE.map((subject) => {
@@ -223,7 +243,8 @@ export default {
             2,
             'nofunc'
           ]
-        }
+        },
+        settings: subject.settings
       };
     })
   ]


### PR DESCRIPTION
Instead of looking for a very specfic string in a part of the docblock,
and then checking the entire docblock for "no" (which can show up in
copyrights, or just general comments that may be documenting a file),
actually see if there's a @noflow comment.