### PR TITLE
feat: support inexact object notation in delimiter-dangle rule

### DIFF
--- a/.README/rules/delimiter-dangle.md
+++ b/.README/rules/delimiter-dangle.md
@@ -4,9 +4,11 @@ _The `--fix` option on the command line automatically fixes problems reported by
 
 Enforces consistent use of trailing commas in Object and Tuple annotations.
 
-This rule takes two arguments which both mirror ESLint's default `comma-dangle` rule.
-The first argument is for Object and Tuple annotations.
-The second argument is used for Interface annotations as ESLint's default `comma-dangle` doesn't apply to interfaces - this defaults to whatever the first argument is.
+This rule takes three arguments where the possible values are the same as ESLint's default `comma-dangle` rule:
+
+1. The first argument is for Object and Tuple annotations. The default value is `'never'`.
+2. The second argument is used for Interface annotations. This defaults to the value of the first argument.
+3. The third argument is used for inexact object notation (trailing `...`). The default value is `'never'`.
 
 If it is `'never'` then a problem is raised when there is a trailing comma.
 
@@ -15,7 +17,5 @@ If it is `'always'` then a problem is raised when there is no trailing comma.
 If it is `'always-multiline'` then a problem is raised when there is no trailing comma on a multi-line definition, or there _is_ a trailing comma on a single-line definition.
 
 If it is `'only-multiline'` then a problem is raised when there is a trailing comma on a single-line definition. It allows, but does not enforce, trailing commas on multi-line definitions.
-
-The default value is `'never'`.
 
 <!-- assertions delimiterDangle -->

--- a/README.md
+++ b/README.md
@@ -822,9 +822,11 @@ _The `--fix` option on the command line automatically fixes problems reported by
 
 Enforces consistent use of trailing commas in Object and Tuple annotations.
 
-This rule takes two arguments which both mirror ESLint's default `comma-dangle` rule.
-The first argument is for Object and Tuple annotations.
-The second argument is used for Interface annotations as ESLint's default `comma-dangle` doesn't apply to interfaces - this defaults to whatever the first argument is.
+This rule takes three arguments where the possible values are the same as ESLint's default `comma-dangle` rule:
+
+1. The first argument is for Object and Tuple annotations. The default value is `'never'`.
+2. The second argument is used for Interface annotations. This defaults to the value of the first argument.
+3. The third argument is used for inexact object notation (trailing `...`). The default value is `'never'`.
 
 If it is `'never'` then a problem is raised when there is a trailing comma.
 
@@ -833,8 +835,6 @@ If it is `'always'` then a problem is raised when there is no trailing comma.
 If it is `'always-multiline'` then a problem is raised when there is no trailing comma on a multi-line definition, or there _is_ a trailing comma on a single-line definition.
 
 If it is `'only-multiline'` then a problem is raised when there is a trailing comma on a single-line definition. It allows, but does not enforce, trailing commas on multi-line definitions.
-
-The default value is `'never'`.
 
 The following patterns are considered problems:
 
@@ -990,6 +990,43 @@ foo: string,
 // Options: ["only-multiline"]
 type X = { foo: string, [key: string]: number; }
 // Message: Unexpected trailing delimiter
+
+// Options: ["never", "never", "never"]
+type X = { foo: string, ..., }
+// Message: Unexpected trailing delimiter
+
+// Options: ["never", "never", "always"]
+type X = { foo: string, ... }
+// Message: Missing trailing delimiter
+
+// Options: ["never", "never", "always-multiline"]
+type X = { foo: string, ..., }
+// Message: Unexpected trailing delimiter
+
+// Options: ["never", "never", "only-multiline"]
+type X = { foo: string, ..., }
+// Message: Unexpected trailing delimiter
+
+// Options: ["never", "never", "never"]
+type X = {
+  foo: string,
+  ...,
+}
+// Message: Unexpected trailing delimiter
+
+// Options: ["never", "never", "always"]
+type X = {
+  foo: string,
+  ...
+}
+// Message: Missing trailing delimiter
+
+// Options: ["never", "never", "always-multiline"]
+type X = {
+  foo: string,
+  ...
+}
+// Message: Missing trailing delimiter
 
 type X = [string, number,]
 // Message: Unexpected trailing delimiter
@@ -1196,6 +1233,48 @@ foo: string;
 
 // Options: ["only-multiline"]
 type X = { foo: string, [key: string]: number }
+
+// Options: ["never", "never", "never"]
+type X = { foo: string, ... }
+
+// Options: ["never", "never", "always"]
+type X = { foo: string, ..., }
+
+// Options: ["never", "never", "always-multiline"]
+type X = { foo: string, ... }
+
+// Options: ["never", "never", "only-multiline"]
+type X = { foo: string, ... }
+
+// Options: ["never", "never", "never"]
+type X = {
+  foo: string,
+  ...
+}
+
+// Options: ["never", "never", "always"]
+type X = {
+  foo: string,
+  ...,
+}
+
+// Options: ["never", "never", "always-multiline"]
+type X = {
+  foo: string,
+  ...,
+}
+
+// Options: ["never", "never", "only-multiline"]
+type X = {
+  foo: string,
+  ...,
+}
+
+// Options: ["never", "never", "only-multiline"]
+type X = {
+  foo: string,
+  ...
+}
 
 type X = [string, number]
 
