### PR TITLE
fix: ignore arrow functions with predicates in arrow-parens

### DIFF
--- a/src/rules/arrowParens.js
+++ b/src/rules/arrowParens.js
@@ -50,6 +50,12 @@ export default {
         return;
       }
 
+      // Similarly, a predicate always requires parens just like a return type
+      // does, and therefore this case can also be safely ignored.
+      if (node.predicate) {
+        return;
+      }
+
       // "as-needed", { "requireForBlockBody": true }: x => x
       if (
         requireForBlockBody &&

--- a/tests/rules/assertions/arrowParens.js
+++ b/tests/rules/assertions/arrowParens.js
@@ -331,6 +331,8 @@ export default {
     {code: '<T>(a: T) => { return a; }',
       options: ['always', {requireForBlockBody: true}]},
     {code: '<T>(a: T) => { return a; }',
+      options: ['as-needed', {requireForBlockBody: true}]},
+    {code: '(a): %checks => typeof a === "number"',
       options: ['as-needed', {requireForBlockBody: true}]}
 
   ]


### PR DESCRIPTION
Found an even smaller corner case for `arrow-parens`. Again, I'm assuming my logic here makes sense. I don't see a case where an arrow function with a predicate could not have parens.

Is `fix:` fine for this or is this a `feat:`?