### PR TITLE
docs: regenerate README.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,10 +31,6 @@ Run them with `npm test`.
 
 Run with `npm run lint`.
 
-## Submitting a PR
-
-Just before submitting a PR, run `npm run create-readme` to generate the new README.md
-
 ## Adding a Rule
 
 ### Source & Tests
@@ -51,7 +47,6 @@ Just before submitting a PR, run `npm run create-readme` to generate the new REA
   * Use [./.README/rules/require-valid-file-annotation.md](./.README/rules/require-valid-file-annotation.md) as a template.
   * Ensure that rule documentation document includes `<!-- assertions spaceAfterTypeColon -->` declaration.
 1. Update [./.README/README.md](/.README/README.md) to include the new rule.
-
-A CI service will build and publish the new documentation.
+1. Run `npm run create-readme` to generate the new `README.md` (you should be on `master` branch for this command to work)
 
 Note: Sections "The following patterns are considered problems:" and "The following patterns are not considered problems:" are **generated automatically** using the test cases.

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@
         * [`no-dupe-keys`](#eslint-plugin-flowtype-rules-no-dupe-keys)
         * [`no-existential-type`](#eslint-plugin-flowtype-rules-no-existential-type)
         * [`no-flow-fix-me-comments`](#eslint-plugin-flowtype-rules-no-flow-fix-me-comments)
+        * [`no-internal-flow-type`](#eslint-plugin-flowtype-rules-no-internal-flow-type)
         * [`no-mixed`](#eslint-plugin-flowtype-rules-no-mixed)
         * [`no-mutable-array`](#eslint-plugin-flowtype-rules-no-mutable-array)
         * [`no-primitive-constructor-types`](#eslint-plugin-flowtype-rules-no-primitive-constructor-types)
@@ -2016,6 +2017,88 @@ const text = 'HELLO';
 // Options: ["TODO [0-9]+"]
 // $FlowFixMe TODO 48
 const text = 'HELLO';
+```
+
+
+
+<a name="eslint-plugin-flowtype-rules-no-internal-flow-type"></a>
+### <code>no-internal-flow-type</code>
+
+Warns against using internal Flow types such as `React$Node`, `React$Ref` and others and suggests using public alternatives instead (`React.Node`, `React.Ref`, …).
+
+The following patterns are considered problems:
+
+```js
+type X = React$AbstractComponent<Config, Instance>
+// Message: Type identifier 'React$AbstractComponent' is not allowed. Use 'React.AbstractComponent' instead.
+
+type X = React$ChildrenArray<string>
+// Message: Type identifier 'React$ChildrenArray' is not allowed. Use 'React.ChildrenArray' instead.
+
+type X = React$ComponentType<Props>
+// Message: Type identifier 'React$ComponentType' is not allowed. Use 'React.ComponentType' instead.
+
+type X = React$Config<Prosp, DefaultProps>
+// Message: Type identifier 'React$Config' is not allowed. Use 'React.Config' instead.
+
+type X = React$Element<typeof Component>
+// Message: Type identifier 'React$Element' is not allowed. Use 'React.Element' instead.
+
+type X = React$ElementConfig<typeof Component>
+// Message: Type identifier 'React$ElementConfig' is not allowed. Use 'React.ElementConfig' instead.
+
+type X = React$ElementProps<typeof Component>
+// Message: Type identifier 'React$ElementProps' is not allowed. Use 'React.ElementProps' instead.
+
+type X = React$ElementRef<typeof Component>
+// Message: Type identifier 'React$ElementRef' is not allowed. Use 'React.ElementRef' instead.
+
+type X = React$ElementType
+// Message: Type identifier 'React$ElementType' is not allowed. Use 'React.ElementType' instead.
+
+type X = React$Key
+// Message: Type identifier 'React$Key' is not allowed. Use 'React.Key' instead.
+
+type X = React$Node
+// Message: Type identifier 'React$Node' is not allowed. Use 'React.Node' instead.
+
+type X = React$Ref<typeof Component>
+// Message: Type identifier 'React$Ref' is not allowed. Use 'React.Ref' instead.
+
+type X = React$StatelessFunctionalComponent<Props>
+// Message: Type identifier 'React$StatelessFunctionalComponent' is not allowed. Use 'React.StatelessFunctionalComponent' instead.
+```
+
+The following patterns are not considered problems:
+
+```js
+type X = React.AbstractComponent<Config, Instance>
+
+type X = React.ChildrenArray<string>
+
+type X = React.ComponentType<Props>
+
+type X = React.Config<Props, DefaultProps>
+
+type X = React.Element<typeof Component>
+
+type X = React.ElementConfig<typeof Component>
+
+type X = React.ElementProps<typeof Component>
+
+type X = React.ElementRef<typeof Component>
+
+type X = React.ElementType
+
+type X = React.Key
+
+type X = React.Node
+
+type X = React.Ref<typeof Component>
+
+type X = React.StatelessFunctionalComponent<Props>
+
+type X = React$Rocks
 ```
 
 

--- a/tests/rules/assertions/noInternalFlowType.js
+++ b/tests/rules/assertions/noInternalFlowType.js
@@ -3,69 +3,95 @@ export default {
     {
       code: 'type X = React$AbstractComponent<Config, Instance>',
       errors: [
-        'Type identifier \'React$AbstractComponent\' is not allowed. Use \'React.AbstractComponent\' instead.',
+        {
+          message: 'Type identifier \'React$AbstractComponent\' is not allowed. Use \'React.AbstractComponent\' instead.',
+        },
       ],
     },
     {
       code: 'type X = React$ChildrenArray<string>',
       errors: [
-        'Type identifier \'React$ChildrenArray\' is not allowed. Use \'React.ChildrenArray\' instead.',
+        {
+          message: 'Type identifier \'React$ChildrenArray\' is not allowed. Use \'React.ChildrenArray\' instead.',
+        },
       ],
     },
     {
       code: 'type X = React$ComponentType<Props>',
       errors: [
-        'Type identifier \'React$ComponentType\' is not allowed. Use \'React.ComponentType\' instead.',
+        {
+          message: 'Type identifier \'React$ComponentType\' is not allowed. Use \'React.ComponentType\' instead.',
+        },
       ],
     },
     {
       code: 'type X = React$Config<Prosp, DefaultProps>',
-      errors: ['Type identifier \'React$Config\' is not allowed. Use \'React.Config\' instead.'],
+      errors: [{
+        message: 'Type identifier \'React$Config\' is not allowed. Use \'React.Config\' instead.',
+      }],
     },
     {
       code: 'type X = React$Element<typeof Component>',
-      errors: ['Type identifier \'React$Element\' is not allowed. Use \'React.Element\' instead.'],
+      errors: [{
+        message: 'Type identifier \'React$Element\' is not allowed. Use \'React.Element\' instead.',
+      }],
     },
     {
       code: 'type X = React$ElementConfig<typeof Component>',
       errors: [
-        'Type identifier \'React$ElementConfig\' is not allowed. Use \'React.ElementConfig\' instead.',
+        {
+          message: 'Type identifier \'React$ElementConfig\' is not allowed. Use \'React.ElementConfig\' instead.',
+        },
       ],
     },
     {
       code: 'type X = React$ElementProps<typeof Component>',
       errors: [
-        'Type identifier \'React$ElementProps\' is not allowed. Use \'React.ElementProps\' instead.',
+        {
+          message: 'Type identifier \'React$ElementProps\' is not allowed. Use \'React.ElementProps\' instead.',
+        },
       ],
     },
     {
       code: 'type X = React$ElementRef<typeof Component>',
       errors: [
-        'Type identifier \'React$ElementRef\' is not allowed. Use \'React.ElementRef\' instead.',
+        {
+          message: 'Type identifier \'React$ElementRef\' is not allowed. Use \'React.ElementRef\' instead.',
+        },
       ],
     },
     {
       code: 'type X = React$ElementType',
       errors: [
-        'Type identifier \'React$ElementType\' is not allowed. Use \'React.ElementType\' instead.',
+        {
+          message: 'Type identifier \'React$ElementType\' is not allowed. Use \'React.ElementType\' instead.',
+        },
       ],
     },
     {
       code: 'type X = React$Key',
-      errors: ['Type identifier \'React$Key\' is not allowed. Use \'React.Key\' instead.'],
+      errors: [{
+        message: 'Type identifier \'React$Key\' is not allowed. Use \'React.Key\' instead.',
+      }],
     },
     {
       code: 'type X = React$Node',
-      errors: ['Type identifier \'React$Node\' is not allowed. Use \'React.Node\' instead.'],
+      errors: [{
+        message: 'Type identifier \'React$Node\' is not allowed. Use \'React.Node\' instead.',
+      }],
     },
     {
       code: 'type X = React$Ref<typeof Component>',
-      errors: ['Type identifier \'React$Ref\' is not allowed. Use \'React.Ref\' instead.'],
+      errors: [{
+        message: 'Type identifier \'React$Ref\' is not allowed. Use \'React.Ref\' instead.',
+      }],
     },
     {
       code: 'type X = React$StatelessFunctionalComponent<Props>',
       errors: [
-        'Type identifier \'React$StatelessFunctionalComponent\' is not allowed. Use \'React.StatelessFunctionalComponent\' instead.',
+        {
+          message: 'Type identifier \'React$StatelessFunctionalComponent\' is not allowed. Use \'React.StatelessFunctionalComponent\' instead.',
+        },
       ],
     },
   ],


### PR DESCRIPTION
Followup after https://github.com/gajus/eslint-plugin-flowtype/commit/fd838c3dce0e5917d7a26ed8074645b2d510cd68

I didn't generate the docs because I misunderstood the contribution guide. This commit fixes it and updates the contribution guide a little bit.