@@ -3687,7 +3766,7 @@ type FooType = { a: number, c: number, b: string }
           c: number,
           b: string,
         }
-      
+
 // Message: Expected type annotations to be in ascending order. "b" should be before "c".
 
 
@@ -3696,7 +3775,7 @@ type FooType = { a: number, c: number, b: string }
           c: number,
           b: string,
         }
-      
+
 // Message: Expected type annotations to be in ascending order. "b" should be before "c".
 
 
@@ -3705,7 +3784,7 @@ type FooType = { a: number, c: number, b: string }
           c: number,
           b: string,
         }
-      
+
 // Message: Expected type annotations to be in ascending order. "b" should be before "c".
 
 
@@ -3714,7 +3793,7 @@ type FooType = { a: number, c: number, b: string }
           c: ?number,
           b: string,
         }
-      
+
 // Message: Expected type annotations to be in ascending order. "b" should be before "c".
 
 
@@ -3723,7 +3802,7 @@ type FooType = { a: number, c: number, b: string }
           c: number,
           b: (param: string) => number,
         }
-      
+
 // Message: Expected type annotations to be in ascending order. "b" should be before "c".
 
 
@@ -3732,7 +3811,7 @@ type FooType = { a: number, c: number, b: string }
           c: number,
           b: (param: string) => number,
         }
-      
+
 // Message: Expected type annotations to be in ascending order. "b" should be before "c".
 
 
@@ -3741,7 +3820,7 @@ type FooType = { a: number, c: number, b: string }
           a: number | string | boolean,
           b: (param: string) => number,
         }
-      
+
 // Message: Expected type annotations to be in ascending order. "a" should be before "c".
 
 
@@ -3754,7 +3833,7 @@ type FooType = { a: number, c: number, b: string }
           a: number | string | boolean,
           b: (param: string) => number,
         }
-      
+
 // Message: Expected type annotations to be in ascending order. "x" should be before "z".
 // Message: Expected type annotations to be in ascending order. "a" should be before "c".
 
@@ -3772,7 +3851,7 @@ type FooType = { a: number, c: number, b: string }
           a: number | string | boolean,
           b: (param: string) => number,
         }
-      
+
 // Message: Expected type annotations to be in ascending order. "k" should be before "l".
 // Message: Expected type annotations to be in ascending order. "x" should be before "z".
 // Message: Expected type annotations to be in ascending order. "a" should be before "c".
@@ -3783,7 +3862,7 @@ type FooType = { a: number, c: number, b: string }
           -b: number,
           a: number,
         }
-      
+
 // Message: Expected type annotations to be in ascending order. "b" should be before "c".
 // Message: Expected type annotations to be in ascending order. "a" should be before "b".
 
@@ -3793,7 +3872,7 @@ type FooType = { a: number, c: number, b: string }
           -b: number,
           a: number,
         |}
