### PR TITLE
fix: fix read-only React props error position

### DIFF
--- a/src/rules/requireReadonlyReactProps.js
+++ b/src/rules/requireReadonlyReactProps.js
@@ -144,7 +144,7 @@ const create = (context) => {
 
           context.report({
             message: identifier.name + ' must be $ReadOnly',
-            node,
+            node: identifier,
           });
 
           reportedFunctionalComponents.push(identifier);

--- a/tests/rules/assertions/requireReadonlyReactProps.js
+++ b/tests/rules/assertions/requireReadonlyReactProps.js
@@ -85,9 +85,14 @@ export default {
 
     // functional components
     {
+      //                                           vvvvv
       code: 'type Props = { }; function Foo(props: Props) { return <p /> }',
       errors: [
         {
+          column: 39,
+          endColumn: 44,
+          endLine: 1,
+          line: 1,
           message: 'Props must be $ReadOnly',
         },
       ],


### PR DESCRIPTION
Example from our repo before this change:

```
error: Props must be $ReadOnly (flowtype/require-readonly-react-props) at src/kochka.com.mx/src/Layout.js:39:7:
  37 |   return (
  38 |     <>
> 39 |       <Head>
     |       ^
  40 |         <title>KOCHKA café · {props.title}</title>
  41 |       </Head>
  42 |
```

As you can see the error seems to be wrongly positioned. This is even more awkward when you want to suppress this error (and you have to do it on some unrelated line).

After this fix:

```
error: Props must be $ReadOnly (flowtype/require-readonly-react-props) at src/kochka.com.mx/src/Layout.js:28:39:
  26 |     };
  27 |
> 28 | export default function Layout(props: Props): React.Node {
     |                                       ^
  29 |   if (props.withHiddenTitle === true) {
  30 |     invariant(props.title == null, 'Cannot use `title` together with `withHiddenTitle` property.');
  31 |     invariant(
```