### PR TITLE
fix: getter and setter for no-dedupe

### DIFF
--- a/src/utilities/getParameterName.js
+++ b/src/utilities/getParameterName.js
@@ -30,6 +30,10 @@ export default (identifierNode, context) => {
       tokenIndex++;
     }
 
+    if (identifierNode.kind === 'set' || identifierNode.kind === 'get') {
+      tokenIndex++;
+    }
+
     return context.getSourceCode().getFirstToken(identifierNode, tokenIndex).value;
   }
 

--- a/tests/rules/assertions/noDupeKeys.js
+++ b/tests/rules/assertions/noDupeKeys.js
@@ -111,5 +111,8 @@ export default {
     {
       code: 'type a = { b: <C>(config: { ...C, key: string}) => C }',
     },
+    {
+      code: 'export interface Foo { get foo(): boolean; get bar(): string; }',
+    },
   ],
 };


### PR DESCRIPTION
Fix #431 

# Summary of problem

The following code failed because `get` occurs twice (it should instead be comparing function names)

```javascript
export interface Foo {
    get foo(): boolean;
    get bar(): string;
}
```

**root cause**: the function call `getParameterName(identifierNode, context)` did not take into account that `get` and `set` tokens may occur before the variable name. This PR fixes this.