### PR TITLE
enforceLineBreak now handles `export type` correctly

### DIFF
--- a/src/rules/enforceLineBreak.js
+++ b/src/rules/enforceLineBreak.js
@@ -12,25 +12,28 @@ const create = (context) => {
         return;
       }
 
+      const exportedType = node.parent.type === 'ExportNamedDeclaration';
+      const leadingComments = exportedType ? node.parent.leadingComments : node.leadingComments;
+
       if (node.loc.start.line !== 1) {
-        if (node.leadingComments && node.leadingComments[0].loc.start.line !== 1) {
-          const lineAboveComment = sourceCode.lines[node.leadingComments[0].loc.start.line - 2];
+        if (leadingComments && leadingComments[0].loc.start.line !== 1) {
+          const lineAboveComment = sourceCode.lines[leadingComments[0].loc.start.line - 2];
           if (lineAboveComment !== '') {
             context.report({
               fix (fixer) {
-                return fixer.insertTextBeforeRange(node.leadingComments[0].range, '\n');
+                return fixer.insertTextBeforeRange(leadingComments[0].range, '\n');
               },
               message: breakLineMessage('above'),
               node,
             });
           }
-        } else if (!node.leadingComments) {
+        } else if (!leadingComments) {
           const isLineAbove = sourceCode.lines[node.loc.start.line - 2];
           if (isLineAbove !== '') {
             context.report({
               fix (fixer) {
                 return fixer.insertTextBefore(
-                  node.parent.type === 'ExportNamedDeclaration' ? node.parent : node,
+                  exportedType ? node.parent : node,
                   '\n',
                 );
               },

--- a/src/rules/enforceLineBreak.js
+++ b/src/rules/enforceLineBreak.js
@@ -29,7 +29,10 @@ const create = (context) => {
           if (isLineAbove !== '') {
             context.report({
               fix (fixer) {
-                return fixer.insertTextBefore(node, '\n');
+                return fixer.insertTextBefore(
+                  node.parent.type === 'ExportNamedDeclaration' ? node.parent : node,
+                  '\n',
+                );
               },
               message: breakLineMessage('above'),
               node,

--- a/src/rules/enforceLineBreak.js
+++ b/src/rules/enforceLineBreak.js
@@ -13,10 +13,11 @@ const create = (context) => {
       }
 
       const exportedType = node.parent.type === 'ExportNamedDeclaration';
-      const leadingComments = exportedType ? node.parent.leadingComments : node.leadingComments;
+      const leadingComments = sourceCode.getCommentsBefore(exportedType ? node.parent : node);
+      const hasLeadingComments = leadingComments.length > 0;
 
       if (node.loc.start.line !== 1) {
-        if (leadingComments && leadingComments[0].loc.start.line !== 1) {
+        if (hasLeadingComments && leadingComments[0].loc.start.line !== 1) {
           const lineAboveComment = sourceCode.lines[leadingComments[0].loc.start.line - 2];
           if (lineAboveComment !== '') {
             context.report({
@@ -27,7 +28,7 @@ const create = (context) => {
               node,
             });
           }
-        } else if (!leadingComments) {
+        } else if (!hasLeadingComments) {
           const isLineAbove = sourceCode.lines[node.loc.start.line - 2];
           if (isLineAbove !== '') {
             context.report({

--- a/tests/rules/assertions/enforceLineBreak.js
+++ b/tests/rules/assertions/enforceLineBreak.js
@@ -43,6 +43,13 @@ export default {
       ],
       output: 'const a = 5;\n\nexport type hello = 34;\n',
     },
+    {
+      code: 'const a = 5;\n// a comment\nexport type hello = 34;\n',
+      errors: [
+        {message: 'New line required above type declaration'},
+      ],
+      output: 'const a = 5;\n\n// a comment\nexport type hello = 34;\n',
+    },
   ],
   valid: [
     {

--- a/tests/rules/assertions/enforceLineBreak.js
+++ b/tests/rules/assertions/enforceLineBreak.js
@@ -50,6 +50,22 @@ export default {
       ],
       output: 'const a = 5;\n\n// a comment\nexport type hello = 34;\n',
     },
+    {
+      code: `const a = 5;
+/**
+ * a jsdoc block
+ */
+type hello = 34;`,
+      errors: [
+        {message: 'New line required above type declaration'},
+      ],
+      output: `const a = 5;
+
+/**
+ * a jsdoc block
+ */
+type hello = 34;`,
+    },
   ],
   valid: [
     {
@@ -90,6 +106,9 @@ type Props = {
 };
 
 type RoadT = "grass" | "gravel" | "cement";`,
+    },
+    {
+      code: '// @flow\ntype A = string',
     },
   ],
 };

--- a/tests/rules/assertions/enforceLineBreak.js
+++ b/tests/rules/assertions/enforceLineBreak.js
@@ -36,6 +36,13 @@ export default {
       ],
       output: 'type hello = 34;\n\nconst som = "jes";\n\ntype fed = "hed";\n',
     },
+    {
+      code: 'const a = 5;\nexport type hello = 34;\n',
+      errors: [
+        {message: 'New line required above type declaration'},
+      ],
+      output: 'const a = 5;\n\nexport type hello = 34;\n',
+    },
   ],
   valid: [
     {


### PR DESCRIPTION
Closes #487