### PR TITLE
fix: annotate fixable rules

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,4 @@
+/* eslint-disable import/max-dependencies */
 import _ from 'lodash';
 import recommended from './configs/recommended.json';
 import arrayStyleComplexType from './rules/arrayStyleComplexType';

--- a/src/rules/arrayStyle/index.js
+++ b/src/rules/arrayStyle/index.js
@@ -80,6 +80,9 @@ export default (defaultConfig, simpleType) => {
 
   return {
     create,
+    meta: {
+      fixable: 'code',
+    },
     schema,
   };
 };

--- a/src/rules/booleanStyle.js
+++ b/src/rules/booleanStyle.js
@@ -37,5 +37,8 @@ const create = (context) => {
 
 export default {
   create,
+  meta: {
+    fixable: 'code',
+  },
   schema,
 };

--- a/src/rules/delimiterDangle.js
+++ b/src/rules/delimiterDangle.js
@@ -15,6 +15,31 @@ const schema = [
   },
 ];
 
+// required for reporting the correct position
+const getLast = (property, indexer) => {
+  if (!property) {
+    return indexer;
+  }
+
+  if (!indexer) {
+    return property;
+  }
+
+  if (property.loc.end.line > indexer.loc.end.line) {
+    return property;
+  }
+
+  if (indexer.loc.end.line > property.loc.end.line) {
+    return indexer;
+  }
+
+  if (property.loc.end.column > indexer.loc.end.column) {
+    return property;
+  }
+
+  return indexer;
+};
+
 const create = (context) => {
   const option = context.options[0] || 'never';
   const interfaceOption = context.options[1] || option;
@@ -97,31 +122,6 @@ const create = (context) => {
     }
   };
 
