### PR TITLE
fix: recommended config cannot omit "parser"

### DIFF
--- a/src/configs/recommended.json
+++ b/src/configs/recommended.json
@@ -1,5 +1,5 @@
 {
-  "parser": "@babel/eslint",
+  "parser": "@babel/eslint-parser",
   "parserOptions": {
     "babelOptions": {
       "plugins": [


### PR DESCRIPTION
In my environment with `eslint` v8.1.0 and `eslint-plugin-flowtype` v8.0.3, `flowtype/recommended` will happens error like below.

```

Oops! Something went wrong! :(

ESLint: 8.1.0

Error: Failed to load parser '@babel/eslint' declared in '.eslintrc.json#overrides[3] » plugin:flowtype/recommended': Cannot find module '@babel/eslint'
```

It cannot omit `parser` suffix on config.