-      
+
 // Message: Expected type annotations to be in ascending order. "b" should be before "c".
 // Message: Expected type annotations to be in ascending order. "a" should be before "b".
 ```
@@ -3918,7 +3997,7 @@ The following patterns are considered problems:
 { a: string, b: number }) => {}
 // Message: There must not be a line break after "foo" parameter type annotation colon.
 
-(foo: 
+(foo:
 { a: string, b: number }) => {}
 // Message: There must not be a line break after "foo" parameter type annotation colon.
 

--- a/README.md
+++ b/README.md
@@ -991,40 +991,219 @@ foo: string,
 type X = { foo: string, [key: string]: number; }
 // Message: Unexpected trailing delimiter
 
-// Options: ["never", "never", "never"]
+type X = { ..., }
+// Message: Unexpected trailing delimiter
+
+type X = { ...; }
+// Message: Unexpected trailing delimiter
+
+// Options: ["never","never","never"]
+type X = { ..., }
+// Message: Unexpected trailing delimiter
+
+// Options: ["never","never","never"]
+type X = { ...; }
+// Message: Unexpected trailing delimiter
+
+// Options: ["never","never","always"]
+type X = { ... }
+// Message: Missing trailing delimiter
+
+// Options: ["never","never","always-multiline"]
+type X = { ..., }
+// Message: Unexpected trailing delimiter
+
+// Options: ["never","never","always-multiline"]
+type X = { ...; }
+// Message: Unexpected trailing delimiter
+
+// Options: ["never","never","only-multiline"]
+type X = { ..., }
+// Message: Unexpected trailing delimiter
+
+// Options: ["never","never","only-multiline"]
+type X = { ...; }
+// Message: Unexpected trailing delimiter
+
+type X = {
+...,
+}
+// Message: Unexpected trailing delimiter
+
+type X = {
+...;
+}
+// Message: Unexpected trailing delimiter
+
+// Options: ["never","never","never"]
+type X = {
+...,
+}
+// Message: Unexpected trailing delimiter
+
+// Options: ["never","never","never"]
+type X = {
+...;
+}
+// Message: Unexpected trailing delimiter
+
+// Options: ["never","never","always"]
+type X = {
+...
+}
+// Message: Missing trailing delimiter
+
+// Options: ["never","never","always-multiline"]
+type X = {
+...
+}
+// Message: Missing trailing delimiter
+
 type X = { foo: string, ..., }
 // Message: Unexpected trailing delimiter
 
-// Options: ["never", "never", "always"]
+type X = { foo: string; ...; }
+// Message: Unexpected trailing delimiter
+
+// Options: ["never","never","never"]
+type X = { foo: string, ..., }
+// Message: Unexpected trailing delimiter
+
+// Options: ["never","never","never"]
+type X = { foo: string; ...; }
+// Message: Unexpected trailing delimiter
+
+// Options: ["never","never","always"]
 type X = { foo: string, ... }
 // Message: Missing trailing delimiter
 
-// Options: ["never", "never", "always-multiline"]
+// Options: ["never","never","always-multiline"]
 type X = { foo: string, ..., }
 // Message: Unexpected trailing delimiter
 
-// Options: ["never", "never", "only-multiline"]
+// Options: ["never","never","always-multiline"]
+type X = { foo: string; ...; }
+// Message: Unexpected trailing delimiter
+
+// Options: ["never","never","only-multiline"]
 type X = { foo: string, ..., }
 // Message: Unexpected trailing delimiter
 
-// Options: ["never", "never", "never"]
+// Options: ["never","never","only-multiline"]
+type X = { foo: string; ...; }
+// Message: Unexpected trailing delimiter
+
 type X = {
-  foo: string,
-  ...,
+foo: string,
+...,
 }
 // Message: Unexpected trailing delimiter
 
-// Options: ["never", "never", "always"]
 type X = {
-  foo: string,
-  ...
+foo: string;
+...;
+}
+// Message: Unexpected trailing delimiter
+
+// Options: ["never","never","never"]
+type X = {
+foo: string,
+...,
+}
+// Message: Unexpected trailing delimiter
+
+// Options: ["never","never","never"]
+type X = {
+foo: string;
+...;
+}
+// Message: Unexpected trailing delimiter
+
+// Options: ["never","never","always"]
+type X = {
+foo: string,
+...
 }
 // Message: Missing trailing delimiter
 
-// Options: ["never", "never", "always-multiline"]
+// Options: ["never","never","always-multiline"]
 type X = {
-  foo: string,
-  ...
+foo: string,
+...
+}
+// Message: Missing trailing delimiter
+
+type X = { [key: string]: number, ..., }
+// Message: Unexpected trailing delimiter
+
+type X = { [key: string]: number; ...; }
+// Message: Unexpected trailing delimiter
+
+// Options: ["never","never","never"]
+type X = { [key: string]: number, ..., }
+// Message: Unexpected trailing delimiter
+
+// Options: ["never","never","never"]
+type X = { [key: string]: number; ...; }
+// Message: Unexpected trailing delimiter
+
+// Options: ["never","never","always"]
+type X = { [key: string]: number, ... }
+// Message: Missing trailing delimiter
+
+// Options: ["never","never","always-multiline"]
+type X = { [key: string]: number, ..., }
+// Message: Unexpected trailing delimiter
+
+// Options: ["never","never","always-multiline"]
+type X = { [key: string]: number; ...; }
+// Message: Unexpected trailing delimiter
+
+// Options: ["never","never","only-multiline"]
+type X = { [key: string]: number, ..., }
+// Message: Unexpected trailing delimiter
+
+// Options: ["never","never","only-multiline"]
+type X = { [key: string]: number; ...; }
+// Message: Unexpected trailing delimiter
+
+type X = {
+[key: string]: number,
+...,
+}
+// Message: Unexpected trailing delimiter
+
+type X = {
+[key: string]: number;
+...;
+}
+// Message: Unexpected trailing delimiter
+
+// Options: ["never","never","never"]
+type X = {
+[key: string]: number,
+...,
+}
+// Message: Unexpected trailing delimiter
+
+// Options: ["never","never","never"]
+type X = {
+[key: string]: number;
+...;
+}
+// Message: Unexpected trailing delimiter
+
+// Options: ["never","never","always"]
+type X = {
+[key: string]: number,
+...
+}
+// Message: Missing trailing delimiter
+
+// Options: ["never","never","always-multiline"]
+type X = {
+[key: string]: number,
+...
 }
 // Message: Missing trailing delimiter
 
@@ -1234,46 +1413,195 @@ foo: string;
 // Options: ["only-multiline"]
 type X = { foo: string, [key: string]: number }
 
-// Options: ["never", "never", "never"]
+type X = { ... }
+
+// Options: ["never","never","never"]
+type X = { ... }
+
+// Options: ["never","never","always"]
+type X = { ..., }
+
+// Options: ["never","never","always-multiline"]
+type X = { ... }
+
+// Options: ["never","never","only-multiline"]
+type X = { ... }
+
+type X = {
+...
+}
+
+// Options: ["never","never","never"]
+type X = {
+...
+}
+
+// Options: ["never","never","always"]
+type X = {
+...,
+ }
+
+// Options: ["never","never","always"]
+type X = {
+...;
+ }
+
+// Options: ["never","never","always-multiline"]
+type X = {
+...,
+}
+
+// Options: ["never","never","always-multiline"]
+type X = {
+...;
+}
+
+// Options: ["never","never","only-multiline"]
+type X = {
+...
+}
+
+// Options: ["never","never","only-multiline"]
+type X = {
+...,
+}
+
+// Options: ["never","never","only-multiline"]
+type X = {
+...;
+}
+
 type X = { foo: string, ... }
 
-// Options: ["never", "never", "always"]
+// Options: ["never","never","never"]
+type X = { foo: string, ... }
+
+// Options: ["never","never","always"]
 type X = { foo: string, ..., }
 
-// Options: ["never", "never", "always-multiline"]
+// Options: ["never","never","always"]
+type X = { foo: string; ...; }
+
+// Options: ["never","never","always-multiline"]
 type X = { foo: string, ... }
 
-// Options: ["never", "never", "only-multiline"]
+// Options: ["never","never","only-multiline"]
 type X = { foo: string, ... }
 
-// Options: ["never", "never", "never"]
 type X = {
-  foo: string,
-  ...
+foo: string,
+...
 }
 
-// Options: ["never", "never", "always"]
+// Options: ["never","never","never"]
 type X = {
-  foo: string,
-  ...,
+foo: string,
+...
 }
 
-// Options: ["never", "never", "always-multiline"]
+// Options: ["never","never","always"]
 type X = {
-  foo: string,
-  ...,
+foo: string,
+...,
 }
 
-// Options: ["never", "never", "only-multiline"]
+// Options: ["never","never","always"]
 type X = {
-  foo: string,
-  ...,
+foo: string;
+...;
 }
 
-// Options: ["never", "never", "only-multiline"]
+// Options: ["never","never","always-multiline"]
 type X = {
-  foo: string,
-  ...
+foo: string,
+...,
+}
+
+// Options: ["never","never","always-multiline"]
+type X = {
+foo: string;
+...;
+}
+
+// Options: ["never","never","only-multiline"]
+type X = {
+foo: string,
+...
+}
+
+// Options: ["never","never","only-multiline"]
+type X = {
+foo: string,
+...,
+}
+
+// Options: ["never","never","only-multiline"]
+type X = {
+foo: string,
+...;
+}
+
+// Options: ["never","never","never"]
+type X = { [key: string]: number, ... }
+
+// Options: ["never","never","always"]
+type X = { [key: string]: number, ..., }
+
+// Options: ["never","never","always"]
+type X = { [key: string]: number; ...; }
+
+// Options: ["never","never","always-multiline"]
+type X = { [key: string]: number, ... }
+
+// Options: ["never","never","only-multiline"]
+type X = { [key: string]: number, ... }
+
+// Options: ["never","never","never"]
+type X = {
+[key: string]: number,
+...
+}
+
+// Options: ["never","never","always"]
+type X = {
+[key: string]: number,
+...,
+}
+
+// Options: ["never","never","always"]
+type X = {
+[key: string]: number;
+...;
+}
+
+// Options: ["never","never","always-multiline"]
+type X = {
+[key: string]: number,
+...,
+}
+
+// Options: ["never","never","always-multiline"]
+type X = {
+[key: string]: number;
+...;
+}
+
+// Options: ["never","never","only-multiline"]
+type X = {
+[key: string]: number,
+...
+}
+
+// Options: ["never","never","only-multiline"]
+type X = {
+[key: string]: number,
+...,
+}
+
+// Options: ["never","never","only-multiline"]
+type X = {
+[key: string]: number;
+...;
 }
 
 type X = [string, number]
@@ -1591,6 +1919,8 @@ var a = {}; var b = {}; type f = { get(key: a): string, get(key: b): string }
 var a = 1; var b = 1; type f = { get(key: a): string, get(key: b): string }
 
 type a = { b: <C>(config: { ...C, key: string}) => C }
+
+export interface Foo { get foo(): boolean; get bar(): string; }
 ```
 
 