-  // required for reporting the correct position
-  const getLast = (property, indexer) => {
-    if (!property) {
-      return indexer;
-    }
-
-    if (!indexer) {
-      return property;
-    }
-
-    if (property.loc.end.line > indexer.loc.end.line) {
-      return property;
-    }
-
-    if (indexer.loc.end.line > property.loc.end.line) {
-      return indexer;
-    }
-
-    if (property.loc.end.column > indexer.loc.end.column) {
-      return property;
-    }
-
-    return indexer;
-  };
-
   return {
     ObjectTypeAnnotation (node) {
       evaluate(node, getLast(_.last(node.properties), _.last(node.indexers)));
@@ -135,5 +135,8 @@ const create = (context) => {
 
 export default {
   create,
+  meta: {
+    fixable: 'code',
+  },
   schema,
 };

--- a/src/rules/genericSpacing.js
+++ b/src/rules/genericSpacing.js
@@ -90,5 +90,8 @@ const create = (context) => {
 
 export default {
   create,
+  meta: {
+    fixable: 'code',
+  },
   schema,
 };

--- a/src/rules/newlineAfterFlowAnnotation.js
+++ b/src/rules/newlineAfterFlowAnnotation.js
@@ -71,5 +71,8 @@ const create = (context) => {
 
 export default {
   create,
+  meta: {
+    fixable: 'code',
+  },
   schema,
 };

--- a/src/rules/noMutableArray.js
+++ b/src/rules/noMutableArray.js
@@ -58,5 +58,8 @@ const create = (context) => {
 
 export default {
   create,
+  meta: {
+    fixable: 'code',
+  },
   schema,
 };

--- a/src/rules/objectTypeDelimiter.js
+++ b/src/rules/objectTypeDelimiter.js
@@ -66,5 +66,8 @@ const schema = [
 
 export default {
   create,
+  meta: {
+    fixable: 'code',
+  },
   schema,
 };

--- a/src/rules/requireIndexerName.js
+++ b/src/rules/requireIndexerName.js
@@ -33,5 +33,8 @@ const create = (context) => {
 
 export default {
   create,
+  meta: {
+    fixable: 'code',
+  },
   schema,
 };

--- a/src/rules/requireReturnType.js
+++ b/src/rules/requireReturnType.js
@@ -35,14 +35,18 @@ const schema = [
   },
 ];
 
+const makeRegExp = (str) => {
+  return new RegExp(str);
+};
+
+const isUndefinedReturnType = (returnNode) => {
+  return returnNode.argument === null || returnNode.argument.name === 'undefined' || returnNode.argument.operator === 'void';
+};
+
 const create = (context) => {
   const annotateReturn = (_.get(context, 'options[0]') || 'always') === 'always';
   const annotateUndefined = _.get(context, 'options[1].annotateUndefined') || 'never';
   const skipArrows = _.get(context, 'options[1].excludeArrowFunctions') || false;
-
-  const makeRegExp = (str) => {
-    return new RegExp(str);
-  };
 
   const excludeMatching = _.get(context, 'options[1].excludeMatching', []).map(makeRegExp);
   const includeOnlyMatching = _.get(context, 'options[1].includeOnlyMatching', []).map(makeRegExp);
@@ -55,12 +59,9 @@ const create = (context) => {
     });
   };
 
-  const isUndefinedReturnType = (returnNode) => {
-    return returnNode.argument === null || returnNode.argument.name === 'undefined' || returnNode.argument.operator === 'void';
-  };
-
   const getIsReturnTypeAnnotationUndefined = (targetNode) => {
-    const isReturnTypeAnnotationLiteralUndefined = _.get(targetNode, 'functionNode.returnType.typeAnnotation.id.name') === 'undefined' && _.get(targetNode, 'functionNode.returnType.typeAnnotation.type') === 'GenericTypeAnnotation';
+    const isReturnTypeAnnotationLiteralUndefined = _.get(targetNode, 'functionNode.returnType.typeAnnotation.id.name') === 'undefined' &&
+      _.get(targetNode, 'functionNode.returnType.typeAnnotation.type') === 'GenericTypeAnnotation';
     const isReturnTypeAnnotationVoid = _.get(targetNode, 'functionNode.returnType.typeAnnotation.type') === 'VoidTypeAnnotation';
     const isAsyncReturnTypeAnnotationVoid = _.get(targetNode, 'functionNode.async') &&
       _.get(targetNode, 'functionNode.returnType.typeAnnotation.id.name') === 'Promise' && (
@@ -113,7 +114,10 @@ const create = (context) => {
 
     const isArrow = functionNode.type === 'ArrowFunctionExpression';
     const isArrowFunctionExpression = functionNode.expression;
-    const isFunctionReturnUndefined = !isArrowFunctionExpression && !functionNode.generator && (!targetNode.returnStatementNode || isUndefinedReturnType(targetNode.returnStatementNode));
+    const isFunctionReturnUndefined =
+      !isArrowFunctionExpression &&
+      !functionNode.generator &&
+      (!targetNode.returnStatementNode || isUndefinedReturnType(targetNode.returnStatementNode));
     const isReturnTypeAnnotationUndefined = getIsReturnTypeAnnotationUndefined(targetNode);
 
     if (skipArrows === 'expressionsOnly' && isArrowFunctionExpression || skipArrows === true && isArrow || shouldFilterNode(functionNode)) {

--- a/src/rules/requireValidFileAnnotation.js
+++ b/src/rules/requireValidFileAnnotation.js
@@ -156,5 +156,8 @@ const create = (context) => {
 
 export default {
   create,
+  meta: {
+    fixable: 'code',
+  },
   schema,
 };

--- a/src/rules/semi.js
+++ b/src/rules/semi.js
@@ -5,6 +5,10 @@ const schema = [
   },
 ];
 
+const isSemicolon = (token) => {
+  return token.type === 'Punctuator' && token.value === ';';
+};
+
 const create = (context) => {
   const never = (context.options[0] || 'always') === 'never';
   const sourceCode = context.getSourceCode();
@@ -37,10 +41,6 @@ const create = (context) => {
     });
   };
 
-  const isSemicolon = (token) => {
-    return token.type === 'Punctuator' && token.value === ';';
-  };
-
   const checkForSemicolon = (node) => {
     const lastToken = sourceCode.getLastToken(node);
     const isLastTokenSemicolon = isSemicolon(lastToken);
@@ -67,5 +67,8 @@ const create = (context) => {
 
 export default {
   create,
+  meta: {
+    fixable: 'code',
+  },
   schema,
 };

--- a/src/rules/sortKeys.js
+++ b/src/rules/sortKeys.js
@@ -220,5 +220,8 @@ const create = (context) => {
 
 export default {
   create,
+  meta: {
+    fixable: 'code',
+  },
   schema,
 };

--- a/src/rules/spaceAfterTypeColon.js
+++ b/src/rules/spaceAfterTypeColon.js
@@ -26,5 +26,8 @@ const create = (context) => {
 
 export default {
   create,
+  meta: {
+    fixable: 'code',
+  },
   schema,
 };

--- a/src/rules/spaceBeforeGenericBracket.js
+++ b/src/rules/spaceBeforeGenericBracket.js
@@ -55,5 +55,8 @@ const create = (context) => {
 
 export default {
   create,
+  meta: {
+    fixable: 'code',
+  },
   schema,
 };

--- a/src/rules/spaceBeforeTypeColon.js
+++ b/src/rules/spaceBeforeTypeColon.js
@@ -15,5 +15,8 @@ const create = (context) => {
 
 export default {
   create,
+  meta: {
+    fixable: 'code',
+  },
   schema,
 };

--- a/src/rules/typeImportStyle.js
+++ b/src/rules/typeImportStyle.js
@@ -87,5 +87,8 @@ const create = (context) => {
 
 export default {
   create,
+  meta: {
+    fixable: 'code',
+  },
   schema,
 };

--- a/src/rules/unionIntersectionSpacing.js
+++ b/src/rules/unionIntersectionSpacing.js
@@ -75,5 +75,8 @@ const create = (context) => {
 
 export default {
   create,
+  meta: {
+    fixable: 'code',
+  },
   schema,
 };

--- a/src/utilities/checkFlowFileAnnotation.js
+++ b/src/utilities/checkFlowFileAnnotation.js
@@ -9,5 +9,6 @@ export default (cb, context) => {
     return () => {};
   }
 
+  // eslint-disable-next-line promise/prefer-await-to-callbacks -- not a promise callback
   return cb(context);
 };

--- a/src/utilities/fuzzyStringMatch.js
+++ b/src/utilities/fuzzyStringMatch.js
@@ -14,35 +14,34 @@ const arrayPairs = (array) => {
 
   return pairs;
 };
-/* eslint-enable */
+
+// Based on http://stackoverflow.com/a/23305385
+
+const stringSimilarity = (str1, str2) => {
+  if (str1.length > 0 && str2.length > 0) {
+    const pairs1 = arrayPairs(str1);
+    const pairs2 = arrayPairs(str2);
+    const unionLen = pairs1.length + pairs2.length;
+    let hitCount;
+
+    hitCount = 0;
+
+    _.forIn(pairs1, (val1) => {
+      _.forIn(pairs2, (val2) => {
+        if (_.isEqual(val1, val2)) {
+          hitCount++;
+        }
+      });
+    });
+
+    if (hitCount > 0) {
+      return 2 * hitCount / unionLen;
+    }
+  }
+
+  return 0;
+};
 
 export default (needle, haystack, weight = 0.5) => {
-  // Based on http://stackoverflow.com/a/23305385
-
-  const stringSimilarity = (str1, str2) => {
-    if (str1.length > 0 && str2.length > 0) {
-      const pairs1 = arrayPairs(str1);
-      const pairs2 = arrayPairs(str2);
-      const unionLen = pairs1.length + pairs2.length;
-      let hitCount;
-
-      hitCount = 0;
-
-      _.forIn(pairs1, (val1) => {
-        _.forIn(pairs2, (val2) => {
-          if (_.isEqual(val1, val2)) {
-            hitCount++;
-          }
-        });
-      });
-
-      if (hitCount > 0) {
-        return 2 * hitCount / unionLen;
-      }
-    }
-
-    return 0;
-  };
-
   return stringSimilarity(needle, haystack) >= Number(weight);
 };


### PR DESCRIPTION
I was going to work on an issue, so I did a fresh clone and an npm install - which installed the latest ESLint version.

The latest version of ESLint RuleTester has a hard requirement that all fixable rules declare `meta.fixable`.

This simply fixes that, and fixes the small number of lint errors that were in the codebase at the same time.