### PR TITLE
feat: add new rule enforce-line-break

### DIFF
--- a/.README/README.md
+++ b/.README/README.md
@@ -160,6 +160,7 @@ When `true`, only checks files with a [`@flow` annotation](http://flowtype.org/d
 {"gitdown": "include", "file": "./rules/boolean-style.md"}
 {"gitdown": "include", "file": "./rules/define-flow-type.md"}
 {"gitdown": "include", "file": "./rules/delimiter-dangle.md"}
+{"gitdown": "include", "file": "./rules/enforce-line-break.md"}
 {"gitdown": "include", "file": "./rules/generic-spacing.md"}
 {"gitdown": "include", "file": "./rules/newline-after-flow-annotation.md"}
 {"gitdown": "include", "file": "./rules/no-dupe-keys.md"}

--- a/.README/rules/enforce-line-break.md
+++ b/.README/rules/enforce-line-break.md
@@ -1,0 +1,5 @@
+### `enforce-line-break`
+
+This rule enforces line breaks between type definitions.
+
+<!-- assertions enforceLineBreak -->

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@
         * [`boolean-style`](#eslint-plugin-flowtype-rules-boolean-style)
         * [`define-flow-type`](#eslint-plugin-flowtype-rules-define-flow-type)
         * [`delimiter-dangle`](#eslint-plugin-flowtype-rules-delimiter-dangle)
+        * [`enforce-line-break`](#eslint-plugin-flowtype-rules-enforce-line-break)
         * [`generic-spacing`](#eslint-plugin-flowtype-rules-generic-spacing)
         * [`newline-after-flow-annotation`](#eslint-plugin-flowtype-rules-newline-after-flow-annotation)
         * [`no-dupe-keys`](#eslint-plugin-flowtype-rules-no-dupe-keys)
@@ -1658,6 +1659,79 @@ type X = []
 
 // Options: ["only-multiline"]
 type X = []
+```
+
+
+
+<a name="eslint-plugin-flowtype-rules-enforce-line-break"></a>
+### <code>enforce-line-break</code>
+
+This rule enforces line breaks between type definitions.
+
+The following patterns are considered problems:
+
+```js
+
+type baz = 6;
+const hi = 2;
+
+// Message: Please enter a line below type declaration
+
+type foo = 6;
+type hi = 2;
+
+// Message: Please enter a line above type declaration
+
+type res = 6;
+type rod = 2;
+
+// Message: Please enter a line above type declaration
+
+const som = "jes";
+// a comment
+type fed = "hed";
+// Message: Please enter a line above type declaration
+// Message: Please enter a line below type declaration
+```
+
+The following patterns are not considered problems:
+
+```js
+type gjs = 6;
+
+type gjs = 6;
+
+type hi = 2;
+
+
+type X = 4;
+
+const red = "serpent";
+console.log("hello");
+
+// number or string
+type Y = string | number;
+
+// resting + sleep
+type snooze = "dreaming" | "";
+
+
+type Props = {
+  accountBalance: string | number,
+  accountNumber: string | number,
+};
+
+const x = 4;
+
+// Some Comment
+type Props = {
+  accountBalance: string | number,
+  accountNumber: string | number,
+};
+
+type RoadT = "grass" | "gravel" | "cement";
+
+
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -1671,27 +1671,33 @@ This rule enforces line breaks between type definitions.
 The following patterns are considered problems:
 
 ```js
-
 type baz = 6;
 const hi = 2;
-
 // Message: Please enter a line below type declaration
 
-type foo = 6;
+const foo = 6;
 type hi = 2;
-
-// Message: Please enter a line above type declaration
-
-type res = 6;
-type rod = 2;
 
 // Message: Please enter a line above type declaration
 
 const som = "jes";
 // a comment
 type fed = "hed";
+
 // Message: Please enter a line above type declaration
+
+type som = "jes";
+// a comment
+const fed = "hed";
+
 // Message: Please enter a line below type declaration
+
+type hello = 34;
+const som = "jes";
+type fed = "hed";
+
+// Message: Please enter a line below type declaration
+// Message: Please enter a line above type declaration
 ```
 
 The following patterns are not considered problems:
@@ -1715,13 +1721,13 @@ type Y = string | number;
 // resting + sleep
 type snooze = "dreaming" | "";
 
-
 type Props = {
   accountBalance: string | number,
   accountNumber: string | number,
 };
 
 const x = 4;
+const y = 489;
 
 // Some Comment
 type Props = {
@@ -1730,8 +1736,6 @@ type Props = {
 };
 
 type RoadT = "grass" | "gravel" | "cement";
-
-
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -1673,31 +1673,31 @@ The following patterns are considered problems:
 ```js
 type baz = 6;
 const hi = 2;
-// Message: Please enter a line below type declaration
+// Message: New line required below type declaration
 
 const foo = 6;
 type hi = 2;
 
-// Message: Please enter a line above type declaration
+// Message: New line required above type declaration
 
 const som = "jes";
 // a comment
 type fed = "hed";
 
-// Message: Please enter a line above type declaration
+// Message: New line required above type declaration
 
 type som = "jes";
 // a comment
 const fed = "hed";
 
-// Message: Please enter a line below type declaration
+// Message: New line required below type declaration
 
 type hello = 34;
 const som = "jes";
 type fed = "hed";
 
-// Message: Please enter a line below type declaration
-// Message: Please enter a line above type declaration
+// Message: New line required below type declaration
+// Message: New line required above type declaration
 ```
 
 The following patterns are not considered problems:

--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,7 @@ import arrayStyleSimpleType from './rules/arrayStyleSimpleType';
 import booleanStyle from './rules/booleanStyle';
 import defineFlowType from './rules/defineFlowType';
 import delimiterDangle from './rules/delimiterDangle';
+import enforceLineBreak from './rules/enforceLineBreak';
 import genericSpacing from './rules/genericSpacing';
 import newlineAfterFlowAnnotation from './rules/newlineAfterFlowAnnotation';
 import noDupeKeys from './rules/noDupeKeys';
@@ -53,6 +54,7 @@ const rules = {
   'boolean-style': booleanStyle,
   'define-flow-type': defineFlowType,
   'delimiter-dangle': delimiterDangle,
+  'enforce-line-break': enforceLineBreak,
   'generic-spacing': genericSpacing,
   'newline-after-flow-annotation': newlineAfterFlowAnnotation,
   'no-dupe-keys': noDupeKeys,

--- a/src/rules/enforceLineBreak.js
+++ b/src/rules/enforceLineBreak.js
@@ -1,0 +1,61 @@
+const schema = [];
+
+const create = (context) => {
+  return {
+    TypeAlias (node) {
+      const sourceCode = context.getSourceCode();
+
+      // if type alias has spacing above and below cancel out of checks
+      // Check for comments above the line (if there is a comment then add the space above that instead)
+      if (node.loc.start.line !== 1) {
+        // Check if there are comments above the line
+        if (node.leadingComments) {
+          const lineAboveComment = sourceCode.lines[node.leadingComments[0].loc.start.line - 2];
+          if (lineAboveComment !== '') {
+            context.report({
+              fix (fixer) {
+                return fixer.insertTextBeforeRange(node.leadingComments[0].range, '\n');
+              },
+              message: 'Please enter a line above type declaration',
+              node,
+            });
+          }
+        } else if (!node.leadingComments) {
+          const lineAbove = sourceCode.lines[node.loc.start.line - 2];
+
+          // there are no comments add space above line
+          if (lineAbove !== '') {
+            context.report({
+              fix (fixer) {
+                return fixer.insertTextBefore(node, '\n');
+              },
+              message: 'Please enter a line above type declaration',
+              node,
+            });
+          }
+        }
+
+        // Check if there is a space under the line
+        const lineBelow = sourceCode.lines[node.loc.end.line];
+
+        if (lineBelow !== '') {
+          context.report({
+            fix (fixer) {
+              return fixer.insertTextAfter(node, '\n');
+            },
+            message: 'Please enter a line below type declaration',
+            node,
+          });
+        }
+      }
+    },
+  };
+};
+
+export default {
+  create,
+  meta: {
+    fixable: 'code',
+  },
+  schema,
+};

--- a/src/rules/enforceLineBreak.js
+++ b/src/rules/enforceLineBreak.js
@@ -4,14 +4,11 @@ const create = (context) => {
   return {
     TypeAlias (node) {
       const sourceCode = context.getSourceCode();
-
       if (sourceCode.lines.length === 1) {
         return;
       }
 
-      // Check for comments above the line (if there is a comment then add the space above that instead)
       if (node.loc.start.line !== 1) {
-        // Check if there are comments above the line
         if (node.leadingComments && node.leadingComments[0].loc.start.line !== 1) {
           const lineAboveComment = sourceCode.lines[node.leadingComments[0].loc.start.line - 2];
           if (lineAboveComment !== '') {
@@ -24,10 +21,8 @@ const create = (context) => {
             });
           }
         } else if (!node.leadingComments) {
-          const lineAbove = sourceCode.lines[node.loc.start.line - 2];
-
-          // there are no comments add space above line
-          if (lineAbove !== '') {
+          const isLineAbove = sourceCode.lines[node.loc.start.line - 2];
+          if (isLineAbove !== '') {
             context.report({
               fix (fixer) {
                 return fixer.insertTextBefore(node, '\n');
@@ -40,10 +35,8 @@ const create = (context) => {
       }
 
       if (sourceCode.lines.length !== node.loc.end.line) {
-        // Check if there is a space under the line
-        const lineBelow = sourceCode.lines[node.loc.end.line];
-
-        if (lineBelow !== '') {
+        const isLineBelow = sourceCode.lines[node.loc.end.line];
+        if (isLineBelow !== '') {
           context.report({
             fix (fixer) {
               return fixer.insertTextAfter(node, '\n');

--- a/src/rules/enforceLineBreak.js
+++ b/src/rules/enforceLineBreak.js
@@ -1,5 +1,9 @@
 const schema = [];
 
+const breakLineMessage = (direction) => {
+  return `New line required ${direction} type declaration`;
+};
+
 const create = (context) => {
   return {
     TypeAlias (node) {
@@ -16,7 +20,7 @@ const create = (context) => {
               fix (fixer) {
                 return fixer.insertTextBeforeRange(node.leadingComments[0].range, '\n');
               },
-              message: 'Please enter a line above type declaration',
+              message: breakLineMessage('above'),
               node,
             });
           }
@@ -27,7 +31,7 @@ const create = (context) => {
               fix (fixer) {
                 return fixer.insertTextBefore(node, '\n');
               },
-              message: 'Please enter a line above type declaration',
+              message: breakLineMessage('above'),
               node,
             });
           }
@@ -41,7 +45,7 @@ const create = (context) => {
             fix (fixer) {
               return fixer.insertTextAfter(node, '\n');
             },
-            message: 'Please enter a line below type declaration',
+            message: breakLineMessage('below'),
             node,
           });
         }

--- a/src/rules/enforceLineBreak.js
+++ b/src/rules/enforceLineBreak.js
@@ -5,11 +5,14 @@ const create = (context) => {
     TypeAlias (node) {
       const sourceCode = context.getSourceCode();
 
-      // if type alias has spacing above and below cancel out of checks
+      if (sourceCode.lines.length === 1) {
+        return;
+      }
+
       // Check for comments above the line (if there is a comment then add the space above that instead)
       if (node.loc.start.line !== 1) {
         // Check if there are comments above the line
-        if (node.leadingComments) {
+        if (node.leadingComments && node.leadingComments[0].loc.start.line !== 1) {
           const lineAboveComment = sourceCode.lines[node.leadingComments[0].loc.start.line - 2];
           if (lineAboveComment !== '') {
             context.report({
@@ -34,7 +37,9 @@ const create = (context) => {
             });
           }
         }
+      }
 
+      if (sourceCode.lines.length !== node.loc.end.line) {
         // Check if there is a space under the line
         const lineBelow = sourceCode.lines[node.loc.end.line];
 

--- a/tests/rules/assertions/enforceLineBreak.js
+++ b/tests/rules/assertions/enforceLineBreak.js
@@ -1,33 +1,40 @@
 export default {
   invalid: [
     {
-      code: '\ntype baz = 6;\nconst hi = 2;\n',
+      code: 'type baz = 6;\nconst hi = 2;',
       errors: [{
         message: 'Please enter a line below type declaration',
       }],
-      output: '\ntype baz = 6;\n\nconst hi = 2;\n',
+      output: 'type baz = 6;\n\nconst hi = 2;',
     },
     {
-      code: 'type foo = 6;\ntype hi = 2;\n',
-      errors: [{
-        message: 'Please enter a line above type declaration',
-      }],
-      output: 'type foo = 6;\n\ntype hi = 2;\n',
-    },
-    {
-      code: 'type res = 6;\ntype rod = 2;\n',
-      errors: [{
-        message: 'Please enter a line above type declaration',
-      }],
-      output: 'type res = 6;\n\ntype rod = 2;\n',
-    },
-    {
-      code: 'const som = "jes";\n// a comment\ntype fed = "hed";',
+      code: 'const foo = 6;\ntype hi = 2;\n',
       errors: [
         {message: 'Please enter a line above type declaration'},
-        {message: 'Please enter a line below type declaration'},
+      ],
+      output: 'const foo = 6;\n\ntype hi = 2;\n',
+    },
+    {
+      code: 'const som = "jes";\n// a comment\ntype fed = "hed";\n',
+      errors: [
+        {message: 'Please enter a line above type declaration'},
       ],
       output: 'const som = "jes";\n\n// a comment\ntype fed = "hed";\n',
+    },
+    {
+      code: 'type som = "jes";\n// a comment\nconst fed = "hed";\n',
+      errors: [
+        {message: 'Please enter a line below type declaration'},
+      ],
+      output: 'type som = "jes";\n\n// a comment\nconst fed = "hed";\n',
+    },
+    {
+      code: 'type hello = 34;\nconst som = "jes";\ntype fed = "hed";\n',
+      errors: [
+        {message: 'Please enter a line below type declaration'},
+        {message: 'Please enter a line above type declaration'},
+      ],
+      output: 'type hello = 34;\n\nconst som = "jes";\n\ntype fed = "hed";\n',
     },
   ],
   valid: [
@@ -48,8 +55,7 @@ console.log("hello");
 type Y = string | number;
 
 // resting + sleep
-type snooze = "dreaming" | "";
-`,
+type snooze = "dreaming" | "";`,
     },
     {
       code:
@@ -61,6 +67,7 @@ type snooze = "dreaming" | "";
     {
       code:
 `const x = 4;
+const y = 489;
 
 // Some Comment
 type Props = {
@@ -68,9 +75,7 @@ type Props = {
   accountNumber: string | number,
 };
 
-type RoadT = "grass" | "gravel" | "cement";
-
-`,
+type RoadT = "grass" | "gravel" | "cement";`,
     },
   ],
 };

--- a/tests/rules/assertions/enforceLineBreak.js
+++ b/tests/rules/assertions/enforceLineBreak.js
@@ -1,0 +1,76 @@
+export default {
+  invalid: [
+    {
+      code: '\ntype baz = 6;\nconst hi = 2;\n',
+      errors: [{
+        message: 'Please enter a line below type declaration',
+      }],
+      output: '\ntype baz = 6;\n\nconst hi = 2;\n',
+    },
+    {
+      code: 'type foo = 6;\ntype hi = 2;\n',
+      errors: [{
+        message: 'Please enter a line above type declaration',
+      }],
+      output: 'type foo = 6;\n\ntype hi = 2;\n',
+    },
+    {
+      code: 'type res = 6;\ntype rod = 2;\n',
+      errors: [{
+        message: 'Please enter a line above type declaration',
+      }],
+      output: 'type res = 6;\n\ntype rod = 2;\n',
+    },
+    {
+      code: 'const som = "jes";\n// a comment\ntype fed = "hed";',
+      errors: [
+        {message: 'Please enter a line above type declaration'},
+        {message: 'Please enter a line below type declaration'},
+      ],
+      output: 'const som = "jes";\n\n// a comment\ntype fed = "hed";\n',
+    },
+  ],
+  valid: [
+    {
+      code: 'type gjs = 6;',
+    },
+    {
+      code: 'type gjs = 6;\n\ntype hi = 2;\n',
+    },
+    {
+      code:
+`type X = 4;
+
+const red = "serpent";
+console.log("hello");
+
+// number or string
+type Y = string | number;
+
+// resting + sleep
+type snooze = "dreaming" | "";
+`,
+    },
+    {
+      code:
+`type Props = {
+  accountBalance: string | number,
+  accountNumber: string | number,
+};`,
+    },
+    {
+      code:
+`const x = 4;
+
+// Some Comment
+type Props = {
+  accountBalance: string | number,
+  accountNumber: string | number,
+};
+
+type RoadT = "grass" | "gravel" | "cement";
+
+`,
+    },
+  ],
+};

--- a/tests/rules/assertions/enforceLineBreak.js
+++ b/tests/rules/assertions/enforceLineBreak.js
@@ -3,36 +3,36 @@ export default {
     {
       code: 'type baz = 6;\nconst hi = 2;',
       errors: [{
-        message: 'Please enter a line below type declaration',
+        message: 'New line required below type declaration',
       }],
       output: 'type baz = 6;\n\nconst hi = 2;',
     },
     {
       code: 'const foo = 6;\ntype hi = 2;\n',
       errors: [
-        {message: 'Please enter a line above type declaration'},
+        {message: 'New line required above type declaration'},
       ],
       output: 'const foo = 6;\n\ntype hi = 2;\n',
     },
     {
       code: 'const som = "jes";\n// a comment\ntype fed = "hed";\n',
       errors: [
-        {message: 'Please enter a line above type declaration'},
+        {message: 'New line required above type declaration'},
       ],
       output: 'const som = "jes";\n\n// a comment\ntype fed = "hed";\n',
     },
     {
       code: 'type som = "jes";\n// a comment\nconst fed = "hed";\n',
       errors: [
-        {message: 'Please enter a line below type declaration'},
+        {message: 'New line required below type declaration'},
       ],
       output: 'type som = "jes";\n\n// a comment\nconst fed = "hed";\n',
     },
     {
       code: 'type hello = 34;\nconst som = "jes";\ntype fed = "hed";\n',
       errors: [
-        {message: 'Please enter a line below type declaration'},
-        {message: 'Please enter a line above type declaration'},
+        {message: 'New line required below type declaration'},
+        {message: 'New line required above type declaration'},
       ],
       output: 'type hello = 34;\n\nconst som = "jes";\n\ntype fed = "hed";\n',
     },

--- a/tests/rules/index.js
+++ b/tests/rules/index.js
@@ -17,6 +17,7 @@ const reportingRules = [
   'boolean-style',
   'define-flow-type',
   'delimiter-dangle',
+  'enforce-line-break',
   'generic-spacing',
   'newline-after-flow-annotation',
   'no-dupe-keys',


### PR DESCRIPTION
New rule to enforce line breaks before and after type declarations.

Closes #476 
```
// Error
type A = string;
type B = number;
// Some Comment
type rez = string;

// Fixes to 
type A = string;

type B = number;

// Some Comment
type rez = string;

```

@gajus 