@@ -3404,7 +3734,7 @@ This rule has an object option:
     "flowtype/require-valid-file-annotation": [
       2,
       "always", {
-        "annotationStyle": "block"
+        "annotationStyle": "block",
         "strict": true,
       }
     ]
@@ -3766,7 +4096,7 @@ type FooType = { a: number, c: number, b: string }
           c: number,
           b: string,
         }
-
+      
 // Message: Expected type annotations to be in ascending order. "b" should be before "c".
 
 
@@ -3775,7 +4105,7 @@ type FooType = { a: number, c: number, b: string }
           c: number,
           b: string,
         }
-
+      
 // Message: Expected type annotations to be in ascending order. "b" should be before "c".
 
 
@@ -3784,7 +4114,7 @@ type FooType = { a: number, c: number, b: string }
           c: number,
           b: string,
         }
-
+      
 // Message: Expected type annotations to be in ascending order. "b" should be before "c".
 
 
@@ -3793,7 +4123,7 @@ type FooType = { a: number, c: number, b: string }
           c: ?number,
           b: string,
         }
-
+      
 // Message: Expected type annotations to be in ascending order. "b" should be before "c".
 
 
@@ -3802,7 +4132,7 @@ type FooType = { a: number, c: number, b: string }
           c: number,
           b: (param: string) => number,
         }
