### PR TITLE
fix(noDupeKeys): fix throw error

### DIFF
--- a/src/rules/noDupeKeys.js
+++ b/src/rules/noDupeKeys.js
@@ -49,7 +49,11 @@ const create = (context) => {
 
   const builObjectStructure = (properties) => {
     return _.map(properties, (property) => {
-      const element = analizeElement(property.value);
+      const element = analizeElement(
+        property.type === 'ObjectTypeSpreadProperty' ?
+          property.argument :
+          property.value
+      );
 
       return {
         ...element,

--- a/tests/rules/assertions/noDupeKeys.js
+++ b/tests/rules/assertions/noDupeKeys.js
@@ -107,6 +107,9 @@ export default {
     },
     {
       code: 'var a = 1; var b = 1; type f = { get(key: a): string, get(key: b): string }'
+    },
+    {
+      code: 'type a = { b: <C>(config: { ...C, key: string}) => C }'
     }
   ]
 };


### PR DESCRIPTION
Example code:

```js
type a = { b: <C>(config: { ...C, key: string}) => C };
```

Error:

```sh
TypeError: Cannot read property 'type' of undefined
Occurred while linting /Users/hsuting/Desktop/work/core/packages/configs/src/types.js:3
    at analizeElement (/Users/hsuting/Desktop/work/core/node_modules/eslint-plugin-flowtype/dist/rules/noDupeKeys.js:29:24)
    at /Users/hsuting/Desktop/work/core/node_modules/eslint-plugin-flowtype/dist/rules/noDupeKeys.js:64:21
    at arrayMap (/Users/hsuting/Desktop/work/core/node_modules/lodash/lodash.js:639:23)
    at Function.map (/Users/hsuting/Desktop/work/core/node_modules/lodash/lodash.js:9556:14)
    at builObjectStructure (/Users/hsuting/Desktop/work/core/node_modules/eslint-plugin-flowtype/dist/rules/noDupeKeys.js:63:29)
    at analizeElement (/Users/hsuting/Desktop/work/core/node_modules/eslint-plugin-flowtype/dist/rules/noDupeKeys.js:39:17)
    at /Users/hsuting/Desktop/work/core/node_modules/eslint-plugin-flowtype/dist/rules/noDupeKeys.js:83:18
    at arrayMap (/Users/hsuting/Desktop/work/core/node_modules/lodash/lodash.js:639:23)
    at Function.map (/Users/hsuting/Desktop/work/core/node_modules/lodash/lodash.js:9556:14)
    at /Users/hsuting/Desktop/work/core/node_modules/eslint-plugin-flowtype/dist/rules/noDupeKeys.js:82:40
```