### PR TITLE
fix: object-type-curly-spacing should not throw errors on multiple spaces on option always 

### DIFF
--- a/README.md
+++ b/README.md
@@ -2611,6 +2611,14 @@ type obj = {| "foo": "bar" |}
 
 // Options: ["always"]
 type obj = { "foo": "bar", [key: string]: string }
+
+// Options: ["always"]
+type obj = {  baz: { "foo": "qux" }, bar: 4  }
+
+// Options: ["always"]
+type obj = {
+  baz: { "foo": "qux" }, bar: 4
+}
 ```
 
 

--- a/src/rules/objectTypeCurlySpacing.js
+++ b/src/rules/objectTypeCurlySpacing.js
@@ -57,16 +57,7 @@ const create = (context) => {
           }
         }
       } else {
-        if (spacesBefore > 1) {
-          context.report({
-            data: {
-              token: opener.value,
-            },
-            fix: spacingFixers.stripSpacesAfter(opener, spacesBefore - 1),
-            message: 'Only one space is required after "{{token}}".',
-            node,
-          });
-        } else if (spacesBefore === 0) {
+        if (!spacesBefore) {
           context.report({
             data: {
               token: opener.value,
@@ -77,16 +68,7 @@ const create = (context) => {
           });
         }
 
-        if (spacesAfter > 1) {
-          context.report({
-            data: {
-              token: closer.value,
-            },
-            fix: spacingFixers.stripSpacesAfter(lastInnerToken, spacesAfter - 1),
-            message: 'Only one space is required before "{{token}}".',
-            node,
-          });
-        } else if (spacesAfter === 0) {
+        if (!spacesAfter) {
           context.report({
             data: {
               token: closer.value,

--- a/tests/rules/assertions/objectTypeCurlySpacing.js
+++ b/tests/rules/assertions/objectTypeCurlySpacing.js
@@ -173,5 +173,13 @@ export default {
       code: 'type obj = { "foo": "bar", [key: string]: string }',
       options: ['always'],
     },
+    {
+      code: 'type obj = {  baz: { "foo": "qux" }, bar: 4  }',
+      options: ['always'],
+    },
+    {
+      code: 'type obj = {\n  baz: { "foo": "qux" }, bar: 4\n}',
+      options: ['always'],
+    },
   ],
 };


### PR DESCRIPTION
Fix errors where on `options: ["always"]` the rule threw errors when there was more than 1 space present from the first and last tokens. 

```
// Options: ["always"] 
type z = {
  foo: "bar",
  raz: "yar",
};
```

@gajus 