### PR TITLE
feat: Added rule objectTypeCurlySpacing

### DIFF
--- a/.README/README.md
+++ b/.README/README.md
@@ -171,6 +171,7 @@ When `true`, only checks files with a [`@flow` annotation](http://flowtype.org/d
 {"gitdown": "include", "file": "./rules/no-types-missing-file-annotation.md"}
 {"gitdown": "include", "file": "./rules/no-unused-expressions.md"}
 {"gitdown": "include", "file": "./rules/no-weak-types.md"}
+{"gitdown": "include", "file": "./rules/object-type-curly-spacing.md"}
 {"gitdown": "include", "file": "./rules/object-type-delimiter.md"}
 {"gitdown": "include", "file": "./rules/require-compound-type-alias.md"}
 {"gitdown": "include", "file": "./rules/require-exact-type.md"}

--- a/.README/rules/object-type-curly-spacing.md
+++ b/.README/rules/object-type-curly-spacing.md
@@ -1,0 +1,15 @@
+### `object-type-curly-spacing`
+
+_The `--fix` option on the command line automatically fixes problems reported by this rule._
+
+This rule enforces consistent spacing inside braces of object types.
+
+#### Options
+
+The rule has a string option:
+
+* `"never"` (default): disallows spacing inside of braces.
+* `"always"`: requires spacing inside of braces.
+
+
+<!-- assertions objectTypeCurlySpacing -->

--- a/README.md
+++ b/README.md
@@ -2520,14 +2520,23 @@ The following patterns are considered problems:
 
 ```js
 type obj = { "foo": "bar" }
-// Message: There should be no space after "{"
-// Message: There should be no space before "}"
+// Message: There should be no space after "{".
+// Message: There should be no space before "}".
 
 type obj = {"foo": "bar" }
-// Message: There should be no space before "}"
+// Message: There should be no space before "}".
+
+type obj = {"foo": "bar", ... }
+// Message: There should be no space before "}".
+
+type obj = {|"foo": "bar" |}
+// Message: There should be no space before "|}".
+
+type obj = {"foo": "bar", [key: string]: string }
+// Message: There should be no space before "}".
 
 type obj = { baz: {"foo": "qux"}, bar: 4}
-// Message: There should be no space after "{"
+// Message: There should be no space after "{".
 
 // Options: ["always"]
 type obj = {"foo": "bar"}
@@ -2547,6 +2556,18 @@ type obj = { baz: {"foo": "qux"}, bar: 4}
 // Options: ["always"]
 type obj = { baz: { "foo": "qux" }, bar: 4}
 // Message: A space is required before "}".
+
+// Options: ["always"]
+type obj = { "foo": "bar", ...}
+// Message: A space is required before "}".
+
+// Options: ["always"]
+type obj = {|"foo": "bar" |}
+// Message: A space is required after "{|".
+
+// Options: ["always"]
+type obj = {"foo": "bar", [key: string]: string }
+// Message: A space is required after "{".
 ```
 
 The following patterns are not considered problems:

--- a/README.md
+++ b/README.md
@@ -2588,6 +2588,10 @@ foo: "bar"}
 type obj = {
 foo: "bar"}
 
+type obj = {|"foo": "bar"|}
+
+type obj = {"foo": "bar", [key: string]: string}
+
 // Options: ["always"]
 type obj = { baz: { "foo": "qux" }, bar: 4 }
 
@@ -2601,6 +2605,12 @@ foo: "bar"
 
 // Options: ["always"]
 type obj = { baz: 4 }
