### PR TITLE
Valid flow strict annotation

### DIFF
--- a/.README/rules/require-valid-file-annotation.md
+++ b/.README/rules/require-valid-file-annotation.md
@@ -18,6 +18,10 @@ This rule has an object option:
     * `"line"`: Require single line annotations (i.e. `// @flow`).
     * `"block"`: Require block annotations (i.e. `/* @flow */`).
 
+* `"strict"` - Enforce a strict flow file annotation.
+    * `false` (default): strict flow annotation is not required.
+    * `true`: Require strict flow annotation (i.e. `// @flow strict`).
+
 ```js
 {
   "rules": {
@@ -34,6 +38,7 @@ This rule has an object option:
       2,
       "always", {
         "annotationStyle": "block"
+        "strict": true,
       }
     ]
   }

--- a/README.md
+++ b/README.md
@@ -3028,6 +3028,10 @@ This rule has an object option:
     * `"line"`: Require single line annotations (i.e. `// @flow`).
     * `"block"`: Require block annotations (i.e. `/* @flow */`).
 
+* `"strict"` - Enforce a strict flow file annotation.
+    * `false` (default): strict flow annotations are not required.
+    * `true`: Require strict flow annotations (i.e. `// @flow strict`).
+
 ```js
 {
   "rules": {
@@ -3043,7 +3047,8 @@ This rule has an object option:
     "flowtype/require-valid-file-annotation": [
       2,
       "always", {
-        "annotationStyle": "block"
+        "annotationStyle": "block",
+        "strict": true
       }
     ]
   }

--- a/README.md
+++ b/README.md
@@ -3087,6 +3087,14 @@ a;
 // @flow
 // Message: Flow file annotation style must be `/* @flow */`
 
+// Options: ["always",{"annotationStyle":"block"}]
+// @flow
+// Message: Flow file annotation style must be `/* @flow */`
+
+// Options: ["always",{"annotationStyle":"line","strict":true}]
+// @flow
+// Message: Strict Flow file annotation is required, should be `// @flow strict`
+
 // Options: ["always",{"annotationStyle":"line"}]
 /* @noflow */
 // Message: Flow file annotation style must be `// @noflow`
@@ -3102,6 +3110,16 @@ a;
 // Options: ["always",{"annotationStyle":"block"}]
 a;
 // Message: Flow file annotation is missing.
+
+// Options: ["always",{"annotationStyle":"line","strict":true}]
+a;
+// Message: Flow file annotation is missing.
+
+// Options: ["always",{"annotationStyle":"line","strict":true}]
+// @flow
+a;
+b;
+// Message: Strict Flow file annotation is required, should be `// @flow strict`
 ```
 
 The following patterns are not considered problems:
@@ -3138,6 +3156,9 @@ a;
 
 // Options: ["always",{"annotationStyle":"line"}]
 // @flow
+
+// Options: ["always",{"annotationStyle":"line","strict":true}]
+// @flow strict
 
 // Options: ["never",{"annotationStyle":"none"}]
 // @function

--- a/README.md
+++ b/README.md
@@ -3028,6 +3028,10 @@ This rule has an object option:
     * `"line"`: Require single line annotations (i.e. `// @flow`).
     * `"block"`: Require block annotations (i.e. `/* @flow */`).
 
+* `"strict"` - Enforce a strict flow file annotation.
+    * `false` (default): strict flow annotation is not required.
+    * `true`: Require strict flow annotation (i.e. `// @flow strict`).
+
 ```js
 {
   "rules": {
@@ -3044,6 +3048,7 @@ This rule has an object option:
       2,
       "always", {
         "annotationStyle": "block"
+        "strict": true,
       }
     ]
   }

--- a/README.md
+++ b/README.md
@@ -3028,10 +3028,6 @@ This rule has an object option:
     * `"line"`: Require single line annotations (i.e. `// @flow`).
     * `"block"`: Require block annotations (i.e. `/* @flow */`).
 
