### PR TITLE
fix: Add '*' to list of weak types

### DIFF
--- a/.README/rules/no-weak-types.md
+++ b/.README/rules/no-weak-types.md
@@ -12,6 +12,7 @@ about `Object` and `Function`:
 {
     "rules": {
         "flowtype/no-weak-types": [2, {
+            "*": false,
             "any": false,
             "Object": true,
             "Function": true
@@ -24,6 +25,7 @@ about `Object` and `Function`:
 {
     "rules": {
         "flowtype/no-weak-types": [2, {
+            "*": false,
             "any": false
         }]
     }

--- a/src/rules/noWeakTypes.js
+++ b/src/rules/noWeakTypes.js
@@ -4,6 +4,9 @@ const schema = [
   {
     additionalProperties: false,
     properties: {
+      '*': {
+        type: 'boolean',
+      },
       any: {
         type: 'boolean',
       },
@@ -40,6 +43,7 @@ const genericTypeEvaluator = (context, {checkFunction, checkObject}) => {
 
 const create = (context) => {
   const checkAny = _.get(context, 'options[0].any', true) === true;
+  const checkExists = _.get(context, 'options[0].*', true) === true;
   const checkFunction = _.get(context, 'options[0].Function', true) === true;
   const checkObject = _.get(context, 'options[0].Object', true) === true;
 
@@ -47,6 +51,10 @@ const create = (context) => {
 
   if (checkAny) {
     checks.AnyTypeAnnotation = reportWeakType(context, 'any');
+  }
+
+  if (checkExists) {
+    checks.ExistsTypeAnnotation = reportWeakType(context, '*');
   }
 
   if (checkFunction || checkObject) {

--- a/tests/rules/assertions/noWeakTypes.js
+++ b/tests/rules/assertions/noWeakTypes.js
@@ -7,6 +7,12 @@ export default {
       }],
     },
     {
+      code: 'function foo(thing): * {}',
+      errors: [{
+        message: 'Unexpected use of weak type "*"',
+      }],
+    },
+    {
       code: 'function foo(thing): Promise<any> {}',
       errors: [{
         message: 'Unexpected use of weak type "any"',
@@ -58,6 +64,12 @@ export default {
       code: '(foo: any) => {}',
       errors: [{
         message: 'Unexpected use of weak type "any"',
+      }],
+    },
+    {
+      code: '(foo: *) => {}',
+      errors: [{
+        message: 'Unexpected use of weak type "*"',
       }],
     },
     {
@@ -192,6 +204,15 @@ export default {
         Object: false,
       }],
     },
+    {
+      code: 'type W = *; type X = any; type Y = Function; type Z = Object',
+      errors: [{message: 'Unexpected use of weak type "*"'}],
+      options: [{
+        any: false,
+        Object: false,
+        Function: false,
+      }],
+    },
   ],
   misconfigured: [
     {
@@ -209,6 +230,9 @@ export default {
           parentSchema: {
             additionalProperties: false,
             properties: {
+              '*': {
+                type: 'boolean',
+              },
               any: {
                 type: 'boolean',
               },


### PR DESCRIPTION
In Flow 0.163.0, `*` is aliased to `any`

https://github.com/facebook/flow/releases/tag/v0.163.0

> The deprecated `*` type is now an alias to `any`