-
+      
 // Message: Expected type annotations to be in ascending order. "b" should be before "c".
 
 
@@ -3811,7 +4141,7 @@ type FooType = { a: number, c: number, b: string }
           c: number,
           b: (param: string) => number,
         }
-
+      
 // Message: Expected type annotations to be in ascending order. "b" should be before "c".
 
 
@@ -3820,7 +4150,7 @@ type FooType = { a: number, c: number, b: string }
           a: number | string | boolean,
           b: (param: string) => number,
         }
-
+      
 // Message: Expected type annotations to be in ascending order. "a" should be before "c".
 
 
@@ -3833,7 +4163,7 @@ type FooType = { a: number, c: number, b: string }
           a: number | string | boolean,
           b: (param: string) => number,
         }
-
+      
 // Message: Expected type annotations to be in ascending order. "x" should be before "z".
 // Message: Expected type annotations to be in ascending order. "a" should be before "c".
 
@@ -3851,7 +4181,7 @@ type FooType = { a: number, c: number, b: string }
           a: number | string | boolean,
           b: (param: string) => number,
         }
-
+      
 // Message: Expected type annotations to be in ascending order. "k" should be before "l".
 // Message: Expected type annotations to be in ascending order. "x" should be before "z".
 // Message: Expected type annotations to be in ascending order. "a" should be before "c".
@@ -3862,7 +4192,7 @@ type FooType = { a: number, c: number, b: string }
           -b: number,
           a: number,
         }
-
+      
 // Message: Expected type annotations to be in ascending order. "b" should be before "c".
 // Message: Expected type annotations to be in ascending order. "a" should be before "b".
 
@@ -3872,7 +4202,7 @@ type FooType = { a: number, c: number, b: string }
           -b: number,
           a: number,
         |}