-* `"strict"` - Enforce a strict flow file annotation.
-    * `false` (default): strict flow annotations are not required.
-    * `true`: Require strict flow annotations (i.e. `// @flow strict`).
-
 ```js
 {
   "rules": {
@@ -3047,8 +3043,7 @@ This rule has an object option:
     "flowtype/require-valid-file-annotation": [
       2,
       "always", {
-        "annotationStyle": "block",
-        "strict": true
+        "annotationStyle": "block"
       }
     ]
   }

--- a/src/rules/requireValidFileAnnotation.js
+++ b/src/rules/requireValidFileAnnotation.js
@@ -75,7 +75,7 @@ const create = (context) => {
         return (fixer) => {
           const annotation = ['line', 'none'].includes(style) ? '// @flow strict\n' : '/* @flow strict */\n';
 
-          return fixer.replaceTextRange(node.range, annotation);
+          return fixer.replaceTextRange([node.start, node.range[0]], annotation);
         };
       };
 

--- a/src/rules/requireValidFileAnnotation.js
+++ b/src/rules/requireValidFileAnnotation.js
@@ -5,7 +5,8 @@ import {
 } from '../utilities';
 
 const defaults = {
-  annotationStyle: 'none'
+  annotationStyle: 'none',
+  strict: false
 };
 
 const looksLikeFlowFileAnnotation = (comment) => {
@@ -24,6 +25,10 @@ const checkAnnotationSpelling = (comment) => {
   return /@[a-z]+\b/.test(comment) && fuzzyStringMatch(comment.replace(/no/i, ''), '@flow', 0.2);
 };
 
+const isFlowStrict = (comment) => {
+  return /@flow\sstrict\b/.test(comment);
+};
+
 const schema = [
   {
     enum: ['always', 'never'],
@@ -35,6 +40,10 @@ const schema = [
       annotationStyle: {
         enum: ['none', 'line', 'block'],
         type: 'string'
+      },
+      strict: {
+        enum: [true, false],
+        type: 'boolean'
       }
     },
     type: 'object'
@@ -44,16 +53,29 @@ const schema = [
 const create = (context) => {
   const always = context.options[0] === 'always';
   const style = _.get(context, 'options[1].annotationStyle', defaults.annotationStyle);
+  const flowStrict = _.get(context, 'options[1].strict', defaults.strict);
 
   return {
     Program (node) {
       const firstToken = node.tokens[0];
-
       const addAnnotation = () => {
         return (fixer) => {
-          const annotation = ['line', 'none'].includes(style) ? '// @flow\n' : '/* @flow */\n';
+          let annotation;
+          if (flowStrict) {
+            annotation = ['line', 'none'].includes(style) ? '// @flow strict\n' : '/* @flow strict */\n';
+          } else {
+            annotation = ['line', 'none'].includes(style) ? '// @flow\n' : '/* @flow */\n';
+          }
 
           return fixer.replaceTextRange([node.start, node.start], annotation);
+        };
+      };
+
+      const addStrictAnnotation = () => {
+        return (fixer) => {
+          const annotation = ['line', 'none'].includes(style) ? '// @flow strict\n' : '/* @flow strict */\n';
+
+          return fixer.replaceTextRange(node.range, annotation);
         };
       };
 
@@ -71,6 +93,16 @@ const create = (context) => {
             const str = style === 'line' ? '`// ' + potentialFlowFileAnnotation.value.trim() + '`' : '`/* ' + potentialFlowFileAnnotation.value.trim() + ' */`';
 
             context.report(potentialFlowFileAnnotation, 'Flow file annotation style must be ' + str);
+          }
+          if (flowStrict) {
+            if (!isFlowStrict(potentialFlowFileAnnotation.value.trim())) {
+              const str = style === 'line' ? '`// @flow strict`' : '`/* @flow strict */`';
+              context.report({
+                fix: addStrictAnnotation(),
+                message: 'Strict Flow file annotation is required, should be ' + str,
+                node
+              });
+            }
           }
         } else if (checkAnnotationSpelling(potentialFlowFileAnnotation.value.trim())) {
           context.report(potentialFlowFileAnnotation, 'Misspelled or malformed Flow file annotation.');

--- a/tests/rules/assertions/requireValidFileAnnotation.js
+++ b/tests/rules/assertions/requireValidFileAnnotation.js
@@ -96,6 +96,35 @@ export default {
       ]
     },
     {
+      code: '// @flow',
+      errors: [
+        {
+          message: 'Flow file annotation style must be `/* @flow */`'
+        }
+      ],
+      options: [
+        'always',
+        {
+          annotationStyle: 'block'
+        }
+      ]
+    },
+    {
+      code: '// @flow',
+      errors: [
+        {
+          message: 'Strict Flow file annotation is required, should be `// @flow strict`'
+        }
+      ],
+      options: [
+        'always',
+        {
+          annotationStyle: 'line',
+          strict: true
+        }
+      ]
+    },
+    {
       code: '/* @noflow */',
       errors: [
         {
@@ -149,6 +178,38 @@ export default {
         }
       ],
       output: '/* @flow */\na;'
+    },
+    {
+      code: 'a;',
+      errors: [
+        {
+          message: 'Flow file annotation is missing.'
+        }
+      ],
+      options: [
+        'always',
+        {
+          annotationStyle: 'line',
+          strict: true
+        }
+      ],
+      output: '// @flow strict\na;'
+    },
+    {
+      code: '// @flow',
+      errors: [
+        {
+          message: 'Strict Flow file annotation is required, should be `// @flow strict`'
+        }
+      ],
+      options: [
+        'always',
+        {
+          annotationStyle: 'line',
+          strict: true
+        }
+      ],
+      output: '// @flow strict\n'
     }
   ],
   misconfigured: [
@@ -254,6 +315,16 @@ export default {
         'always',
         {
           annotationStyle: 'line'
+        }
+      ]
+    },
+    {
+      code: '// @flow strict',
+      options: [
+        'always',
+        {
+          annotationStyle: 'line',
+          strict: true
         }
       ]
     },

--- a/tests/rules/assertions/requireValidFileAnnotation.js
+++ b/tests/rules/assertions/requireValidFileAnnotation.js
@@ -196,7 +196,7 @@ export default {
       output: '// @flow strict\na;'
     },
     {
-      code: '// @flow',
+      code: '// @flow\na;\nb;',
       errors: [
         {
           message: 'Strict Flow file annotation is required, should be `// @flow strict`'
@@ -209,7 +209,7 @@ export default {
           strict: true
         }
       ],
-      output: '// @flow strict\n'
+      output: '// @flow strict\na;\nb;'
     }
   ],
   misconfigured: [


### PR DESCRIPTION
## Support flow strict annotation

- Added eslint rule for `@flow strict` and its fixer
- Ref, https://github.com/gajus/eslint-plugin-flowtype/issues/364

### Examples
```js

// Options: ["always",{"annotationStyle":"line","strict":true}]
// @flow
// Message: Strict Flow file annotation is required, should be `// @flow strict`

```