### PR TITLE
fix: use name to sort method property

### DIFF
--- a/src/rules/sortKeys.js
+++ b/src/rules/sortKeys.js
@@ -57,7 +57,7 @@ const generateOrderedList = (context, sort, properties) => {
       });
       const text = source.getText().slice(startIndex, beforePunctuator.range[1]);
 
-      return [property, text];
+      return [property, name, text];
     }
 
     const colonToken = source.getTokenBefore(property.value, {
@@ -123,8 +123,8 @@ const generateOrderedList = (context, sort, properties) => {
         });
     }
     orderedList.push(...itemGroup.map((item) => {
-      if (item.length === 2) {
-        return item[1];
+      if (item.length === 3) {
+        return item[2];
       }
 
       return item[2] + ':' + item[3];

--- a/tests/rules/assertions/sortKeys.js
+++ b/tests/rules/assertions/sortKeys.js
@@ -557,6 +557,29 @@ export default {
         }
       `,
     },
+    {
+      code: `
+        type FooType = {
+          /* preserves block comment before a */
+          a: number | string | boolean,
+          /* preserves block comment before c */
+          c: number,
+          /* preserves block comment before b */
+          b(param: string): number,
+        }
+      `,
+      errors: [{message: 'Expected type annotations to be in ascending order. "b" should be before "c".'}],
+      output: `
+        type FooType = {
+          /* preserves block comment before a */
+          a: number | string | boolean,
+          /* preserves block comment before b */
+          b(param: string): number,
+          /* preserves block comment before c */
+          c: number,
+        }
+      `,
+    },
 
     // https://github.com/gajus/eslint-plugin-flowtype/issues/493
     {


### PR DESCRIPTION
what was the issue?

if there is a comment (block/line) in front of the function property, the comment will affect the sorted order of items.

for example, a should be placed in front of b, but b got in front because it's ranked with "/"

```
      + expected - actual

       
               type FooType = {
      +          /* preserves block comment before a */
      +          a: number | string | boolean,
                 /* preserves block comment before b */
                 b(param: string): number,
      -          /* preserves block comment before a */
      -          a: number | string | boolean,
                 /* preserves block comment before c */
                 c: number,
               }
```

this PR fix the issue.