### PR TITLE
New rule: `no-flow-fix-me-in-strict-files`

### DIFF
--- a/.README/README.md
+++ b/.README/README.md
@@ -162,6 +162,7 @@ When `true`, only checks files with a [`@flow` annotation](http://flowtype.org/d
 {"gitdown": "include", "file": "./rules/no-duplicate-type-union-intersection-members.md"}
 {"gitdown": "include", "file": "./rules/no-existential-type.md"}
 {"gitdown": "include", "file": "./rules/no-flow-fix-me-comments.md"}
+{"gitdown": "include", "file": "./rules/no-flow-fix-in-strict-files.md"}
 {"gitdown": "include", "file": "./rules/no-internal-flow-type.md"}
 {"gitdown": "include", "file": "./rules/no-mixed.md"}
 {"gitdown": "include", "file": "./rules/no-mutable-array.md"}

--- a/.README/rules/no-flow-fix-me-in-strict-files.md
+++ b/.README/rules/no-flow-fix-me-in-strict-files.md
@@ -1,0 +1,21 @@
+### `no-flow-fix-me-in-strict-files`
+
+This rule validates that no error suppression comments (e.g. `$FlowFixMe`) are used in `// @flow strict` (or `// @flow strict-local`) files.
+
+This codifies the best practices [as documented here](https://flow.org/en/docs/strict/#toc-adoption):
+
+> _"Do not add `$FlowFixMe` to suppress the new errors as they appear; just add `@flow strict` once all issues have been resolved."_
+
+#### Options
+
+The rule has no options.
+
+```js
+{
+  "rules": {
+    "flowtype/no-flow-fix-me-in-strict-files": 2,
+  }
+}
+```
+
+<!-- assertions noFlowFixMeInStrictFiles -->

--- a/src/index.js
+++ b/src/index.js
@@ -14,6 +14,7 @@ import noDupeKeys from './rules/noDupeKeys';
 import noDuplicateTypeUnionIntersectionMembers from './rules/noDuplicateTypeUnionIntersectionMembers';
 import noExistentialType from './rules/noExistentialType';
 import noFlowFixMeComments from './rules/noFlowFixMeComments';
+import noFlowFixMeInStrictFiles from './rules/noFlowFixMeInStrictFiles';
 import noInternalFlowType from './rules/noInternalFlowType';
 import noMixed from './rules/noMixed';
 import noMutableArray from './rules/noMutableArray';
@@ -66,6 +67,7 @@ const rules = {
   'no-duplicate-type-union-intersection-members': noDuplicateTypeUnionIntersectionMembers,
   'no-existential-type': noExistentialType,
   'no-flow-fix-me-comments': noFlowFixMeComments,
+  'no-flow-fix-me-in-strict-files': noFlowFixMeInStrictFiles,
   'no-internal-flow-type': noInternalFlowType,
   'no-mixed': noMixed,
   'no-mutable-array': noMutableArray,

--- a/src/rules/noFlowFixMeInStrictFiles.js
+++ b/src/rules/noFlowFixMeInStrictFiles.js
@@ -1,0 +1,43 @@
+const FLOW_STRICT_MATCHER = /^\s*@(?:no)?flow\s*strict(?:-local)?\s*$/u;
+
+const isStrictFlowFile = (context) => {
+  return context
+    .getAllComments()
+    .some((comment) => {
+      return FLOW_STRICT_MATCHER.test(comment.value);
+    });
+};
+
+const message =
+  'No suppression comments are allowed in "strict" Flow files. Either remove the error supression, or lower the strictness of this module.';
+
+const create = (context) => {
+  if (!isStrictFlowFile(context)) {
+    // Skip this file - nothing to check here
+    return {};
+  }
+
+  return {
+    Program: () => {
+      const comments = context
+        .getSourceCode()
+        .getAllComments()
+        .filter((node) => {
+          return node.type === 'Block' || node.type === 'Line';
+        });
+
+      for (const comment of comments) {
+        if (/\$FlowFixMe/iu.test(comment.value)) {
+          context.report({
+            message,
+            node: comment,
+          });
+        }
+      }
+    },
+  };
+};
+
+export default {
+  create,
+};

--- a/src/rules/noFlowFixMeInStrictFiles.js
+++ b/src/rules/noFlowFixMeInStrictFiles.js
@@ -1,5 +1,13 @@
 const FLOW_STRICT_MATCHER = /^\s*@(?:no)?flow\s*strict(?:-local)?\s*$/u;
 
+// Possibly move these to a central config?
+const suppressionCommentPrefixes = [
+  '$FlowFixMe',
+  '$FlowExpectedError',
+  '$FlowIssue',
+  '$FlowIgnore',
+];
+
 const isStrictFlowFile = (context) => {
   return context
     .getAllComments()
@@ -26,11 +34,15 @@ const create = (context) => {
           return node.type === 'Block' || node.type === 'Line';
         });
 
-      for (const comment of comments) {
-        if (/\$FlowFixMe/iu.test(comment.value)) {
+      for (const commentNode of comments) {
+        const comment = commentNode.value.trimStart();
+        const match = suppressionCommentPrefixes.some((prefix) => {
+          return comment.startsWith(prefix);
+        });
+        if (match) {
           context.report({
             message,
-            node: comment,
+            node: commentNode,
           });
         }
       }

--- a/tests/rules/assertions/noFlowFixMeInStrictFiles.js
+++ b/tests/rules/assertions/noFlowFixMeInStrictFiles.js
@@ -18,6 +18,7 @@ export default {
   invalid: [
     invalid('// @flow strict\n\n// $FlowFixMe\nconst text: string = 42;'),
     invalid('// @flow strict-local\n\n// $FlowFixMe\nconst text: string = 42;'),
+    invalid('// @flow strict\n\n// $FlowExpectedError[xxx]\nconst text: string = 42;'),
   ],
   valid: [
     valid('// @flow\n\n// Error suppressions are fine in "normal" Flow files\n// $FlowFixMe\nconst text: string = 42;'),

--- a/tests/rules/assertions/noFlowFixMeInStrictFiles.js
+++ b/tests/rules/assertions/noFlowFixMeInStrictFiles.js
@@ -1,0 +1,27 @@
+const message =
+  'No suppression comments are allowed in "strict" Flow files. Either remove the error supression, or lower the strictness of this module.';
+
+const invalid = (code) => {
+  return {
+    code,
+    errors: [{message}],
+  };
+};
+
+const valid = (code) => {
+  return {
+    code,
+  };
+};
+
+export default {
+  invalid: [
+    invalid('// @flow strict\n\n// $FlowFixMe\nconst text: string = 42;'),
+    invalid('// @flow strict-local\n\n// $FlowFixMe\nconst text: string = 42;'),
+  ],
+  valid: [
+    valid('// @flow\n\n// Error suppressions are fine in "normal" Flow files\n// $FlowFixMe\nconst text: string = 42;'),
+    valid('// @flow-strict\n\n// Definitely nothing to supress here\n// ...'),
+    valid('// @flow-strict-local\n\n// Definitely nothing to supress here\n// ...'),
+  ],
+};

--- a/tests/rules/index.js
+++ b/tests/rules/index.js
@@ -35,6 +35,7 @@ const reportingRules = [
   'no-duplicate-type-union-intersection-members',
   'no-existential-type',
   'no-flow-fix-me-comments',
+  'no-flow-fix-me-in-strict-files',
   'no-mutable-array',
   'no-primitive-constructor-types',
   'no-types-missing-file-annotation',


### PR DESCRIPTION
This rule validates that no error suppression comments (e.g. `$FlowFixMe`) are used in `// @flow strict` (or `// @flow strict-local`) files.

This codifies the best practices [as documented here](https://flow.org/en/docs/strict/#toc-adoption):

![Screen Shot 2021-11-03 at 09 10 04@2x](https://user-images.githubusercontent.com/83844/140033096-4d586086-04e8-4a96-9355-0db9ad022d57.png)

It's a simple rule without any options.

---

@gajus I followed all of the contributing guidelines, adding documentation and tests, but I failed at the last step while running `npm run create-readme`. See [my error log](https://gist.github.com/nvie/113e8d4053beb080a5d29d9b389598c3) here.