### PR TITLE
chore: update recommended config to @babel/eslint-parser

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
   "main": "./dist/index.js",
   "name": "eslint-plugin-flowtype",
   "peerDependencies": {
+    "@babel/eslint-parser": "^7.12.0",
     "eslint": "^7.1.0"
   },
   "repository": {

--- a/src/configs/recommended.json
+++ b/src/configs/recommended.json
@@ -1,5 +1,5 @@
 {
-  "parser": "babel-eslint",
+  "parser": "@babel/eslint-parser",
   "plugins": [
     "flowtype"
   ],


### PR DESCRIPTION
Closes #474

Recommended config now uses @babel/eslint-parser. This should be a breaking change for consumers, the only difference should be that eslint how uses a projects babel config to read files which may cause issues if the babel config has exclusions setup based on environment variables that don't play nice with eslint.

This should be a major version bump.

@wilt-rally @gajus 