### PR TITLE
Fix/require exact type nested

### DIFF
--- a/src/rules/requireExactType.js
+++ b/src/rules/requireExactType.js
@@ -17,7 +17,7 @@ const create = (context) => {
     ObjectTypeAnnotation (node) {
       const {exact, indexers} = node;
 
-      if (always && !exact && indexers.length === 0) {
+      if (node.parent.type !== 'InterfaceDeclaration' && always && !exact && indexers.length === 0) {
         context.report({
           fix: (fixer) => {
             return [

--- a/tests/rules/assertions/requireExactType.js
+++ b/tests/rules/assertions/requireExactType.js
@@ -40,6 +40,26 @@ export default {
       options: ['always'],
       output: '(foo: Array<{|bar: string|}>) => {};',
     },
+    {
+      code: `interface StackFrame {
+          colno?: number;
+          lineno?: number;
+          filename?: string;
+          function?: { name: string };
+      }`,
+      errors: [
+        {
+          message: 'Object type must be exact.',
+        },
+      ],
+      options: ['always'],
+      output: `interface StackFrame {
+          colno?: number;
+          lineno?: number;
+          filename?: string;
+          function?: {| name: string |};
+      }`,
+    },
 
     // Never
 
@@ -92,6 +112,26 @@ export default {
       ],
       options: ['never'],
       output: '(foo: Array<{ bar: string }>) => {};',
+    },
+    {
+      code: `interface StackFrame {
+          colno?: number;
+          lineno?: number;
+          filename?: string;
+          function?: {| name: string |};
+      }`,
+      errors: [
+        {
+          message: 'Object type must not be exact.',
+        },
+      ],
+      options: ['never'],
+      output: `interface StackFrame {
+          colno?: number;
+          lineno?: number;
+          filename?: string;
+          function?: { name: string };
+      }`,
     },
   ],
   valid: [

--- a/tests/rules/assertions/requireExactType.js
+++ b/tests/rules/assertions/requireExactType.js
@@ -131,6 +131,22 @@ export default {
       options: ['always'],
     },
 
+    {
+      code: `interface StackFrame {
+          colno?: number;
+          lineno?: number;
+          filename?: string;
+          function?: {| name: string |};
+      }`,
+      options: ['always'],
+      output: `interface StackFrame {
+          colno?: number;
+          lineno?: number;
+          filename?: string;
+          function?: {| name: string |};
+      }`,
+    },
+
     // Never
 
     {
@@ -152,6 +168,22 @@ export default {
     {
       code: 'type foo = number;',
       options: ['never'],
+    },
+
+    {
+      code: `interface StackFrame {
+          colno?: number;
+          lineno?: number;
+          filename?: string;
+          function?: {| name: string |};
+      }`,
+      options: ['always'],
+      output: `interface StackFrame {
+          colno?: number;
+          lineno?: number;
+          filename?: string;
+          function?: {| name: string |};
+      }`,
     },
   ],
 };


### PR DESCRIPTION
Just found a bug for #441. Unfortunately AST Node type for Interfaces first child is an ObjectTypeAnnotation too, thus we have to check for that case and ignore it. 