### PR TITLE
fix: declare parsers as optional peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,17 @@
   "main": "./dist/index.js",
   "name": "eslint-plugin-flowtype",
   "peerDependencies": {
+    "@babel/eslint-parser": "^7.0.0",
+    "babel-eslint": "*",
     "eslint": "^7.1.0"
+  },
+  "peerDependenciesMeta": {
+    "@babel/eslint-parser": {
+      "optional": true
+    },
+    "babel-eslint": {
+      "optional": true
+    }
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
The [test](https://github.com/ylemkimon/eslint-plugin-flowtype-babel-eslint/actions/runs/218763178) shows `babel-eslint-plugin` is compatible with the latest of all major version of `babel-eslint`, so `*` is used.