### PR TITLE
feat: add support for implicit exact Flow types

### DIFF
--- a/.README/rules/require-readonly-react-props.md
+++ b/.README/rules/require-readonly-react-props.md
@@ -79,4 +79,21 @@ class Bar extends React.Component<Props> { }
 ```
 
 
+Optionally, you can enable support for [implicit exact Flow types](https://medium.com/flow-type/on-the-roadmap-exact-objects-by-default-16b72933c5cf) (useful when using `exact_by_default=true` Flow option):
+
+
+```js
+{
+    "rules": {
+        "flowtype/require-readonly-react-props": [
+            2,
+            {
+                "useImplicitExactTypes": true
+            }
+        ]
+    }
+}
+```
+
+
 <!-- assertions requireReadonlyReactProps -->

--- a/README.md
+++ b/README.md
@@ -3461,6 +3461,23 @@ class Bar extends React.Component<Props> { }
 ```
 
 
+Optionally, you can enable support for [implicit exact Flow types](https://medium.com/flow-type/on-the-roadmap-exact-objects-by-default-16b72933c5cf) (useful when using `exact_by_default=true` Flow option):
+
+
+```js
+{
+    "rules": {
+        "flowtype/require-readonly-react-props": [
+            2,
+            {
+                "useImplicitExactTypes": true
+            }
+        ]
+    }
+}
+```
+
+
 The following patterns are considered problems:
 
 ```js
@@ -3540,7 +3557,19 @@ type Props = $FlowFixMe; class Foo extends Component<Props> { }
 
 type Props = {||}; class Foo extends Component<Props> { }
 
+// Options: [{"useImplicitExactTypes":true}]
+type Props = {||}; class Foo extends Component<Props> { }
+
+// Options: [{"useImplicitExactTypes":true}]
+type Props = {}; class Foo extends Component<Props> { }
+
 class Foo extends Component<{||}> { }
+
+// Options: [{"useImplicitExactTypes":true}]
+class Foo extends Component<{||}> { }
+
+// Options: [{"useImplicitExactTypes":true}]
+class Foo extends Component<{}> { }
 
 class Foo extends React.Component<UnknownProps> { }
 
@@ -3557,6 +3586,12 @@ function Foo() { return <p /> }
 function Foo(props: $FlowFixMe) { return <p /> }
 
 function Foo(props: {||}) { return <p /> }
+
+// Options: [{"useImplicitExactTypes":true}]
+function Foo(props: {||}) { return <p /> }
+
+// Options: [{"useImplicitExactTypes":true}]
+function Foo(props: {}) { return <p /> }
 ```
 
 

--- a/tests/rules/assertions/requireReadonlyReactProps.js
+++ b/tests/rules/assertions/requireReadonlyReactProps.js
@@ -166,7 +166,39 @@ export default {
       code: 'type Props = {||}; class Foo extends Component<Props> { }',
     },
     {
+      code: 'type Props = {||}; class Foo extends Component<Props> { }',
+      options: [
+        {
+          useImplicitExactTypes: true,
+        },
+      ],
+    },
+    {
+      code: 'type Props = {}; class Foo extends Component<Props> { }',
+      options: [
+        {
+          useImplicitExactTypes: true,
+        },
+      ],
+    },
+    {
       code: 'class Foo extends Component<{||}> { }',
+    },
+    {
+      code: 'class Foo extends Component<{||}> { }',
+      options: [
+        {
+          useImplicitExactTypes: true,
+        },
+      ],
+    },
+    {
+      code: 'class Foo extends Component<{}> { }',
+      options: [
+        {
+          useImplicitExactTypes: true,
+        },
+      ],
     },
     {
       code: 'class Foo extends React.Component<UnknownProps> { }',
@@ -193,6 +225,22 @@ export default {
     },
     {
       code: 'function Foo(props: {||}) { return <p /> }',
+    },
+    {
+      code: 'function Foo(props: {||}) { return <p /> }',
+      options: [
+        {
+          useImplicitExactTypes: true,
+        },
+      ],
+    },
+    {
+      code: 'function Foo(props: {}) { return <p /> }',
+      options: [
+        {
+          useImplicitExactTypes: true,
+        },
+      ],
     },
   ],
 };


### PR DESCRIPTION
This commit adds a support for implicit exact Flow types. This is especially useful when using `exact_by_default=true` Flow option and migrating towards `{ }` and `{ ... }` syntax (Flow standard is now to use `{ }` for strict objects and `{ key: value, ... }` for open objects).

Closes: https://github.com/gajus/eslint-plugin-flowtype/issues/467

TODO:

- [x] rebase after https://github.com/gajus/eslint-plugin-flowtype/pull/470
- [x] regenerate docs