### PR TITLE
Implement arrow-parens to support type parameters

### DIFF
--- a/.README/README.md
+++ b/.README/README.md
@@ -156,6 +156,7 @@ When `true`, only checks files with a [`@flow` annotation](http://flowtype.org/d
 
 {"gitdown": "include", "file": "./rules/array-style-complex-type.md"}
 {"gitdown": "include", "file": "./rules/array-style-simple-type.md"}
+{"gitdown": "include", "file": "./rules/arrow-parens.md"}
 {"gitdown": "include", "file": "./rules/boolean-style.md"}
 {"gitdown": "include", "file": "./rules/define-flow-type.md"}
 {"gitdown": "include", "file": "./rules/delimiter-dangle.md"}

--- a/.README/rules/arrow-parens.md
+++ b/.README/rules/arrow-parens.md
@@ -1,0 +1,18 @@
+### `arrow-parens`
+
+_The `--fix` option on the command line automatically fixes problems reported by this rule._
+
+Enforces the consistent use of parentheses in arrow functions.
+
+This rule has a string option and an object one.
+
+String options are:
+
+- `"always"` (default) requires parens around arguments in all cases.
+- `"as-needed"` enforces no braces where they can be omitted.
+
+Object properties for variants of the `"as-needed"` option:
+
+- `"requireForBlockBody": true` modifies the as-needed rule in order to require parens if the function body is in an instructions block (surrounded by braces).
+
+<!-- assertions arrowParens -->

--- a/src/configs/recommended.json
+++ b/src/configs/recommended.json
@@ -18,9 +18,9 @@
     "flowtype/no-types-missing-file-annotation": 2,
     "flowtype/no-weak-types": 0,
     "flowtype/require-parameter-type": 0,
+    "flowtype/require-readonly-react-props": 0,
     "flowtype/require-return-type": 0,
     "flowtype/require-valid-file-annotation": 0,
-    "flowtype/require-readonly-react-props": 0,
     "flowtype/semi": 0,
     "flowtype/space-after-type-colon": [
       2,

--- a/src/index.js
+++ b/src/index.js
@@ -37,11 +37,13 @@ import unionIntersectionSpacing from './rules/unionIntersectionSpacing';
 import useFlowType from './rules/useFlowType';
 import validSyntax from './rules/validSyntax';
 import spreadExactType from './rules/spreadExactType';
+import arrowParens from './rules/arrowParens';
 import {checkFlowFileAnnotation} from './utilities';
 
 const rules = {
   'array-style-complex-type': arrayStyleComplexType,
   'array-style-simple-type': arrayStyleSimpleType,
+  'arrow-parens': arrowParens,
   'boolean-style': booleanStyle,
   'define-flow-type': defineFlowType,
   'delimiter-dangle': delimiterDangle,

--- a/src/rules/arrowParens.js
+++ b/src/rules/arrowParens.js
@@ -1,0 +1,169 @@
+const getLocation = (node) => {
+  return {
+    end: node.params[node.params.length - 1].loc.end,
+    start: node.params[0].loc.start
+  };
+};
+
+const isOpeningParenToken = (token) => {
+  return token.value === '(' && token.type === 'Punctuator';
+};
+
+const isClosingParenToken = (token) => {
+  return token.value === ')' && token.type === 'Punctuator';
+};
+
+export default {
+  create (context) {
+    const asNeeded = context.options[0] === 'as-needed';
+    const requireForBlockBody = asNeeded && context.options[1] && context.options[1].requireForBlockBody === true;
+
+    const sourceCode = context.getSourceCode();
+
+    // Determines whether a arrow function argument end with `)`
+    // eslint-disable-next-line complexity
+    const parens = (node) => {
+      const isAsync = node.async;
+      const firstTokenOfParam = sourceCode.getFirstToken(node, isAsync ? 1 : 0);
+
+      // Remove the parenthesis around a parameter
+      const fixParamsWithParenthesis = (fixer) => {
+        const paramToken = sourceCode.getTokenAfter(firstTokenOfParam);
+
+        /*
+         * ES8 allows Trailing commas in function parameter lists and calls
+         * https://github.com/eslint/eslint/issues/8834
+         */
+        const closingParenToken = sourceCode.getTokenAfter(paramToken, isClosingParenToken);
+        const asyncToken = isAsync ? sourceCode.getTokenBefore(firstTokenOfParam) : null;
+        const shouldAddSpaceForAsync = asyncToken && asyncToken.range[1] === firstTokenOfParam.range[0];
+
+        return fixer.replaceTextRange([
+          firstTokenOfParam.range[0],
+          closingParenToken.range[1]
+        ], `${shouldAddSpaceForAsync ? ' ' : ''}${paramToken.value}`);
+      };
+
+      // Type parameters without an opening paren is always a parse error, and
+      // can therefore be safely ignored.
+      if (node.typeParameters) {
+        return;
+      }
+
+      // "as-needed", { "requireForBlockBody": true }: x => x
+      if (
+        requireForBlockBody &&
+                node.params.length === 1 &&
+                node.params[0].type === 'Identifier' &&
+                !node.params[0].typeAnnotation &&
+                node.body.type !== 'BlockStatement' &&
+                !node.returnType
+      ) {
+        if (isOpeningParenToken(firstTokenOfParam)) {
+          context.report({
+            fix: fixParamsWithParenthesis,
+            loc: getLocation(node),
+            messageId: 'unexpectedParensInline',
+            node
+          });
+        }
+
+        return;
+      }
+
+      if (
+        requireForBlockBody &&
+                node.body.type === 'BlockStatement'
+      ) {
+        if (!isOpeningParenToken(firstTokenOfParam)) {
+          context.report({
+            fix (fixer) {
+              return fixer.replaceText(firstTokenOfParam, `(${firstTokenOfParam.value})`);
+            },
+            loc: getLocation(node),
+            messageId: 'expectedParensBlock',
+            node
+          });
+        }
+
+        return;
+      }
+
+      // "as-needed": x => x
+      if (asNeeded &&
+                node.params.length === 1 &&
+                node.params[0].type === 'Identifier' &&
+                !node.params[0].typeAnnotation &&
+                !node.returnType
+      ) {
+        if (isOpeningParenToken(firstTokenOfParam)) {
+          context.report({
+            fix: fixParamsWithParenthesis,
+            loc: getLocation(node),
+            messageId: 'unexpectedParens',
+            node
+          });
+        }
+
+        return;
+      }
+
+      if (firstTokenOfParam.type === 'Identifier') {
+        const after = sourceCode.getTokenAfter(firstTokenOfParam);
+
+        // (x) => x
+        if (after.value !== ')') {
+          context.report({
+            fix (fixer) {
+              return fixer.replaceText(firstTokenOfParam, `(${firstTokenOfParam.value})`);
+            },
+            loc: getLocation(node),
+            messageId: 'expectedParens',
+            node
+          });
+        }
+      }
+    };
+
+    return {
+      ArrowFunctionExpression: parens
+    };
+  },
+
+  meta: {
+    docs: {
+      category: 'ECMAScript 6',
+      description: 'require parentheses around arrow function arguments',
+      recommended: false,
+      url: 'https://eslint.org/docs/rules/arrow-parens'
+    },
+
+    fixable: 'code',
+
+    messages: {
+      expectedParens: 'Expected parentheses around arrow function argument.',
+      expectedParensBlock: 'Expected parentheses around arrow function argument having a body with curly braces.',
+
+      unexpectedParens: 'Unexpected parentheses around single function argument.',
+      unexpectedParensInline: 'Unexpected parentheses around single function argument having a body with no curly braces.'
+    },
+
+    type: 'layout'
+  },
+
+  schema: [
+    {
+      enum: ['always', 'as-needed']
+    },
+    {
+      additionalProperties: false,
+      properties: {
+        requireForBlockBody: {
+          default: false,
+          type: 'boolean'
+        }
+      },
+      type: 'object'
+    }
+  ]
+};

--- a/src/utilities/isFlowFile.js
+++ b/src/utilities/isFlowFile.js
@@ -2,6 +2,7 @@ import isFlowFileAnnotation from './isFlowFileAnnotation';
 /* eslint-disable flowtype/require-valid-file-annotation */
 /**
  * Checks whether a file has an @flow or @noflow annotation.
+ *
  * @param context
  * @param [strict] - By default, the function returns true if the file starts with @flow but not if it
  * starts by @noflow. When the strict flag is set to false, the function returns true if the flag has @noflow also.

--- a/tests/rules/assertions/arrowParens.js
+++ b/tests/rules/assertions/arrowParens.js
@@ -1,0 +1,337 @@
+/* eslint-disable sort-keys */
+const type = 'ArrowFunctionExpression';
+
+export default {
+  invalid: [
+
+    // "always" (by default)
+    {
+      code: 'a => {}',
+      output: '(a) => {}',
+      errors: [{
+        line: 1,
+        column: 1,
+        endColumn: 2,
+        messageId: 'expectedParens',
+        type
+      }]
+    },
+    {
+      code: 'a => a',
+      output: '(a) => a',
+      errors: [{
+        line: 1,
+        column: 1,
+        endColumn: 2,
+        messageId: 'expectedParens',
+        type
+      }]
+    },
+    {
+      code: 'a => {\n}',
+      output: '(a) => {\n}',
+      errors: [{
+        line: 1,
+        column: 1,
+        endColumn: 2,
+        messageId: 'expectedParens',
+        type
+      }]
+    },
+    {
+      code: 'a.then(foo => {});',
+      output: 'a.then((foo) => {});',
+      errors: [{
+        line: 1,
+        column: 8,
+        endColumn: 11,
+        messageId: 'expectedParens',
+        type
+      }]
+    },
+    {
+      code: 'a.then(foo => a);',
+      output: 'a.then((foo) => a);',
+      errors: [{
+        line: 1,
+        column: 8,
+        endColumn: 11,
+        messageId: 'expectedParens',
+        type
+      }]
+    },
+    {
+      code: 'a(foo => { if (true) {}; });',
+      output: 'a((foo) => { if (true) {}; });',
+      errors: [{
+        line: 1,
+        column: 3,
+        endColumn: 6,
+        messageId: 'expectedParens',
+        type
+      }]
+    },
+    {
+      code: 'a(async foo => { if (true) {}; });',
+      output: 'a(async (foo) => { if (true) {}; });',
+      parserOptions: {ecmaVersion: 8},
+      errors: [{
+        line: 1,
+        column: 9,
+        endColumn: 12,
+        messageId: 'expectedParens',
+        type
+      }]
+    },
+
+    // "as-needed"
+    {
+      code: '(a) => a',
+      output: 'a => a',
+      options: ['as-needed'],
+      errors: [{
+        line: 1,
+        column: 2,
+        endColumn: 3,
+        messageId: 'unexpectedParens',
+        type
+      }]
+    },
+    {
+      code: '(a,) => a',
+      output: 'a => a',
+      options: ['as-needed'],
+      parserOptions: {ecmaVersion: 8},
+      errors: [{
+        line: 1,
+        column: 2,
+        endColumn: 3,
+        messageId: 'unexpectedParens',
+        type
+      }]
+    },
+    {
+      code: 'async (a) => a',
+      output: 'async a => a',
+      options: ['as-needed'],
+      parserOptions: {ecmaVersion: 8},
+      errors: [{
+        line: 1,
+        column: 8,
+        endColumn: 9,
+        messageId: 'unexpectedParens',
+        type
+      }]
+    },
+    {
+      code: 'async(a) => a',
+      output: 'async a => a',
+      options: ['as-needed'],
+      parserOptions: {ecmaVersion: 8},
+      errors: [{
+        line: 1,
+        column: 7,
+        endColumn: 8,
+        messageId: 'unexpectedParens',
+        type
+      }]
+    },
+
+    // "as-needed", { "requireForBlockBody": true }
+    {
+      code: 'a => {}',
+      output: '(a) => {}',
+      options: ['as-needed', {requireForBlockBody: true}],
+      errors: [{
+        line: 1,
+        column: 1,
+        endColumn: 2,
+        messageId: 'expectedParensBlock',
+        type
+      }]
+    },
+    {
+      code: '(a) => a',
+      output: 'a => a',
+      options: ['as-needed', {requireForBlockBody: true}],
+      errors: [{
+        line: 1,
+        column: 2,
+        endColumn: 3,
+        messageId: 'unexpectedParensInline',
+        type
+      }]
+    },
+    {
+      code: 'async a => {}',
+      output: 'async (a) => {}',
+      options: ['as-needed', {requireForBlockBody: true}],
+      parserOptions: {ecmaVersion: 8},
+      errors: [{
+        line: 1,
+        column: 7,
+        endColumn: 8,
+        messageId: 'expectedParensBlock',
+        type
+      }]
+    },
+    {
+      code: 'async (a) => a',
+      output: 'async a => a',
+      options: ['as-needed', {requireForBlockBody: true}],
+      parserOptions: {ecmaVersion: 8},
+      errors: [{
+        line: 1,
+        column: 8,
+        endColumn: 9,
+        messageId: 'unexpectedParensInline',
+        type
+      }]
+    },
+    {
+      code: 'async(a) => a',
+      output: 'async a => a',
+      options: ['as-needed', {requireForBlockBody: true}],
+      parserOptions: {ecmaVersion: 8},
+      errors: [{
+        line: 1,
+        column: 7,
+        endColumn: 8,
+        messageId: 'unexpectedParensInline',
+        type
+      }]
+    }
+  ],
+
+  // can't figure out how to get this working
+  // misconfigured: [
+  //   {
+  //     errors: [
+  //       {
+  //         keyword: 'enum',
+  //         dataPath: '[0]',
+  //         schemaPath: '#/items/0/enum',
+  //         params: {
+  //           allowedValues: [
+  //             'always',
+  //             'as-needed'
+  //           ]
+  //         },
+  //         message: 'should be equal to one of the allowed values',
+  //         schema: [
+  //           'always',
+  //           'as-needed'
+  //         ],
+  //         parentSchema: {
+  //           enum: [
+  //             'always',
+  //             'as-needed'
+  //           ]
+  //         }
+  //       }
+  //     ],
+  //     options: ['temporarily']
+  //   }
+  // ],
+  valid: [
+    // "always" (by default)
+    {code: '() => {}'},
+    {code: '(a) => {}'},
+    {code: '(a) => a'},
+    {code: '(a) => {\n}'},
+    {code: 'a.then((foo) => {});'},
+    {code: 'a.then((foo) => { if (true) {}; });'},
+    {code: 'a.then(async (foo) => { if (true) {}; });',
+      parserOptions: {ecmaVersion: 8}},
+
+    // "always" (explicit)
+    {code: '() => {}',
+      options: ['always']},
+    {code: '(a) => {}',
+      options: ['always']},
+    {code: '(a) => a',
+      options: ['always']},
+    {code: '(a) => {\n}',
+      options: ['always']},
+    {code: 'a.then((foo) => {});',
+      options: ['always']},
+    {code: 'a.then((foo) => { if (true) {}; });',
+      options: ['always']},
+    {code: 'a.then(async (foo) => { if (true) {}; });',
+      options: ['always'],
+      parserOptions: {ecmaVersion: 8}},
+
+    // "as-needed"
+    {code: '() => {}',
+      options: ['as-needed']},
+    {code: 'a => {}',
+      options: ['as-needed']},
+    {code: 'a => a',
+      options: ['as-needed']},
+    {code: '([a, b]) => {}',
+      options: ['as-needed']},
+    {code: '({ a, b }) => {}',
+      options: ['as-needed']},
+    {code: '(a = 10) => {}',
+      options: ['as-needed']},
+    {code: '(...a) => a[0]',
+      options: ['as-needed']},
+    {code: '(a, b) => {}',
+      options: ['as-needed']},
+    {code: 'async ([a, b]) => {}',
+      options: ['as-needed'],
+      parserOptions: {ecmaVersion: 8}},
+    {code: 'async (a, b) => {}',
+      options: ['as-needed'],
+      parserOptions: {ecmaVersion: 8}},
+    {code: '(a: T) => a',
+      options: ['as-needed']
+    },
+    {code: '(a): T => a',
+      options: ['as-needed']
+    },
+
+    // "as-needed", { "requireForBlockBody": true }
+    {code: '() => {}',
+      options: ['as-needed', {requireForBlockBody: true}]},
+    {code: 'a => a',
+      options: ['as-needed', {requireForBlockBody: true}]},
+    {code: '([a, b]) => {}',
+      options: ['as-needed', {requireForBlockBody: true}]},
+    {code: '([a, b]) => a',
+      options: ['as-needed', {requireForBlockBody: true}]},
+    {code: '({ a, b }) => {}',
+      options: ['as-needed', {requireForBlockBody: true}]},
+    {code: '({ a, b }) => a + b',
+      options: ['as-needed', {requireForBlockBody: true}]},
+    {code: '(a = 10) => {}',
+      options: ['as-needed', {requireForBlockBody: true}]},
+    {code: '(...a) => a[0]',
+      options: ['as-needed', {requireForBlockBody: true}]},
+    {code: '(a, b) => {}',
+      options: ['as-needed', {requireForBlockBody: true}]},
+    {code: 'a => ({})',
+      options: ['as-needed', {requireForBlockBody: true}]},
+    {code: 'async a => ({})',
+      options: ['as-needed', {requireForBlockBody: true}],
+      parserOptions: {ecmaVersion: 8}},
+    {code: 'async a => a',
+      options: ['as-needed', {requireForBlockBody: true}],
+      parserOptions: {ecmaVersion: 8}},
+    {code: '(a: T) => a',
+      options: ['as-needed', {requireForBlockBody: true}]},
+    {code: '(a): T => a',
+      options: ['as-needed', {requireForBlockBody: true}]},
+
+    // flow-specific
+    {code: '<T>(a: T) => a',
+      options: ['always', {requireForBlockBody: true}]},
+    {code: '<T>(a: T) => { return a; }',
+      options: ['as-needed', {requireForBlockBody: false}]},
+    {code: '<T>(a: T) => { return a; }',
+      options: ['always', {requireForBlockBody: true}]},
+    {code: '<T>(a: T) => { return a; }',
+      options: ['as-needed', {requireForBlockBody: true}]}
+
+  ]
+};

--- a/tests/rules/index.js
+++ b/tests/rules/index.js
@@ -13,6 +13,7 @@ const ruleTester = new RuleTester();
 const reportingRules = [
   'array-style-complex-type',
   'array-style-simple-type',
+  'arrow-parens',
   'boolean-style',
   'define-flow-type',
   'delimiter-dangle',


### PR DESCRIPTION
This should resolve #344.

I did this quick and dirty, and I'm not sure if it's the correct approach. What I did was:

1. Copied `arrow-parens` rule and tests into `eslint-plugin-flowtype` from `eslint`,
2. Resolved various linting issues and glued code together to work with `eslint-plugin-flowtype` environment,
3. Added tests specific to flow support,
4. Modified behavior of `arrow-parens` rule so that the tests passed.

Let me know if there's a better way to override an eslint rule. Also, I'm not sure if this should go into the recommended config or whatever.

This may also be of interest to https://github.com/typescript-eslint/typescript-eslint/issues/14.