+
+// Options: ["always"]
+type obj = {| "foo": "bar" |}
+
+// Options: ["always"]
+type obj = { "foo": "bar", [key: string]: string }
 ```
 
 

--- a/src/index.js
+++ b/src/index.js
@@ -17,6 +17,7 @@ import noTypesMissingFileAnnotation from './rules/noTypesMissingFileAnnotation';
 import noUnusedExpressions from './rules/noUnusedExpressions';
 import noWeakTypes from './rules/noWeakTypes';
 import noMixed from './rules/noMixed';
+import objectTypeCurlySpacing from './rules/objectTypeCurlySpacing';
 import objectTypeDelimiter from './rules/objectTypeDelimiter';
 import requireIndexerName from './rules/requireIndexerName';
 import requireCompoundTypeAlias from './rules/requireCompoundTypeAlias';
@@ -60,6 +61,7 @@ const rules = {
   'no-types-missing-file-annotation': noTypesMissingFileAnnotation,
   'no-unused-expressions': noUnusedExpressions,
   'no-weak-types': noWeakTypes,
+  'object-type-curly-spacing': objectTypeCurlySpacing,
   'object-type-delimiter': objectTypeDelimiter,
   'require-compound-type-alias': requireCompoundTypeAlias,
   'require-exact-type': requireExactType,
@@ -109,6 +111,7 @@ export default {
     'no-mixed': 0,
     'no-mutable-array': 0,
     'no-weak-types': 0,
+    'object-type-curly-spacing': 0,
     'object-type-delimiter': 0,
     'require-compound-type-alias': 0,
     'require-exact-type': 0,

--- a/src/rules/objectTypeCurlySpacing.js
+++ b/src/rules/objectTypeCurlySpacing.js
@@ -35,8 +35,11 @@ const create = (context) => {
         if (spacesBefore) {
           if (sourceCode.text[opener?.range[1]] !== '\n') {
             context.report({
+              data: {
+                token: opener.value,
+              },
               fix: spacingFixers.stripSpacesAfter(opener, spacesBefore),
-              message: 'There should be no space after "{"',
+              message: 'There should be no space after "{{token}}".',
               node,
             });
           }
@@ -44,8 +47,11 @@ const create = (context) => {
         if (spacesAfter) {
           if (sourceCode.text[closer?.range[0] - 1] !== '\n') {
             context.report({
+              data: {
+                token: closer.value,
+              },
               fix: spacingFixers.stripSpacesBefore(closer, spacesAfter),
-              message: 'There should be no space before "}"',
+              message: 'There should be no space before "{{token}}".',
               node,
             });
           }
@@ -53,28 +59,40 @@ const create = (context) => {
       } else {
         if (spacesBefore > 1) {
           context.report({
+            data: {
+              token: opener.value,
+            },
             fix: spacingFixers.stripSpacesAfter(opener, spacesBefore - 1),
-            message: 'Only one space is required after "{".',
+            message: 'Only one space is required after "{{token}}".',
             node,
           });
         } else if (spacesBefore === 0) {
           context.report({
+            data: {
+              token: opener.value,
+            },
             fix: spacingFixers.addSpaceAfter(opener),
-            message: 'A space is required after "{".',
+            message: 'A space is required after "{{token}}".',
             node,
           });
         }
 
         if (spacesAfter > 1) {
           context.report({
+            data: {
+              token: closer.value,
+            },
             fix: spacingFixers.stripSpacesAfter(lastInnerToken, spacesAfter - 1),
-            message: 'Only one space is required before "}".',
+            message: 'Only one space is required before "{{token}}".',
             node,
           });
         } else if (spacesAfter === 0) {
           context.report({
+            data: {
+              token: closer.value,
+            },
             fix: spacingFixers.addSpaceAfter(lastInnerToken),
-            message: 'A space is required before "}".',
+            message: 'A space is required before "{{token}}".',
             node,
           });
         }

--- a/src/rules/objectTypeCurlySpacing.js
+++ b/src/rules/objectTypeCurlySpacing.js
@@ -1,0 +1,90 @@
+import {spacingFixers} from '../utilities';
+
+const schema = [
+  {
+    enum: ['always', 'never'],
+    type: 'string',
+  },
+];
+
+const meta = {
+  fixable: 'code',
+};
+
+const create = (context) => {
+  const never = (context?.options[0] ?? 'never') === 'never';
+  const sourceCode = context.getSourceCode();
+
+  return {
+    ObjectTypeAnnotation (node) {
+      const {
+        properties,
+      } = node;
+
+      if (properties.length === 0) {
+        return;
+      }
+
+      const [opener, firstInnerToken] = sourceCode.getFirstTokens(node, 2);
+      const [lastInnerToken, closer] = sourceCode.getLastTokens(node, 2);
+
+      const spacesBefore = firstInnerToken.range[0] - opener.range[1];
+      const spacesAfter = closer.range[0] - lastInnerToken.range[1];
+
+      if (never) {
+        if (spacesBefore) {
+          if (sourceCode.text[opener?.range[1]] !== '\n') {
+            context.report({
+              fix: spacingFixers.stripSpacesAfter(opener, spacesBefore),
+              message: 'There should be no space after "{"',
+              node,
+            });
+          }
+        }
+        if (spacesAfter) {
+          if (sourceCode.text[closer?.range[0] - 1] !== '\n') {
+            context.report({
+              fix: spacingFixers.stripSpacesBefore(closer, spacesAfter),
+              message: 'There should be no space before "}"',
+              node,
+            });
+          }
+        }
+      } else {
+        if (spacesBefore > 1) {
+          context.report({
+            fix: spacingFixers.stripSpacesAfter(opener, spacesBefore - 1),
+            message: 'Only one space is required after "{".',
+            node,
+          });
+        } else if (spacesBefore === 0) {
+          context.report({
+            fix: spacingFixers.addSpaceAfter(opener),
+            message: 'A space is required after "{".',
+            node,
+          });
+        }
+
+        if (spacesAfter > 1) {
+          context.report({
+            fix: spacingFixers.stripSpacesAfter(lastInnerToken, spacesAfter - 1),
+            message: 'Only one space is required before "}".',
+            node,
+          });
+        } else if (spacesAfter === 0) {
+          context.report({
+            fix: spacingFixers.addSpaceAfter(lastInnerToken),
+            message: 'A space is required before "}".',
+            node,
+          });
+        }
+      }
+    },
+  };
+};
+
+export default {
+  create,
+  meta,
+  schema,
+};

--- a/tests/rules/assertions/objectTypeCurlySpacing.js
+++ b/tests/rules/assertions/objectTypeCurlySpacing.js
@@ -4,43 +4,43 @@ export default {
     {
       code: 'type obj = { "foo": "bar" }',
       errors: [
-        {message: 'There should be no space after "{"'},
-        {message: 'There should be no space before "}"'},
+        {message: 'There should be no space after "{".'},
+        {message: 'There should be no space before "}".'},
       ],
       output: 'type obj = {"foo": "bar"}',
     },
     {
       code: 'type obj = {"foo": "bar" }',
       errors: [
-        {message: 'There should be no space before "}"'},
+        {message: 'There should be no space before "}".'},
       ],
       output: 'type obj = {"foo": "bar"}',
     },
     {
       code: 'type obj = {"foo": "bar", ... }',
       errors: [
-        {message: 'There should be no space before "}"'},
+        {message: 'There should be no space before "}".'},
       ],
       output: 'type obj = {"foo": "bar", ...}',
     },
     {
       code: 'type obj = {|"foo": "bar" |}',
       errors: [
-        {message: 'There should be no space before "}"'},
+        {message: 'There should be no space before "|}".'},
       ],
       output: 'type obj = {|"foo": "bar"|}',
     },
     {
       code: 'type obj = {"foo": "bar", [key: string]: string }',
       errors: [
-        {message: 'There should be no space before "}"'},
+        {message: 'There should be no space before "}".'},
       ],
       output: 'type obj = {"foo": "bar", [key: string]: string}',
     },
     {
       code: 'type obj = { baz: {"foo": "qux"}, bar: 4}',
       errors: [
-        {message: 'There should be no space after "{"'},
+        {message: 'There should be no space after "{".'},
       ],
       output: 'type obj = {baz: {"foo": "qux"}, bar: 4}',
     },
@@ -80,6 +80,30 @@ export default {
       ],
       options: ['always'],
       output: 'type obj = { baz: { "foo": "qux" }, bar: 4 }',
+    },
+    {
+      code: 'type obj = { "foo": "bar", ...}',
+      errors: [
+        {message: 'A space is required before "}".'},
+      ],
+      options: ['always'],
+      output: 'type obj = { "foo": "bar", ... }',
+    },
+    {
+      code: 'type obj = {|"foo": "bar" |}',
+      errors: [
+        {message: 'A space is required after "{|".'},
+      ],
+      options: ['always'],
+      output: 'type obj = {| "foo": "bar" |}',
+    },
+    {
+      code: 'type obj = {"foo": "bar", [key: string]: string }',
+      errors: [
+        {message: 'A space is required after "{".'},
+      ],
+      options: ['always'],
+      output: 'type obj = { "foo": "bar", [key: string]: string }',
     },
   ],
   misconfigured: [

--- a/tests/rules/assertions/objectTypeCurlySpacing.js
+++ b/tests/rules/assertions/objectTypeCurlySpacing.js
@@ -17,6 +17,27 @@ export default {
       output: 'type obj = {"foo": "bar"}',
     },
     {
+      code: 'type obj = {"foo": "bar", ... }',
+      errors: [
+        {message: 'There should be no space before "}"'},
+      ],
+      output: 'type obj = {"foo": "bar", ...}',
+    },
+    {
+      code: 'type obj = {|"foo": "bar" |}',
+      errors: [
+        {message: 'There should be no space before "}"'},
+      ],
+      output: 'type obj = {|"foo": "bar"|}',
+    },
+    {
+      code: 'type obj = {"foo": "bar", [key: string]: string }',
+      errors: [
+        {message: 'There should be no space before "}"'},
+      ],
+      output: 'type obj = {"foo": "bar", [key: string]: string}',
+    },
+    {
       code: 'type obj = { baz: {"foo": "qux"}, bar: 4}',
       errors: [
         {message: 'There should be no space after "{"'},

--- a/tests/rules/assertions/objectTypeCurlySpacing.js
+++ b/tests/rules/assertions/objectTypeCurlySpacing.js
@@ -1,0 +1,122 @@
+export default {
+  invalid: [
+    // Never
+    {
+      code: 'type obj = { "foo": "bar" }',
+      errors: [
+        {message: 'There should be no space after "{"'},
+        {message: 'There should be no space before "}"'},
+      ],
+      output: 'type obj = {"foo": "bar"}',
+    },
+    {
+      code: 'type obj = {"foo": "bar" }',
+      errors: [
+        {message: 'There should be no space before "}"'},
+      ],
+      output: 'type obj = {"foo": "bar"}',
+    },
+    {
+      code: 'type obj = { baz: {"foo": "qux"}, bar: 4}',
+      errors: [
+        {message: 'There should be no space after "{"'},
+      ],
+      output: 'type obj = {baz: {"foo": "qux"}, bar: 4}',
+    },
+
+    // Always
+    {
+      code: 'type obj = {"foo": "bar"}',
+      errors: [
+        {message: 'A space is required after "{".'},
+        {message: 'A space is required before "}".'},
+      ],
+      options: ['always'],
+      output: 'type obj = { "foo": "bar" }',
+    },
+    {
+      code: 'type obj = {"foo": "bar" }',
+      errors: [
+        {message: 'A space is required after "{".'},
+      ],
+      options: ['always'],
+      output: 'type obj = { "foo": "bar" }',
+    },
+    {
+      code: 'type obj = { baz: {"foo": "qux"}, bar: 4}',
+      errors: [
+        {message: 'A space is required before "}".'},
+        {message: 'A space is required after "{".'},
+        {message: 'A space is required before "}".'},
+      ],
+      options: ['always'],
+      output: 'type obj = { baz: { "foo": "qux" }, bar: 4 }',
+    },
+    {
+      code: 'type obj = { baz: { "foo": "qux" }, bar: 4}',
+      errors: [
+        {message: 'A space is required before "}".'},
+      ],
+      options: ['always'],
+      output: 'type obj = { baz: { "foo": "qux" }, bar: 4 }',
+    },
+  ],
+  misconfigured: [
+    {
+      errors: [
+        {
+          data: 'sometimes',
+          dataPath: '[0]',
+          keyword: 'enum',
+          message: 'should be equal to one of the allowed values',
+          params: {
+            allowedValues: [
+              'always',
+              'never',
+            ],
+          },
+          parentSchema: {
+            enum: [
+              'always',
+              'never',
+            ],
+            type: 'string',
+          },
+          schema: [
+            'always',
+            'never',
+          ],
+          schemaPath: '#/items/0/enum',
+        },
+      ],
+      options: ['sometimes'],
+    },
+  ],
+  valid: [
+    // Never
+    {code: 'type obj = {baz: {"foo": "qux"}, bar: 4}'},
+    {code: 'type obj = {foo: {"foo": "qux"}}'},
+    {code: 'type obj = {foo: "bar"}'},
+    {code: 'type obj = {foo: "bar"\n}'},
+    {code: 'type obj = {\nfoo: "bar"}'},
+    {code: 'type obj = {\nfoo: "bar"}'},
+
+    // Always
+    {
+      code: 'type obj = { baz: { "foo": "qux" }, bar: 4 }',
+      options: ['always'],
+    },
+    {
+      code: 'type obj = {}',
+      options: ['always'],
+    },
+    {
+      code: 'type obj = {\nfoo: "bar"\n}',
+      options: ['always'],
+    },
+    {
+      code: 'type obj = { baz: 4 }',
+      options: ['always'],
+    },
+  ],
+};

--- a/tests/rules/assertions/objectTypeCurlySpacing.js
+++ b/tests/rules/assertions/objectTypeCurlySpacing.js
@@ -145,6 +145,8 @@ export default {
     {code: 'type obj = {foo: "bar"\n}'},
     {code: 'type obj = {\nfoo: "bar"}'},
     {code: 'type obj = {\nfoo: "bar"}'},
+    {code: 'type obj = {|"foo": "bar"|}'},
+    {code: 'type obj = {"foo": "bar", [key: string]: string}'},
 
     // Always
     {
@@ -161,6 +163,14 @@ export default {
     },
     {
       code: 'type obj = { baz: 4 }',
+      options: ['always'],
+    },
+    {
+      code: 'type obj = {| "foo": "bar" |}',
+      options: ['always'],
+    },
+    {
+      code: 'type obj = { "foo": "bar", [key: string]: string }',
       options: ['always'],
     },
   ],

--- a/tests/rules/index.js
+++ b/tests/rules/index.js
@@ -28,6 +28,7 @@ const reportingRules = [
   'no-unused-expressions',
   'no-weak-types',
   'no-mixed',
+  'object-type-curly-spacing',
   'object-type-delimiter',
   'require-compound-type-alias',
   'require-inexact-type',


### PR DESCRIPTION
Added new rule `objectTypeCurlySpacing`  that enforces consistent spacing inside braces of object types.

Options: never (default) or always

Never (default)
```
// Correct
type Y = {foo: "bar"};

// Incorrect
type N = { foo: "bar" };
```

Always
```
// Options: ["always"]
// Correct
type Y = { foo: "bar" };

// Incorrect
type N = {foo: "bar"};
type Z = {foo: "bar" };
type X = { foo: "bar"};
```
@gajus 
Note: 
Closes #146 