### PR TITLE
Add fixer to invalid file annotation style message

### DIFF
--- a/src/rules/requireValidFileAnnotation.js
+++ b/src/rules/requireValidFileAnnotation.js
@@ -94,9 +94,18 @@ const create = (context) => {
         const annotationValue = potentialFlowFileAnnotation.value.trim();
         if (isFlowFileAnnotation(annotationValue)) {
           if (!isValidAnnotationStyle(potentialFlowFileAnnotation, style)) {
-            const str = style === 'line' ? '`// ' + annotationValue + '`' : '`/* ' + annotationValue + ' */`';
+            const annotation = style === 'line' ? '// ' + annotationValue : '/* ' + annotationValue + ' */';
 
-            context.report(potentialFlowFileAnnotation, 'Flow file annotation style must be ' + str);
+            context.report({
+              fix: (fixer) => {
+                return fixer.replaceTextRange(
+                  [potentialFlowFileAnnotation.start, potentialFlowFileAnnotation.end],
+                  annotation
+                );
+              },
+              message: 'Flow file annotation style must be `' + annotation + '`',
+              node: potentialFlowFileAnnotation,
+            });
           }
           if (!noFlowAnnotation(annotationValue) && flowStrict) {
             if (!isFlowStrict(annotationValue)) {

--- a/tests/rules/assertions/requireValidFileAnnotation.js
+++ b/tests/rules/assertions/requireValidFileAnnotation.js
@@ -226,6 +226,21 @@ export default {
       ],
       output: '// @flow\na;\nb;',
     },
+    {
+      code: '/* @flow strict */\na;\nb;',
+      errors: [
+        {
+          message: 'Flow file annotation style must be `// @flow strict`',
+        },
+      ],
+      options: [
+        'never',
+        {
+          annotationStyle: 'line',
+        },
+      ],
+      output: '// @flow strict\na;\nb;',
+    },
   ],
   misconfigured: [
     {

--- a/tests/rules/assertions/requireValidFileAnnotation.js
+++ b/tests/rules/assertions/requireValidFileAnnotation.js
@@ -211,6 +211,21 @@ export default {
       ],
       output: '// @flow strict\na;\nb;',
     },
+    {
+      code: '/* @flow */\na;\nb;',
+      errors: [
+        {
+          message: 'Flow file annotation style must be `// @flow`',
+        },
+      ],
+      options: [
+        'never',
+        {
+          annotationStyle: 'line',
+        },
+      ],
+      output: '// @flow\na;\nb;',
+    },
   ],
   misconfigured: [
     {


### PR DESCRIPTION
This helps to make annotation style consistent gradually when touching files.