-
+      
 // Message: Expected type annotations to be in ascending order. "b" should be before "c".
 // Message: Expected type annotations to be in ascending order. "a" should be before "b".
 ```
@@ -3997,7 +4327,7 @@ The following patterns are considered problems:
 { a: string, b: number }) => {}
 // Message: There must not be a line break after "foo" parameter type annotation colon.
 
-(foo:
+(foo: 
 { a: string, b: number }) => {}
 // Message: There must not be a line break after "foo" parameter type annotation colon.
 

--- a/tests/rules/assertions/delimiterDangle.js
+++ b/tests/rules/assertions/delimiterDangle.js
@@ -223,6 +223,267 @@ const OBJECT_TYPE_ANNOTATION = {
       options: ['only-multiline'],
       output: 'type X = { foo: string, [key: string]: number }',
     },
+
+    // Inexact object notation
+    {
+      code: 'type X = { ..., }',
+      errors: [{message: 'Unexpected trailing delimiter'}],
+      output: 'type X = { ... }',
+    },
+    {
+      code: 'type X = { ...; }',
+      errors: [{message: 'Unexpected trailing delimiter'}],
+      output: 'type X = { ... }',
+    },
+    {
+      code: 'type X = { ..., }',
+      errors: [{message: 'Unexpected trailing delimiter'}],
+      options: ['never', 'never', 'never'],
+      output: 'type X = { ... }',
+    },
+    {
+      code: 'type X = { ...; }',
+      errors: [{message: 'Unexpected trailing delimiter'}],
+      options: ['never', 'never', 'never'],
+      output: 'type X = { ... }',
+    },
+    {
+      code: 'type X = { ... }',
+      errors: [{message: 'Missing trailing delimiter'}],
+      options: ['never', 'never', 'always'],
+      output: 'type X = { ..., }',
+    },
+    {
+      code: 'type X = { ..., }',
+      errors: [{message: 'Unexpected trailing delimiter'}],
+      options: ['never', 'never', 'always-multiline'],
+      output: 'type X = { ... }',
+    },
+    {
+      code: 'type X = { ...; }',
+      errors: [{message: 'Unexpected trailing delimiter'}],
+      options: ['never', 'never', 'always-multiline'],
+      output: 'type X = { ... }',
+    },
+    {
+      code: 'type X = { ..., }',
+      errors: [{message: 'Unexpected trailing delimiter'}],
+      options: ['never', 'never', 'only-multiline'],
+      output: 'type X = { ... }',
+    },
+    {
+      code: 'type X = { ...; }',
+      errors: [{message: 'Unexpected trailing delimiter'}],
+      options: ['never', 'never', 'only-multiline'],
+      output: 'type X = { ... }',
+    },
+    {
+      code: 'type X = {\n...,\n}',
+      errors: [{message: 'Unexpected trailing delimiter'}],
+      output: 'type X = {\n...\n}',
+    },
+    {
+      code: 'type X = {\n...;\n}',
+      errors: [{message: 'Unexpected trailing delimiter'}],
+      output: 'type X = {\n...\n}',
+    },
+    {
+      code: 'type X = {\n...,\n}',
+      errors: [{message: 'Unexpected trailing delimiter'}],
+      options: ['never', 'never', 'never'],
+      output: 'type X = {\n...\n}',
+    },
+    {
+      code: 'type X = {\n...;\n}',
+      errors: [{message: 'Unexpected trailing delimiter'}],
+      options: ['never', 'never', 'never'],
+      output: 'type X = {\n...\n}',
+    },
+    {
+      code: 'type X = {\n...\n}',
+      errors: [{message: 'Missing trailing delimiter'}],
+      options: ['never', 'never', 'always'],
+      output: 'type X = {\n...,\n}',
+    },
+    {
+      code: 'type X = {\n...\n}',
+      errors: [{message: 'Missing trailing delimiter'}],
+      options: ['never', 'never', 'always-multiline'],
+      output: 'type X = {\n...,\n}',
+    },
+    {
+      code: 'type X = { foo: string, ..., }',
+      errors: [{message: 'Unexpected trailing delimiter'}],
+      output: 'type X = { foo: string, ... }',
+    },
+    {
+      code: 'type X = { foo: string; ...; }',
+      errors: [{message: 'Unexpected trailing delimiter'}],
+      output: 'type X = { foo: string; ... }',
+    },
+    {
+      code: 'type X = { foo: string, ..., }',
+      errors: [{message: 'Unexpected trailing delimiter'}],
+      options: ['never', 'never', 'never'],
+      output: 'type X = { foo: string, ... }',
+    },
+    {
+      code: 'type X = { foo: string; ...; }',
+      errors: [{message: 'Unexpected trailing delimiter'}],
+      options: ['never', 'never', 'never'],
+      output: 'type X = { foo: string; ... }',
+    },
+    {
+      code: 'type X = { foo: string, ... }',
+      errors: [{message: 'Missing trailing delimiter'}],
+      options: ['never', 'never', 'always'],
+      output: 'type X = { foo: string, ..., }',
+    },
+    {
+      code: 'type X = { foo: string, ..., }',
+      errors: [{message: 'Unexpected trailing delimiter'}],
+      options: ['never', 'never', 'always-multiline'],
+      output: 'type X = { foo: string, ... }',
+    },
+    {
+      code: 'type X = { foo: string; ...; }',
+      errors: [{message: 'Unexpected trailing delimiter'}],
+      options: ['never', 'never', 'always-multiline'],
+      output: 'type X = { foo: string; ... }',
+    },
+    {
+      code: 'type X = { foo: string, ..., }',
+      errors: [{message: 'Unexpected trailing delimiter'}],
+      options: ['never', 'never', 'only-multiline'],
+      output: 'type X = { foo: string, ... }',
+    },
+    {
+      code: 'type X = { foo: string; ...; }',
+      errors: [{message: 'Unexpected trailing delimiter'}],
+      options: ['never', 'never', 'only-multiline'],
+      output: 'type X = { foo: string; ... }',
+    },
+    {
+      code: 'type X = {\nfoo: string,\n...,\n}',
+      errors: [{message: 'Unexpected trailing delimiter'}],
+      output: 'type X = {\nfoo: string,\n...\n}',
+    },
+    {
+      code: 'type X = {\nfoo: string;\n...;\n}',
+      errors: [{message: 'Unexpected trailing delimiter'}],
+      output: 'type X = {\nfoo: string;\n...\n}',
+    },
+    {
+      code: 'type X = {\nfoo: string,\n...,\n}',
+      errors: [{message: 'Unexpected trailing delimiter'}],
+      options: ['never', 'never', 'never'],
+      output: 'type X = {\nfoo: string,\n...\n}',
+    },
+    {
+      code: 'type X = {\nfoo: string;\n...;\n}',
+      errors: [{message: 'Unexpected trailing delimiter'}],
+      options: ['never', 'never', 'never'],
+      output: 'type X = {\nfoo: string;\n...\n}',
+    },
+    {
+      code: 'type X = {\nfoo: string,\n...\n}',
+      errors: [{message: 'Missing trailing delimiter'}],
+      options: ['never', 'never', 'always'],
+      output: 'type X = {\nfoo: string,\n...,\n}',
+    },
+    {
+      code: 'type X = {\nfoo: string,\n...\n}',
+      errors: [{message: 'Missing trailing delimiter'}],
+      options: ['never', 'never', 'always-multiline'],
+      output: 'type X = {\nfoo: string,\n...,\n}',
+    },
+
+    {
+      code: 'type X = { [key: string]: number, ..., }',
+      errors: [{message: 'Unexpected trailing delimiter'}],
+      output: 'type X = { [key: string]: number, ... }',
+    },
+    {
+      code: 'type X = { [key: string]: number; ...; }',
+      errors: [{message: 'Unexpected trailing delimiter'}],
+      output: 'type X = { [key: string]: number; ... }',
+    },
+    {
+      code: 'type X = { [key: string]: number, ..., }',
+      errors: [{message: 'Unexpected trailing delimiter'}],
+      options: ['never', 'never', 'never'],
+      output: 'type X = { [key: string]: number, ... }',
+    },
+    {
+      code: 'type X = { [key: string]: number; ...; }',
+      errors: [{message: 'Unexpected trailing delimiter'}],
+      options: ['never', 'never', 'never'],
+      output: 'type X = { [key: string]: number; ... }',
+    },
+    {
+      code: 'type X = { [key: string]: number, ... }',
+      errors: [{message: 'Missing trailing delimiter'}],
+      options: ['never', 'never', 'always'],
+      output: 'type X = { [key: string]: number, ..., }',
+    },
+    {
+      code: 'type X = { [key: string]: number, ..., }',
+      errors: [{message: 'Unexpected trailing delimiter'}],
+      options: ['never', 'never', 'always-multiline'],
+      output: 'type X = { [key: string]: number, ... }',
+    },
+    {
+      code: 'type X = { [key: string]: number; ...; }',
+      errors: [{message: 'Unexpected trailing delimiter'}],
+      options: ['never', 'never', 'always-multiline'],
+      output: 'type X = { [key: string]: number; ... }',
+    },
+    {
+      code: 'type X = { [key: string]: number, ..., }',
+      errors: [{message: 'Unexpected trailing delimiter'}],
+      options: ['never', 'never', 'only-multiline'],
+      output: 'type X = { [key: string]: number, ... }',
+    },
+    {
+      code: 'type X = { [key: string]: number; ...; }',
+      errors: [{message: 'Unexpected trailing delimiter'}],
+      options: ['never', 'never', 'only-multiline'],
+      output: 'type X = { [key: string]: number; ... }',
+    },
+    {
+      code: 'type X = {\n[key: string]: number,\n...,\n}',
+      errors: [{message: 'Unexpected trailing delimiter'}],
+      output: 'type X = {\n[key: string]: number,\n...\n}',
+    },
+    {
+      code: 'type X = {\n[key: string]: number;\n...;\n}',
+      errors: [{message: 'Unexpected trailing delimiter'}],
+      output: 'type X = {\n[key: string]: number;\n...\n}',
+    },
+    {
+      code: 'type X = {\n[key: string]: number,\n...,\n}',
+      errors: [{message: 'Unexpected trailing delimiter'}],
+      options: ['never', 'never', 'never'],
+      output: 'type X = {\n[key: string]: number,\n...\n}',
+    },
+    {
+      code: 'type X = {\n[key: string]: number;\n...;\n}',
+      errors: [{message: 'Unexpected trailing delimiter'}],
+      options: ['never', 'never', 'never'],
+      output: 'type X = {\n[key: string]: number;\n...\n}',
+    },
+    {
+      code: 'type X = {\n[key: string]: number,\n...\n}',
+      errors: [{message: 'Missing trailing delimiter'}],
+      options: ['never', 'never', 'always'],
+      output: 'type X = {\n[key: string]: number,\n...,\n}',
+    },
+    {
+      code: 'type X = {\n[key: string]: number,\n...\n}',
+      errors: [{message: 'Missing trailing delimiter'}],
+      options: ['never', 'never', 'always-multiline'],
+      output: 'type X = {\n[key: string]: number,\n...,\n}',
+    },
   ],
   valid: [
     {
@@ -401,6 +662,172 @@ const OBJECT_TYPE_ANNOTATION = {
     {
       code: 'type X = { foo: string, [key: string]: number }',
       options: ['only-multiline'],
+    },
+
+    // Inexact object notation
+    {
+      code: 'type X = { ... }',
+    },
+    {
+      code: 'type X = { ... }',
+      options: ['never', 'never', 'never'],
+    },
+    {
+      code: 'type X = { ..., }',
+      options: ['never', 'never', 'always'],
+    },
+    {
+      code: 'type X = { ... }',
+      options: ['never', 'never', 'always-multiline'],
+    },
+    {
+      code: 'type X = { ... }',
+      options: ['never', 'never', 'only-multiline'],
+    },
+    {
+      code: 'type X = {\n...\n}',
+    },
+    {
+      code: 'type X = {\n...\n}',
+      options: ['never', 'never', 'never'],
+    },
+    {
+      code: 'type X = {\n...,\n }',
+      options: ['never', 'never', 'always'],
+    },
+    {
+      code: 'type X = {\n...;\n }',
+      options: ['never', 'never', 'always'],
+    },
+    {
+      code: 'type X = {\n...,\n}',
+      options: ['never', 'never', 'always-multiline'],
+    },
+    {
+      code: 'type X = {\n...;\n}',
+      options: ['never', 'never', 'always-multiline'],
+    },
+    {
+      code: 'type X = {\n...\n}',
+      options: ['never', 'never', 'only-multiline'],
+    },
+    {
+      code: 'type X = {\n...,\n}',
+      options: ['never', 'never', 'only-multiline'],
+    },
+    {
+      code: 'type X = {\n...;\n}',
+      options: ['never', 'never', 'only-multiline'],
+    },
+    {
+      code: 'type X = { foo: string, ... }',
+    },
+    {
+      code: 'type X = { foo: string, ... }',
+      options: ['never', 'never', 'never'],
+    },
+    {
+      code: 'type X = { foo: string, ..., }',
+      options: ['never', 'never', 'always'],
+    },
+    {
+      code: 'type X = { foo: string; ...; }',
+      options: ['never', 'never', 'always'],
+    },
+    {
+      code: 'type X = { foo: string, ... }',
+      options: ['never', 'never', 'always-multiline'],
+    },
+    {
+      code: 'type X = { foo: string, ... }',
+      options: ['never', 'never', 'only-multiline'],
+    },
+    {
+      code: 'type X = {\nfoo: string,\n...\n}',
+    },
+    {
+      code: 'type X = {\nfoo: string,\n...\n}',
+      options: ['never', 'never', 'never'],
+    },
+    {
+      code: 'type X = {\nfoo: string,\n...,\n}',
+      options: ['never', 'never', 'always'],
+    },
+    {
+      code: 'type X = {\nfoo: string;\n...;\n}',
+      options: ['never', 'never', 'always'],
+    },
+    {
+      code: 'type X = {\nfoo: string,\n...,\n}',
+      options: ['never', 'never', 'always-multiline'],
+    },
+    {
+      code: 'type X = {\nfoo: string;\n...;\n}',
+      options: ['never', 'never', 'always-multiline'],
+    },
+    {
+      code: 'type X = {\nfoo: string,\n...\n}',
+      options: ['never', 'never', 'only-multiline'],
+    },
+    {
+      code: 'type X = {\nfoo: string,\n...,\n}',
+      options: ['never', 'never', 'only-multiline'],
+    },
+    {
+      code: 'type X = {\nfoo: string,\n...;\n}',
+      options: ['never', 'never', 'only-multiline'],
+    },
+    {
+      code: 'type X = { [key: string]: number, ... }',
+      options: ['never', 'never', 'never'],
+    },
+    {
+      code: 'type X = { [key: string]: number, ..., }',
+      options: ['never', 'never', 'always'],
+    },
+    {
+      code: 'type X = { [key: string]: number; ...; }',
+      options: ['never', 'never', 'always'],
+    },
+    {
+      code: 'type X = { [key: string]: number, ... }',
+      options: ['never', 'never', 'always-multiline'],
+    },
+    {
+      code: 'type X = { [key: string]: number, ... }',
+      options: ['never', 'never', 'only-multiline'],
+    },
+    {
+      code: 'type X = {\n[key: string]: number,\n...\n}',
+      options: ['never', 'never', 'never'],
+    },
+    {
+      code: 'type X = {\n[key: string]: number,\n...,\n}',
+      options: ['never', 'never', 'always'],
+    },
+    {
+      code: 'type X = {\n[key: string]: number;\n...;\n}',
+      options: ['never', 'never', 'always'],
+    },
+    {
+      code: 'type X = {\n[key: string]: number,\n...,\n}',
+      options: ['never', 'never', 'always-multiline'],
+    },
+    {
+      code: 'type X = {\n[key: string]: number;\n...;\n}',
+      options: ['never', 'never', 'always-multiline'],
+    },
+    {
+      code: 'type X = {\n[key: string]: number,\n...\n}',
+      options: ['never', 'never', 'only-multiline'],
+    },
+    {
+      code: 'type X = {\n[key: string]: number,\n...,\n}',
+      options: ['never', 'never', 'only-multiline'],
+    },
+    {
+      code: 'type X = {\n[key: string]: number;\n...;\n}',
+      options: ['never', 'never', 'only-multiline'],
     },
   ],
 };


### PR DESCRIPTION
Currently, the `delimiter-dangle` rule either requires or disallows a dangling delimiter for inexact object notation the same as if it were a regular property. Most often, it's preferred not to have a delimiter after the inexact object notation since it must always be at the end of the object. This PR adds an option to the `delimiter-dangle` rule either require or disallow a dangling delimiter specifically for the inexact object notation.

This also fixes a bug where the property before the inexact notation is reported as the location of the error when the error is actually for the inexact notation.

Before:
```js
// Options: ["always-multiline"]
type X = {
  foo: string, // Error is (incorrectly) for this property
  ...
}
```

After:
```js
// Options: ["always-multiline"]
type X = {
  foo: string,
  ... // No error
}

// Options: ["always", "always", "always"]
type X = {
  foo: string,
  ..., // No error
}
```