### PR TITLE
fix: object-type-curly-spacing should not trim multi-line expressions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2620,6 +2620,10 @@ type obj = {|"foo": "bar" |}
 type obj = {"foo": "bar", [key: string]: string }
 // Message: There should be no space before "}".
 
+type obj = {
+"foo": "bar", [key: string]: string }
+// Message: There should be no space before "}".
+
 type obj = { baz: {"foo": "qux"}, bar: 4}
 // Message: There should be no space after "{".
 
@@ -2671,7 +2675,18 @@ type obj = {
 foo: "bar"}
 
 type obj = {
-foo: "bar"}
+foo: "bar"
+}
+
+type obj = {
+foo: "bar",
+ee: "bar",
+}
+
+type obj = {
+foo: "bar",
+ee: "bar",
+             }
 
 type obj = {|"foo": "bar"|}
 

--- a/tests/rules/assertions/objectTypeCurlySpacing.js
+++ b/tests/rules/assertions/objectTypeCurlySpacing.js
@@ -38,6 +38,13 @@ export default {
       output: 'type obj = {"foo": "bar", [key: string]: string}',
     },
     {
+      code: 'type obj = {\n"foo": "bar", [key: string]: string }',
+      errors: [
+        {message: 'There should be no space before "}".'},
+      ],
+      output: 'type obj = {\n"foo": "bar", [key: string]: string}',
+    },
+    {
       code: 'type obj = { baz: {"foo": "qux"}, bar: 4}',
       errors: [
         {message: 'There should be no space after "{".'},
@@ -144,7 +151,9 @@ export default {
     {code: 'type obj = {foo: "bar"}'},
     {code: 'type obj = {foo: "bar"\n}'},
     {code: 'type obj = {\nfoo: "bar"}'},
-    {code: 'type obj = {\nfoo: "bar"}'},
+    {code: 'type obj = {\nfoo: "bar"\n}'},
+    {code: 'type obj = {\nfoo: "bar",\nee: "bar",\n}'},
+    {code: 'type obj = {\nfoo: "bar",\nee: "bar",\n             }'},
     {code: 'type obj = {|"foo": "bar"|}'},
     {code: 'type obj = {"foo": "bar", [key: string]: string}'},
 


### PR DESCRIPTION
closes #480 
`object-type-curly-spacing` does not get triggered when the token and brace are not on the same line.

2 Scenarios: 
-  **opening brace & first token** must be on the same line
- **closing brace & last token** must be on the same line

The following are valid under the `object-type-curly-spacing` rule: 

Option: Never 
```
type bar = {
  rew: string,
  yup: string,}

type bar = {
  rew: string,
  yup: string,
}

type bar = {
  rew: string,
  yup: string,
                }
```

Option: Always 
```
type bar = {
  rew: string,
  yup: string, }

type bar = {
  rew: string,
  yup: string,
}

type bar = { 
  rew: string,
  yup: string,
                }
```

@gajus 