### PR TITLE
Add `eslint-plugin-eslint-plugin`

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,6 +1,12 @@
 {
-  "extends": "canonical",
+  "extends": [
+    "canonical",
+    "plugin:eslint-plugin/recommended"
+  ],
   "rules": {
+    "eslint-plugin/require-meta-schema": 0,
+    "eslint-plugin/require-meta-type": 0,
+
     "unicorn/prevent-abbreviations": 0
   }
 }

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "eclint": "^2.8.1",
     "eslint": "^7.32.0",
     "eslint-config-canonical": "^27.0.1",
+    "eslint-plugin-eslint-plugin": "^4.0.1",
     "gitdown": "^3.1.4",
     "glob": "^7.1.7",
     "husky": "^7.0.2",

--- a/src/utilities/iterateFunctionNodes.js
+++ b/src/utilities/iterateFunctionNodes.js
@@ -1,3 +1,4 @@
+// eslint-disable-next-line eslint-plugin/prefer-object-rule -- false positive, this is not a rule
 export default (iterator) => {
   return (context, ...rest) => {
     const nodeIterator = iterator(context, ...rest);


### PR DESCRIPTION
Enforces best practices for eslint rules and rule tests. Commonly used internally by eslint plugins.

A few rules were disabled as they have too many violations now but would be good to address as follow-ups.

https://github.com/not-an-aardvark/eslint-plugin-eslint-plugin