### PR TITLE
fix: support CRLF line breaks in generic-spacing (#485)

### DIFF
--- a/src/rules/genericSpacing.js
+++ b/src/rules/genericSpacing.js
@@ -31,7 +31,8 @@ const create = (context) => {
 
       if (never) {
         if (spacesBefore) {
-          if (sourceCode.text[opener.range[1]] !== '\n') {
+          const whiteSpaceBefore = sourceCode.text[opener.range[1]];
+          if (whiteSpaceBefore !== '\n' && whiteSpaceBefore !== '\r') {
             context.report({
               data: {name: node.id.name},
               fix: spacingFixers.stripSpacesAfter(opener, spacesBefore),
@@ -42,7 +43,8 @@ const create = (context) => {
         }
 
         if (spacesAfter) {
-          if (sourceCode.text[closer.range[0] - 1] !== '\n') {
+          const whiteSpaceAfter = sourceCode.text[closer.range[0] - 1];
+          if (whiteSpaceAfter !== '\n' && whiteSpaceAfter !== '\r') {
             context.report({
               data: {name: node.id.name},
               fix: spacingFixers.stripSpacesAfter(lastInnerToken, spacesAfter),

--- a/tests/rules/assertions/genericSpacing.js
+++ b/tests/rules/assertions/genericSpacing.js
@@ -133,8 +133,9 @@ export default {
 `type X = Promise<
   (foo),
   bar,
-  (((baz))),
+  (((baz)))
 >`},
+    {code: 'type X =  Promise<\r\n    (foo),\r\n    bar,\r\n    (((baz)))\r\n>'},
 
     // Always
 


### PR DESCRIPTION
The generic-spacing rule doesn't support CRLF line breaks.

```js
// Passes
type X =  Promise<\n    (foo),\n    bar,\n    (((baz)))\n>

// Doesn't pass
type X =  Promise<\r\n    (foo),\r\n    bar,\r\n    (((baz)))\r\n>
```