### PR TITLE
feat: add require-inexact-type rule

### DIFF
--- a/.README/README.md
+++ b/.README/README.md
@@ -173,7 +173,9 @@ When `true`, only checks files with a [`@flow` annotation](http://flowtype.org/d
 {"gitdown": "include", "file": "./rules/object-type-delimiter.md"}
 {"gitdown": "include", "file": "./rules/require-compound-type-alias.md"}
 {"gitdown": "include", "file": "./rules/require-exact-type.md"}
+{"gitdown": "include", "file": "./rules/require-inexact-type.md"}
 {"gitdown": "include", "file": "./rules/require-parameter-type.md"}
+{"gitdown": "include", "file": "./rules/require-readonly-react-props.md"}
 {"gitdown": "include", "file": "./rules/require-return-type.md"}
 {"gitdown": "include", "file": "./rules/require-types-at-top.md"}
 {"gitdown": "include", "file": "./rules/require-valid-file-annotation.md"}

--- a/.README/rules/require-inexact-type.md
+++ b/.README/rules/require-inexact-type.md
@@ -1,0 +1,32 @@
+### `require-inexact-type`
+
+This rule enforces explicit inexact object types.
+
+#### Options
+
+The rule has one string option:
+
+- `"always"` (default): Report all object type definitions that aren't explicit inexact, but ignore exact objects.
+- `"never"`: Report all object type definitions that are explicit inexact.
+
+```js
+{
+  "rules": {
+    "flowtype/require-inexact-type": [
+      2,
+      "always"
+    ]
+  }
+}
+
+{
+  "rules": {
+    "flowtype/require-inexact-type": [
+      2,
+      "never"
+    ]
+  }
+}
+```
+
+<!-- assertions requireInexactType -->

--- a/.README/rules/require-readonly-react-props.md
+++ b/.README/rules/require-readonly-react-props.md
@@ -2,7 +2,7 @@
 
 This rule validates that React props are marked as $ReadOnly. React props are immutable and modifying them could lead to unexpected results. Marking prop shapes as $ReadOnly avoids these issues.
 
-The rule tries its best to work with both class and functional components. For class components, it does a fuzzy check for one of "Component", "PureComponent", "React.Component" and "React.PureComponent". It doesn't actually infer that those identifiers resolve to a proper `React.Component` object. 
+The rule tries its best to work with both class and functional components. For class components, it does a fuzzy check for one of "Component", "PureComponent", "React.Component" and "React.PureComponent". It doesn't actually infer that those identifiers resolve to a proper `React.Component` object.
 
 For example, this will NOT be checked:
 
@@ -79,4 +79,4 @@ class Bar extends React.Component<Props> { }
 ```
 
 
-<!-- assertions requireReadOnlyReactProps -->
+<!-- assertions requireReadonlyReactProps -->

--- a/src/index.js
+++ b/src/index.js
@@ -18,6 +18,7 @@ import noWeakTypes from './rules/noWeakTypes';
 import noMixed from './rules/noMixed';
 import objectTypeDelimiter from './rules/objectTypeDelimiter';
 import requireCompoundTypeAlias from './rules/requireCompoundTypeAlias';
+import requireInexactType from './rules/requireInexactType';
 import requireExactType from './rules/requireExactType';
 import requireParameterType from './rules/requireParameterType';
 import requireReadonlyReactProps from './rules/requireReadonlyReactProps';
@@ -58,6 +59,7 @@ const rules = {
   'object-type-delimiter': objectTypeDelimiter,
   'require-compound-type-alias': requireCompoundTypeAlias,
   'require-exact-type': requireExactType,
+  'require-inexact-type': requireInexactType,
   'require-parameter-type': requireParameterType,
   'require-readonly-react-props': requireReadonlyReactProps,
   'require-return-type': requireReturnType,

--- a/src/rules/requireInexactType.js
+++ b/src/rules/requireInexactType.js
@@ -1,0 +1,35 @@
+const schema = [
+  {
+    enum: ['always', 'never'],
+    type: 'string'
+  }
+];
+
+const create = (context) => {
+  const always = (context.options[0] || 'always') === 'always';
+
+  return {
+    ObjectTypeAnnotation (node) {
+      const {inexact, exact} = node;
+
+      if (always && !inexact && !exact) {
+        context.report({
+          message: 'Type must be explicit inexact.',
+          node
+        });
+      }
+
+      if (!always && inexact) {
+        context.report({
+          message: 'Type must not be explicit inexact.',
+          node
+        });
+      }
+    }
+  };
+};
+
+export default {
+  create,
+  schema
+};

--- a/tests/rules/assertions/requireInexactType.js
+++ b/tests/rules/assertions/requireInexactType.js
@@ -1,0 +1,124 @@
+export default {
+  invalid: [
+    // Always
+
+    {
+      code: 'type foo = {};',
+      errors: [
+        {
+          message: 'Type must be explicit inexact.'
+        }
+      ]
+    },
+    {
+      code: 'type foo = { bar: string };',
+      errors: [
+        {
+          message: 'Type must be explicit inexact.'
+        }
+      ]
+    },
+    {
+      code: 'type foo = {};',
+      errors: [
+        {
+          message: 'Type must be explicit inexact.'
+        }
+      ],
+      options: ['always']
+    },
+    {
+      code: 'type foo = { bar: string };',
+      errors: [
+        {
+          message: 'Type must be explicit inexact.'
+        }
+      ],
+      options: ['always']
+    },
+
+    // Never
+
+    {
+      code: 'type foo = {...};',
+      errors: [
+        {
+          message: 'Type must not be explicit inexact.'
+        }
+      ],
+      options: ['never']
+    },
+    {
+      code: 'type foo = { bar: string, ... };',
+      errors: [
+        {
+          message: 'Type must not be explicit inexact.'
+        }
+      ],
+      options: ['never']
+    }
+  ],
+  valid: [
+
+    // Always
+
+    {
+      code: 'type foo = { foo: string, ... };'
+    },
+    {
+      code: 'type foo = {| |};'
+    },
+    {
+      code: 'type foo = {| bar: string |};'
+    },
+    {
+      code: 'type foo = { [key: string]: string, ... };'
+    },
+    {
+      code: 'type foo = number;'
+    },
+    {
+      code: 'type foo = {| |};',
+      options: ['always']
+    },
+    {
+      code: 'type foo = {...};',
+      options: ['always']
+    },
+    {
+      code: 'type foo = { bar: string, ... };',
+      options: ['always']
+    },
+    {
+      code: 'type foo = {| bar: string |};',
+      options: ['always']
+    },
+    {
+      code: 'type foo = number;',
+      options: ['always']
+    },
+
+    // Never
+
+    {
+      code: 'type foo = { };',
+      options: ['never']
+    },
+    {
+      code: 'type foo = {| |};',
+      options: ['never']
+    },
+    {
+      code: 'type foo = { bar: string };',
+      options: ['never']
+    },
+    {
+      code: 'type foo = {| bar: string |};',
+      options: ['never']
+    },
+    {
+      code: 'type foo = number;',
+      options: ['never']
+    }
+  ]
+};

--- a/tests/rules/index.js
+++ b/tests/rules/index.js
@@ -29,6 +29,7 @@ const reportingRules = [
   'no-mixed',
   'object-type-delimiter',
   'require-compound-type-alias',
+  'require-inexact-type',
   'require-exact-type',
   'require-parameter-type',
   'require-readonly-react-props',


### PR DESCRIPTION
Duplicate of same lint in new Flow version
This syntax exists from Flow v0.84