### PR TITLE
fix: sort-keys spreads, spreads with generics, comment handling

### DIFF
--- a/tests/rules/assertions/sortKeys.js
+++ b/tests/rules/assertions/sortKeys.js
@@ -68,6 +68,179 @@ export default {
     {
       code: `
         type FooType = {
+          a: $ReadOnlyArray<number>,
+          c: $ReadOnlyMap<string, number>,
+          b: Map<string, Array<Map<string, number>>>,
+        }
+      `,
+      errors: [{message: 'Expected type annotations to be in ascending order. "b" should be before "c".'}],
+      output: `
+        type FooType = {
+          a: $ReadOnlyArray<number>,
+          b: Map<string, Array<Map<string, number>>>,
+          c: $ReadOnlyMap<string, number>,
+        }
+      `,
+    },
+    {
+      code: `
+        type FooType = {
+          ...ErrorsInRecursiveGenericTypeArgsButDoesNotFix<{
+            y: boolean,
+            x: string,
+            z: {
+              j: string,
+              l: number,
+              k: boolean,
+            },
+          }>,
+          a: number,
+          c: string,
+          b: Map<string, Array<ErrorsInRecursiveGenericTypeArgsButDoesNotFix<{
+            y: boolean,
+            x: string,
+            z: {
+              j: string,
+              l: number,
+              k: boolean,
+            },
+          }>>>,
+        }
+      `,
+      errors: [
+        {message: 'Expected type annotations to be in ascending order. "x" should be before "y".'},
+        {message: 'Expected type annotations to be in ascending order. "k" should be before "l".'},
+        {message: 'Expected type annotations to be in ascending order. "b" should be before "c".'},
+        {message: 'Expected type annotations to be in ascending order. "x" should be before "y".'},
+        {message: 'Expected type annotations to be in ascending order. "k" should be before "l".'},
+      ],
+      output: `
+        type FooType = {
+          ...ErrorsInRecursiveGenericTypeArgsButDoesNotFix<{
+            y: boolean,
+            x: string,
+            z: {
+              j: string,
+              l: number,
+              k: boolean,
+            },
+          }>,
+          a: number,
+          b: Map<string, Array<ErrorsInRecursiveGenericTypeArgsButDoesNotFix<{
+            y: boolean,
+            x: string,
+            z: {
+              j: string,
+              l: number,
+              k: boolean,
+            },
+          }>>>,
+          c: string,
+        }
+      `,
+    },
+    {
+      code: `
+        type FooType = {
+          ...BPreservesSpreadOrder,
+          ...APreservesSpreadOrder,
+          c: string,
+          b: number,
+        }
+      `,
+      errors: [{message: 'Expected type annotations to be in ascending order. "b" should be before "c".'}],
+      output: `
+        type FooType = {
+          ...BPreservesSpreadOrder,
+          ...APreservesSpreadOrder,
+          b: number,
+          c: string,
+        }
+      `,
+    },
+    {
+      code: `
+        type FooType = {
+          ...BPreservesSpreadSpans,
+          ...APreservesSpreadSpans,
+          c: string,
+          b: number,
+          ...CPreservesSpreadSpans,
+          e: string,
+          d: number,
+        }
+      `,
+      errors: [
+        {message: 'Expected type annotations to be in ascending order. "b" should be before "c".'},
+        {message: 'Expected type annotations to be in ascending order. "d" should be before "e".'},
+      ],
+      output: `
+        type FooType = {
+          ...BPreservesSpreadSpans,
+          ...APreservesSpreadSpans,
+          b: number,
+          c: string,
+          ...CPreservesSpreadSpans,
+          d: number,
+          e: string,
+        }
+      `,
+    },
+    {
+      code: `
+        type FooType = {
+          ...BPreservesSpreadOrderAndTypeArgs<string, number>,
+          ...APreservesSpreadOrderAndTypeArgs<number>,
+          c: string,
+          b: number,
+        }
+      `,
+      errors: [{message: 'Expected type annotations to be in ascending order. "b" should be before "c".'}],
+      output: `
+        type FooType = {
+          ...BPreservesSpreadOrderAndTypeArgs<string, number>,
+          ...APreservesSpreadOrderAndTypeArgs<number>,
+          b: number,
+          c: string,
+        }
+      `,
+    },
+    {
+      code: `
+        type FooType = {
+          /* preserves block comment before spread BType */
+          // preserves line comment before spread BType
+          ... /* preserves comment in spread BType */ BType<Generic> /* preserves trailing comment in spread AType */,
+          /* preserves block comment before spread AType */
+          // preserves line comment before spread AType
+          ... /* preserves comment in spread AType */ AType /* preserves trailing comment in spread AType */,
+          /* preserves block comment before reordered key "c" */
+          // preserves line comment before reordered key "c"
+          c:/* preserves comment and white space or lack of it */string/* preserves trailing comment for key "c" */,
+          b: number,
+          dWithoutComma: boolean
+        }
+      `,
+      errors: [{message: 'Expected type annotations to be in ascending order. "b" should be before "c".'}],
+      output: `
+        type FooType = {
+          /* preserves block comment before spread BType */
+          // preserves line comment before spread BType
+          ... /* preserves comment in spread BType */ BType<Generic> /* preserves trailing comment in spread AType */,
+          /* preserves block comment before spread AType */
+          // preserves line comment before spread AType
+          ... /* preserves comment in spread AType */ AType /* preserves trailing comment in spread AType */,
+          b: number,
+          /* preserves block comment before reordered key "c" */
+          // preserves line comment before reordered key "c"
+          c:/* preserves comment and white space or lack of it */string/* preserves trailing comment for key "c" */,
+          dWithoutComma: boolean
+        }
+      `,
+    },
+    {
+      code: `
+        type FooType = {
           +a: number,
           c: number,
           b: string,


### PR DESCRIPTION
For the `flowtype/sort-keys` rule:

1. Fixes dropping of spread generic type arguments when keys are reordered.
2. Fixes reordering of spread elements. The order of spreads is significant and must be preserved, sort only standalone keys between the spans of spreads.
3. Fixes comment handling and preservation.
4. Makes it clear in the tests and code comments that the objects within generic type arguments are not auto-fixed even though they show an error (can be fixed later).

I had to reimplement `generateOrderedList` and a part of `generateFix` to get this working to find tokens an replacement ranges more precisely (most difficult were comments). Hope it won't be very hard to review; I recommend reviewing the full code, not the red/green diff lines.

See added tests. Before this PR, the added tests were failing:

```
  1419 passing (2s)
  5 failing

  1) sort-keys
       invalid
         
        type FooType = {
          ...ErrorsInRecursiveGenericTypeArgsButDoesNotFix<{
            y: boolean,
            x: string,
            z: {
              j: string,
              l: number,
              k: boolean,
            },
          }>,
          a: number,
          c: string,
          b: Map<string, Array<ErrorsInRecursiveGenericTypeArgsButDoesNotFix<{
            y: boolean,
            x: string,
            z: {
              j: string,
              l: number,
              k: boolean,
            },
          }>>>,
        }
      :

      AssertionError [ERR_ASSERTION] [ERR_ASSERTION]: Output is incorrect.
      + expected - actual

       
               type FooType = {
      -          ...ErrorsInRecursiveGenericTypeArgsButDoesNotFix,
      +          ...ErrorsInRecursiveGenericTypeArgsButDoesNotFix<{
      +            y: boolean,
      +            x: string,
      +            z: {
      +              j: string,
      +              l: number,
      +              k: boolean,
      +            },
      +          }>,
                 a: number,
                 b: Map<string, Array<ErrorsInRecursiveGenericTypeArgsButDoesNotFix<{
                   y: boolean,
                   x: string,
      
      at testInvalidTemplate (node_modules/eslint/lib/testers/rule-tester.js:569:28)
      at Context.<anonymous> (node_modules/eslint/lib/testers/rule-tester.js:592:25)
      at processImmediate (internal/timers.js:439:21)

  2) sort-keys
       invalid
         
        type FooType = {
          ...BPreservesSpreadOrder,
          ...APreservesSpreadOrder,
          c: string,
          b: number,
        }
      :

      AssertionError [ERR_ASSERTION] [ERR_ASSERTION]: Output is incorrect.
      + expected - actual

       
               type FooType = {
      +          ...BPreservesSpreadOrder,
                 ...APreservesSpreadOrder,
      -          ...BPreservesSpreadOrder,
                 b: number,
                 c: string,
               }
             
      
      at testInvalidTemplate (node_modules/eslint/lib/testers/rule-tester.js:569:28)
      at Context.<anonymous> (node_modules/eslint/lib/testers/rule-tester.js:592:25)
      at processImmediate (internal/timers.js:439:21)

  3) sort-keys
       invalid
         
        type FooType = {
          ...BPreservesSpreadSpans,
          ...APreservesSpreadSpans,
          c: string,
          b: number,
          ...CPreservesSpreadSpans,
          e: string,
          d: number,
        }
      :

      AssertionError [ERR_ASSERTION] [ERR_ASSERTION]: Output is incorrect.
      + expected - actual

       
               type FooType = {
      +          ...BPreservesSpreadSpans,
                 ...APreservesSpreadSpans,
      -          ...BPreservesSpreadSpans,
      -          ...CPreservesSpreadSpans,
                 b: number,
                 c: string,
      +          ...CPreservesSpreadSpans,
                 d: number,
                 e: string,
               }
             
      
      at testInvalidTemplate (node_modules/eslint/lib/testers/rule-tester.js:569:28)
      at Context.<anonymous> (node_modules/eslint/lib/testers/rule-tester.js:592:25)
      at processImmediate (internal/timers.js:439:21)

  4) sort-keys
       invalid
         
        type FooType = {
          ...BPreservesSpreadOrderAndTypeArgs<string, number>,
          ...APreservesSpreadOrderAndTypeArgs<number>,
          c: string,
          b: number,
        }
      :

      AssertionError [ERR_ASSERTION] [ERR_ASSERTION]: Output is incorrect.
      + expected - actual

       
               type FooType = {
      -          ...APreservesSpreadOrderAndTypeArgs,
      -          ...BPreservesSpreadOrderAndTypeArgs,
      +          ...BPreservesSpreadOrderAndTypeArgs<string, number>,
      +          ...APreservesSpreadOrderAndTypeArgs<number>,
                 b: number,
                 c: string,
               }
             
      
      at testInvalidTemplate (node_modules/eslint/lib/testers/rule-tester.js:569:28)
      at Context.<anonymous> (node_modules/eslint/lib/testers/rule-tester.js:592:25)
      at processImmediate (internal/timers.js:439:21)

  5) sort-keys
       invalid
         
        type FooType = {
          /* preserves block comment before spread BType */
          // preserves line comment before spread BType
          ... /* preserves comment in spread BType */ BType<Generic> /* preserves trailing comment in spread AType */,
          /* preserves block comment before spread AType */
          // preserves line comment before spread AType
          ... /* preserves comment in spread AType */ AType /* preserves trailing comment in spread AType */,
          /* preserves block comment before reordered key "c" */
          // preserves line comment before reordered key "c"
          c:/* preserves comment and white space or lack of it */string/* preserves trailing comment for key "c" */,
          b: number,
          dWithoutComma: boolean
        }
      :

      AssertionError [ERR_ASSERTION] [ERR_ASSERTION]: Output is incorrect.
      + expected - actual

       
               type FooType = {
                 /* preserves block comment before spread BType */
                 // preserves line comment before spread BType
      -          ...AType /* preserves trailing comment in spread AType */,
      +          ... /* preserves comment in spread BType */ BType<Generic> /* preserves trailing comment in spread AType */,
                 /* preserves block comment before spread AType */
                 // preserves line comment before spread AType
      -          ...BType /* preserves trailing comment in spread AType */,
      +          ... /* preserves comment in spread AType */ AType /* preserves trailing comment in spread AType */,
      +          b: number,
                 /* preserves block comment before reordered key "c" */
                 // preserves line comment before reordered key "c"
      -          b: number/* preserves trailing comment for key "c" */,
      -          c: string,
      +          c:/* preserves comment and white space or lack of it */string/* preserves trailing comment for key "c" */,
                 dWithoutComma: boolean
               }
             
      
      at testInvalidTemplate (node_modules/eslint/lib/testers/rule-tester.js:569:28)
      at Context.<anonymous> (node_modules/eslint/lib/testers/rule-tester.js:592:25)
      at processImmediate (internal/timers.js:439:21)
```